### PR TITLE
Bug Fixes

### DIFF
--- a/roles/rsyslog/README.md
+++ b/roles/rsyslog/README.md
@@ -15,10 +15,10 @@ Two files - inventory_file and vars.yaml - in the command line is to be updated 
    Sample inventory file for the es-ops enabled case
 ```
 [masters]
-localhost ansible_ssh_user=${RSYSLOG_ANSIBLE_SSH_USER} openshift_logging_use_ops=True
+localhost ansible_user=YOUR_ANSIBLE_USER openshift_logging_use_ops=True
 
 [nodes]
-localhost ansible_ssh_user=${RSYSLOG_ANSIBLE_SSH_USER} openshift_logging_use_ops=True
+localhost ansible_user=YOUR_ANSIBLE_USER openshift_logging_use_ops=True
 ```
 
 2. vars.yaml stores variables which are passed to ansible to control the tasks.
@@ -35,6 +35,8 @@ rsyslog__viaq: true
 rsyslog__capabilities: [ 'viaq' ]
 rsyslog__group: root
 rsyslog__user: root
+elasticsearch_server_host: es_hostname
+elasticsearch_server_port: 9200
 ```
 
 2.1  vars.yaml to configure to handle the inputs from openshift containers
@@ -54,6 +56,15 @@ logging_elasticsearch_ca_cert: "{{rsyslog__viaq_config_dir}}/es-ca.crt"
 logging_elasticsearch_cert: "{{rsyslog__viaq_config_dir}}/es-cert.pem"
 logging_elasticsearch_key: "{{rsyslog__viaq_config_dir}}/es-key.pem"
 
+```
+
+2.2  vars.yaml to configure custom config files.
+
+   To include existing config files in the new ansible deployment, add the paths to rsyslog__custom_config_files as follows.  The specified files are copied to /etc/rsyslog.d.
+```
+rsyslog__enabled: true
+....
+rsyslog__custom_config_files: [ '/path/to/custom_A.conf', '/path/to/custom_B.conf' ]
 ```
 
 3. playbook.yaml

--- a/roles/rsyslog/defaults/main.yaml
+++ b/roles/rsyslog/defaults/main.yaml
@@ -35,7 +35,8 @@ rsyslog__work_dir: '/var/lib/rsyslog'
 # .. envvar:: rsyslog__capabilities
 #
 # List of different capabilities to configure. See :ref:`rsyslog__capabilities`
-rsyslog__capabilities: [ 'network', 'remote-files', 'tls', 'viaq', 'viaq-k8s' ]
+# rsyslog__capabilities: [ 'network', 'remote-files', 'tls', 'viaq', 'viaq-k8s' ]
+rsyslog__capabilities: []
 
 # .. envvar:: rsyslog__unprivileged
 #
@@ -818,6 +819,9 @@ rsyslog__conf_viaq_main_modules:
 
   - name: 'viaq_main'
     type: 'modules'
+    state: "{{ 'present'
+               if ('viaq' in rsyslog__capabilities)
+               else 'absent' }}"
     sections:
 
       - options: |-
@@ -849,6 +853,9 @@ rsyslog__conf_viaq_mmk8s:
   - name: 'mmk8s'
     type: 'modules'
     path: '{{rsyslog__viaq_config_dir }}'
+    state: "{{ 'present'
+               if ('viaq-k8s' in rsyslog__capabilities)
+               else 'absent' }}"
     sections:
 
       - options: |-
@@ -872,15 +879,15 @@ rsyslog__conf_viaq_mmk8s:
                  tls.cacert="{{logging_mmk8s_ca_cert}}"
                  tokenfile="{{logging_mmk8s_token}}" annotation_match=["."])
           }
-        state: '{{ "present"
-               if ("viaq-k8s" in rsyslog__capabilities)
-               else "absent" }}'
 
 rsyslog__conf_viaq_elasticsearch:
 
   - name: 'elasticsearch'
     type: 'output'
     path: '{{rsyslog__viaq_config_dir }}'
+    state: "{{ 'present'
+               if ('viaq' in rsyslog__capabilities)
+               else 'absent' }}"
     sections:
 
       - options: |-
@@ -998,6 +1005,9 @@ rsyslog__conf_viaq_viaq_formatting:
   - name: 'viaq_formatting'
     type: 'template'
     path: '{{rsyslog__viaq_config_dir }}'
+    state: "{{ 'present'
+               if ('viaq' in rsyslog__capabilities)
+               else 'absent' }}"
     sections:
 
       - options: |-
@@ -1299,6 +1309,9 @@ rsyslog__rulebase_viaq_k8s_filename:
     filename: 'k8s_filename.rulebase'
     nocomment: 'true'
     path: '{{rsyslog__viaq_config_dir }}'
+    state: "{{ 'present'
+               if ('viaq-k8s' in rsyslog__capabilities)
+               else 'absent' }}"
     sections:
 
       - options: |-
@@ -1311,6 +1324,9 @@ rsyslog__rulebase_viaq_parse_json:
     filename: 'parse_json.rulebase'
     nocomment: 'true'
     path: '{{rsyslog__viaq_config_dir }}'
+    state: "{{ 'present'
+               if ('viaq' in rsyslog__capabilities)
+               else 'absent' }}"
     sections:
 
       - options: |-
@@ -1323,6 +1339,9 @@ rsyslog__rulebase_viaq_k8s_container_name:
     filename: 'k8s_container_name.rulebase'
     nocomment: 'true'
     path: '{{rsyslog__viaq_config_dir }}'
+    state: "{{ 'present'
+               if ('viaq-k8s' in rsyslog__capabilities)
+               else 'absent' }}"
     sections:
 
       - options: |-
@@ -1338,6 +1357,9 @@ rsyslog__json_viaq_normalize_level:
     filename: 'normalize_level.json'
     nocomment: 'true'
     path: '{{rsyslog__viaq_config_dir }}'
+    state: "{{ 'present'
+               if ('viaq' in rsyslog__capabilities)
+               else 'absent' }}"
     sections:
 
       - options: |-
@@ -1368,6 +1390,9 @@ rsyslog__json_viaq_prio_to_level:
     filename: 'prio_to_level.json'
     nocomment: 'true'
     path: '{{rsyslog__viaq_config_dir }}'
+    state: "{{ 'present'
+               if ('viaq' in rsyslog__capabilities)
+               else 'absent' }}"
     sections:
 
       - options: |-
@@ -1393,6 +1418,9 @@ rsyslog__rulebase_viaq_crio:
     filename: 'crio.rulebase'
     nocomment: 'true'
     path: '{{rsyslog__viaq_config_dir }}'
+    state: "{{ 'present'
+               if ('viaq-k8s' in rsyslog__capabilities)
+               else 'absent' }}"
     sections:
       - options: |-
           version=2

--- a/roles/rsyslog/tasks/main.yaml
+++ b/roles/rsyslog/tasks/main.yaml
@@ -101,7 +101,8 @@
     - '{{ rsyslog__group_rules }}'
     - '{{ rsyslog__host_rules }}'
     - '{{ rsyslog__dependent_rules }}'
-  when: (rsyslog__enabled|bool and rsyslog__example|bool and (item.filename|d() or item.name|d()) and
+  when: (rsyslog__enabled|bool and rsyslog__example|bool and
+         (item.filename|d() or item.name|d()) and
          (item.state is undefined or item.state != 'absent') and
          (item.options|d() or item.sections|d()))
 
@@ -114,7 +115,8 @@
     mode:  '{{ item.mode  | d("0400") }}'
   with_flattened:
     - '{{ rsyslog__viaq_rules }}'
-  when: (rsyslog__enabled|bool and rsyslog__viaq|bool and (item.filename|d() or item.name|d()) and
+  when: (rsyslog__enabled|bool and rsyslog__viaq|bool and
+         (item.filename|d() or item.name|d()) and
          (item.state is undefined or item.state != 'absent') and
          (item.options|d() or item.sections|d()))
 
@@ -129,22 +131,20 @@
     - '{{ rsyslog__group_rules }}'
     - '{{ rsyslog__host_rules }}'
     - '{{ rsyslog__dependent_rules }}'
-  when: (not rsyslog__enabled|bool or
+  when: (not rsyslog__enabled|bool or not rsyslog__example|bool and
          (item.filename|d() or item.name|d()) and
-         (item.state|d() and item.state == 'absent') and
+         (item.state is defined and item.state == 'absent') and
          (item.options|d() or item.sections|d()))
 
 - name: Remove viaq config files in rsyslog.d and rsyslog.d/viaq
-  template:
-    src: 'etc/rsyslog.d/rules.conf.j2'
-    dest: '{{ item.path | d(rsyslog__config_dir) }}/{{ item.filename | d((item.weight if item.weight|d() else rsyslog__weight_map[item.type|d("rules")]) + "-" + (item.name|d("rules")) + "." + (item.suffix |d ("conf"))) }}'
-    owner: '{{ item.owner | d("root") }}'
-    group: '{{ item.group | d("root") }}'
-    mode:  '{{ item.mode  | d("0400") }}'
+  file:
+    path: '{{ item.path | d(rsyslog__config_dir) }}/{{ item.filename | d((item.weight if item.weight|d() else rsyslog__weight_map[item.type|d("rules")]) + "-" + (item.name|d("rules")) + "." + (item.suffix |d ("conf"))) }}'
+    state: 'absent'
   with_flattened:
     - '{{ rsyslog__viaq_rules }}'
-  when: (rsyslog__enabled|bool and not rsyslog__viaq|bool and (item.filename|d() or item.name|d()) and
-         (item.state is undefined or item.state == 'absent') and
+  when: (not rsyslog__enabled|bool or not rsyslog__viaq|bool and
+         (item.filename|d() or item.name|d()) and
+         (item.state is defined and item.state == 'absent') and
          (item.options|d() or item.sections|d()))
 
 # How to set rsyslog__custom_config_files:


### PR DESCRIPTION
Thanks to @sradco for reviews.  These are fixes based on her comments.

README.md
- Sample inventory file
  - Replacing deprecated ansible_ssh_user with ansible_user
  - Having ${RSYSLOG_ANSIBLE_SSH_USER} for ansible_user in the inventory
    file example is not appropriate. Replacing it with more specific string.
- Sample vars.yaml
  - Adding elasticsearch_server_host and elasticsearch_server_port.
  - Adding a section for copying custom config files by rsyslog__custom_config_files.

defaults/main.yaml
- Setting rsyslog__capabilities to [].  Setting capabilities to add a capability.
- Using 'viaq' capability explicitly.
- Deploying crio.rulebase only when 'viaq-k8s' is in rsyslog__capabilities.