### PR TITLE
[WIP] Support elasticsearch certs deployment

### DIFF
--- a/roles/rsyslog/README.md
+++ b/roles/rsyslog/README.md
@@ -61,8 +61,10 @@ rsyslog_enabled: true
 rsyslog_viaq: true
 rsyslog_capabilities: [ 'viaq' ]
 rsyslog_unprivileged: False
-elasticsearch_server_host: es_hostname
-elasticsearch_server_port: 9200
+rsyslog_elasticsearch_viaq:
+  - name: viaq-elasticsearch
+    server_host: es-hostname
+    server_port: 9200
 ```
 
 2. vars.yaml to configure to handle the inputs from openshift containers
@@ -77,6 +79,8 @@ logging_mmk8s_token: "{{rsyslog_viaq_config_dir}}/mmk8s.token"
 logging_mmk8s_ca_cert: "{{rsyslog_viaq_config_dir}}/mmk8s.ca.crt"
 # If use_omelasticsearch_cert is True, ca_cert, cert and key in rsyslog_elasticsearch_viaq needs to be set.
 use_omelasticsearch_cert: True
+# If use_local_omelasticsearch_cert is True, local files ca_cert_src, cert_src and key_src in rsyslog_elasticsearch_viaq will be deployed to the remote host.
+use_local_omelasticsearch_cert: True
 openshift_logging_use_ops: True
 rsyslog_elasticsearch_viaq:
   - name: viaq-elasticsearch
@@ -86,6 +90,9 @@ rsyslog_elasticsearch_viaq:
     ca_cert: "{{rsyslog_viaq_config_dir}}/es-ca.crt"
     cert: "{{rsyslog_viaq_config_dir}}/es-cert.pem"
     key: "{{rsyslog_viaq_config_dir}}/es-key.pem"
+    ca_cert_src : "/path/to/es-ca.crt"
+    cert_src : "/path/to/es-cert.pem"
+    key_src : "/path/to/es-key.pem"
   - name: viaq-elasticsearch-ops
     server_host: logging-es-ops
     server_port: 9200
@@ -93,6 +100,9 @@ rsyslog_elasticsearch_viaq:
     ca_cert: "{{rsyslog_viaq_config_dir}}/es-ca.crt"
     cert: "{{rsyslog_viaq_config_dir}}/es-cert.pem"
     key: "{{rsyslog_viaq_config_dir}}/es-key.pem"
+    ca_cert_src : "/path/to/es-ca.crt"
+    cert_src : "/path/to/es-cert.pem"
+    key_src : "/path/to/es-key.pem"
 ```
 The key-value pairs in rsylog_elasticsearch_viaq are used to configure rsyslog to send the logs to the Openshift Aggregated Logging ElasticSearch.  The elements are used in the output elasticsearch configuration 30-elasticsearch.conf as follows (note: not following the abstract syntax):
 ```
@@ -122,6 +132,7 @@ if index_prefix starts with "project." then {
 ```
 The order of the list in rsyslog_elasticsearch_viaq is important.  The first item is in the first if clause with the index_prefix value and the last item is in the else clause.  Elements in between will be placed with else if clause.
 
+The variables ca_cert, cert and key in rsyslog_elasticsearch_viaq specify the paths where the CA certificate, certificate and key are located in the remote host.  The variables ca_cert_src, cert_src, and key_src are paths of them to be deployed to the remote host.
 
 3. vars.yaml to configure custom config files.
 
@@ -272,6 +283,8 @@ Viaq sub-variables
 - `openshift_logging_use_ops`: Set to 'True', if you have a second ES cluster for infrastructure logs. Default to 'False'.
 - `logging_mmk8s_token`: Path to token for kubernetes.  Default to "/etc/rsyslog.d/viaq/mmk8s.token"
 - `logging_mmk8s_ca_cert`: Path to CA cert for kubernetes.  Default to "/etc/rsyslog.d/viaq/mmk8s.ca.crt"
+- `use_omelasticsearch_cert` : If set to `True`, mmelasticsearch is configured to use the certificates specified in rsyslog_elasticsearch_viaq.  Default to `False`.
+- `use_local_omelasticsearch_cert` : If set to `True`, local files ca_cert_src, cert_src and key_src in rsyslog_elasticsearch_viaq will be deployed to the remote host.  Default to `False`
 - `rsyslog_elasticsearch_viaq`: A set of following variables to specify output elasticsearch configurations.  It could be an array if multiple elasticsearch clusters to be configured. 
   - `name`: Name of the elasticsearch element.
   - `server_host`: Hostname elasticsearch is running on.

--- a/roles/rsyslog/README.md
+++ b/roles/rsyslog/README.md
@@ -284,7 +284,7 @@ Viaq sub-variables
 - `logging_mmk8s_token`: Path to token for kubernetes.  Default to "/etc/rsyslog.d/viaq/mmk8s.token"
 - `logging_mmk8s_ca_cert`: Path to CA cert for kubernetes.  Default to "/etc/rsyslog.d/viaq/mmk8s.ca.crt"
 - `use_omelasticsearch_cert` : If set to `True`, mmelasticsearch is configured to use the certificates specified in rsyslog_elasticsearch_viaq.  Default to `False`.
-- `use_local_omelasticsearch_cert` : If set to `True`, local files ca_cert_src, cert_src and key_src in rsyslog_elasticsearch_viaq will be deployed to the remote host.  Default to `False`
+- `use_local_omelasticsearch_cert` : If set to `True`, local files ca_cert_src, cert_src and key_src in rsyslog_elasticsearch_viaq will be deployed to the remote host.  If set to `True`, ca_cert_src, cert_src and key_src must be set in each `rsyslog_elastic_viaq` element.  Otherwise, the deployment fails.  Default to `False`  
 - `rsyslog_elasticsearch_viaq`: A set of following variables to specify output elasticsearch configurations.  It could be an array if multiple elasticsearch clusters to be configured. 
   - `name`: Name of the elasticsearch element.
   - `server_host`: Hostname elasticsearch is running on.
@@ -293,6 +293,9 @@ Viaq sub-variables
   - `ca_cert`: Path to CA cert for ElasticSearch.  Default to '/etc/rsyslog.d/viaq/es-ca.crt'
   - `cert`: Path to cert for ElasticSearch.  Default to '/etc/rsyslog.d/viaq/es-cert.pem'
   - `key`: Path to key for ElasticSearch.  Default to "/etc/rsyslog.d/viaq/es-key.pem"
+  - `ca_cert_src`: Path to the local CA cert file to deploy for ElasticSearch.
+  - `cert_src`: Path to the local cert file to deploy for ElasticSearch.
+  - `key_src`: Path to the local key file to deploy for ElasticSearch.
 
 Contents of Roles
 =================

--- a/roles/rsyslog/tasks/main.yaml
+++ b/roles/rsyslog/tasks/main.yaml
@@ -85,7 +85,7 @@
 
 - name: Collect local viaq cert files
   set_fact:
-    viaq_local_cert_files0: "{{ rsyslog_elasticsearch_viaq | map(attribute='ca_cert_src') | list }} + {{ rsyslog_elasticsearch_viaq | map(attribute='cert_src') | list }} + {{ rsyslog_elasticsearch_viaq | map(attribute='key_src') | list }}"
+    viaq_local_cert_files0: "{{ viaq_local_cert_files0 | default([]) }} + {{ rsyslog_elasticsearch_viaq | map(attribute='ca_cert_src') | list | default([]) }} + {{ rsyslog_elasticsearch_viaq | map(attribute='cert_src') | list | default([]) }} + {{ rsyslog_elasticsearch_viaq | map(attribute='key_src') | list | default([]) }}"
   when: use_omelasticsearch_cert|default(False)|bool and use_local_omelasticsearch_cert|default(Flase)|bool
 
 - name: Make local viaq cert files unique

--- a/roles/rsyslog/tasks/main.yaml
+++ b/roles/rsyslog/tasks/main.yaml
@@ -83,11 +83,59 @@
   file: path="{{ rsyslog_viaq_config_dir }}" state=directory mode=0700
   when: rsyslog_viaq|bool
 
+- name: Collect local viaq cert files
+  set_fact:
+    viaq_local_cert_files0: "{{ rsyslog_elasticsearch_viaq | map(attribute='ca_cert_src') | list }} + {{ rsyslog_elasticsearch_viaq | map(attribute='cert_src') | list }} + {{ rsyslog_elasticsearch_viaq | map(attribute='key_src') | list }}"
+  when: use_omelasticsearch_cert|default(False)|bool and use_local_omelasticsearch_cert|default(Flase)|bool
+
+- name: Make local viaq cert files unique
+  set_fact:
+    viaq_local_cert_files: "{{ viaq_local_cert_files0 | unique }}"
+  when: use_omelasticsearch_cert|default(False)|bool and use_local_omelasticsearch_cert|default(Flase)|bool
+
+- name: Collect remote viaq cert files
+  set_fact:
+    viaq_remote_cert_files0: "{{ rsyslog_elasticsearch_viaq | map(attribute='ca_cert') | list }} + {{ rsyslog_elasticsearch_viaq | map(attribute='cert') | list }} + {{ rsyslog_elasticsearch_viaq | map(attribute='key') | list }}"
+  when: use_omelasticsearch_cert|default(False)|bool
+
+- name: Make remote viaq cert files unique
+  set_fact:
+    viaq_remote_cert_files: "{{ viaq_remote_cert_files0 | unique }}"
+  when: use_omelasticsearch_cert|default(False)|bool
+
+- debug:
+    msg: "viaq_local_cert_files is {{ viaq_local_cert_files }}"
+  when: use_omelasticsearch_cert|bool and use_local_omelasticsearch_cert|bool
+
+- debug:
+    msg: "viaq_remote_cert_files are {{ viaq_remote_cert_files }}"
+  when: use_omelasticsearch_cert|bool and use_local_omelasticsearch_cert|bool
+
+- name: Setup viaq keys and certs
+  copy:
+    src: '{{ item }}'
+    dest: '{{ rsyslog_viaq_config_dir }}'
+  with_items:
+    - '{{ viaq_local_cert_files | default([]) }}'
+  when: (rsyslog_enabled|bool and rsyslog_viaq|bool) and
+        use_omelasticsearch_cert|default(False)|bool and 
+        use_local_omelasticsearch_cert|default(Flase)|bool and
+        item is defined
+
+- name: Remove viaq keys and certs
+  file:
+    path: '{{ item }}'
+    state: 'absent'
+  with_flattened:
+    - '{{ viaq_remote_cert_files }}'
+  when: (not rsyslog_enabled|bool or not rsyslog_viaq|bool) and
+        item is defined
+
 - name: Remove rsyslog viaq subdir
   file:
     path: "{{ rsyslog_viaq_config_dir }}/"
     state: 'absent'
-  when: not rsyslog_viaq|bool
+  when: (not rsyslog_enabled|bool or not rsyslog_viaq|bool)
 
 - name: Update directory and file permissions
   shell: |


### PR DESCRIPTION
rsyslog: Supporting local paths of ca_cert, cert and key for the elasticsearch to be deployed to the remote host.
Adding use_local_omelasticsearch_cert.
Adding the suggestion from @sradco to "Collect local viaq cert files" task.