### PR TITLE
 Update ovirt role timestamp parsing and sub roles deploy config to /etc/rsyslog.d directory

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,7 +10,3 @@ logging_custom_config_files: []
 
 logging_purge_confs: true
 
-logging_elasticsearch_default_ca_cert_path: /path/to/ca-cert.pem
-logging_elasticsearch_default_client_cert_path: /path/to/cert.pem
-logging_elasticsearch_default_client_key_path: /path/to/cert-key.pem
-

--- a/roles/rsyslog/roles/input_roles/debops/tasks/main.yaml
+++ b/roles/rsyslog/roles/input_roles/debops/tasks/main.yaml
@@ -2,7 +2,6 @@
 - name: Set debops facts
   set_fact:
     rsyslog_role_packages: ""
-    rsyslog_role_config_dir: "{{ rsyslog_config_dir }}"
     rsyslog_role_rules: "{{ rsyslog_debops_rules }}"
 
 - name: Install/Update debops role packages and generate example configuration files to role subdir

--- a/roles/rsyslog/roles/input_roles/ovirt/defaults/main.yaml
+++ b/roles/rsyslog/roles/input_roles/ovirt/defaults/main.yaml
@@ -89,11 +89,15 @@ rsyslog_conf_ovirt_formatting:
       - options: |-
           # formatting
 
+          template(name="cnvt_to_viaq_timestamp" type="list") {
+              property(name="TIMESTAMP" dateFormat="rfc3339")
+          }
+
           input (type="imtcp" port="{{ rsyslog_read_collectd_port|d(44514) }}")
           if $syslogtag == 'collectd' then {
               set $!original_raw_message = $msg;
               action(type="mmjsonparse" cookie="") # parse entire message as json
-              set $!@timestamp = format_time($!time, "date-rfc3339");
+              set $!@timestamp = exec_template('cnvt_to_viaq_timestamp');
               unset $!time;
           }
 

--- a/roles/rsyslog/roles/input_roles/ovirt/defaults/main.yaml
+++ b/roles/rsyslog/roles/input_roles/ovirt/defaults/main.yaml
@@ -2,11 +2,6 @@
 # oVirt configuration
 # ---------------------
 
-# .. envvar:: rsyslog_ovirt_config_dir
-#
-# oVirt configuration directory
-rsyslog_ovirt_config_dir: '{{rsyslog_config_dir}}/ovirt'
-
 # oVirt rpm packages
 # adding rsyslog_logging_packages
 # ------------------
@@ -75,15 +70,11 @@ rsyslog_conf_ovirt_main_modules:
           # Parse logs to JSON
           module(load="mmjsonparse")
 
-      - options: |-
-          # Include oVirt config files
-          $IncludeConfig {{ rsyslog_ovirt_config_dir }}/*.conf
-
 rsyslog_conf_ovirt_formatting:
 
   - name: 'ovirt_formatting'
     type: 'template'
-    path: '{{ rsyslog_ovirt_config_dir }}'
+    path: '{{ rsyslog_config_dir }}'
     sections:
 
       - options: |-
@@ -116,7 +107,7 @@ rsyslog_conf_ovirt_formatting:
                 startmsg.regex="^[[:digit:]]{4}-[[:digit:]]{2}-[[:digit:]]{2}")
 
           if $syslogtag == 'ovirt.engine' then {
-            action(type="mmnormalize" rulebase="{{ rsyslog_ovirt_config_dir }}/ovirt_engine.rulebase" path="$!ovirt")
+            action(type="mmnormalize" rulebase="{{ rsyslog_config_dir }}/ovirt_engine.rulebase" path="$!ovirt")
           }
           {% endif %}
 
@@ -125,7 +116,7 @@ rsyslog_conf_ovirt_formatting:
                 startmsg.regex="^[[:digit:]]{4}-[[:digit:]]{2}-[[:digit:]]{2}")
 
           if $syslogtag == 'ovirt.vdsm' then {
-            action(type="mmnormalize" rulebase="{{ rsyslog_ovirt_config_dir }}/ovirt_vdsm.rulebase" path="$!ovirt")
+            action(type="mmnormalize" rulebase="{{ rsyslog_config_dir }}/ovirt_vdsm.rulebase" path="$!ovirt")
           }
           {% endif %}
 
@@ -164,7 +155,7 @@ rsyslog_rulebase_ovirt_engine:
   - name: 'ovirt_engine'
     filename: 'ovirt_engine.rulebase'
     nocomment: 'true'
-    path: '{{ rsyslog_ovirt_config_dir }}'
+    path: '{{ rsyslog_config_dir }}'
     sections:
       - options: |-
           version=2
@@ -174,7 +165,7 @@ rsyslog_rulebase_ovirt_vdsm:
   - name: 'ovirt_vdsm'
     filename: 'ovirt_vdsm.rulebase'
     nocomment: 'true'
-    path: '{{ rsyslog_ovirt_config_dir }}'
+    path: '{{ rsyslog_config_dir }}'
     sections:
       - options: |-
           version=2
@@ -186,7 +177,7 @@ rsyslog_rulebase_ovirt_parse_json:
   - name: 'parse_json'
     filename: 'parse_json.rulebase'
     nocomment: 'true'
-    path: '{{rsyslog_ovirt_config_dir }}'
+    path: '{{rsyslog_config_dir }}'
     sections:
 
       - options: |-

--- a/roles/rsyslog/roles/input_roles/ovirt/tasks/cleanup.yaml
+++ b/roles/rsyslog/roles/input_roles/ovirt/tasks/cleanup.yaml
@@ -1,11 +1,9 @@
 ---
 - name: Set oVirt facts
   set_fact:
-    rsyslog_role_config_dir: "{{ rsyslog_ovirt_config_dir }}"
     rsyslog_role_rules: "{{ rsyslog_ovirt_rules }}"
-    remove_role_config_dir: true
 
-- name: Remove oVirt subdir
+- name: Remove oVirt configs
   include_role:
     name: "{{ logging_role_path|d('logging') }}/roles/rsyslog"
     tasks_from: cleanup.yaml

--- a/roles/rsyslog/roles/input_roles/ovirt/tasks/main.yaml
+++ b/roles/rsyslog/roles/input_roles/ovirt/tasks/main.yaml
@@ -2,7 +2,6 @@
 - name: Set oVirt facts
   set_fact:
     rsyslog_role_packages: "{{rsyslog_ovirt_prereq_packages|flatten|d([])}}+{{rsyslog_ovirt_packages|flatten|d([])}}"
-    rsyslog_role_config_dir: "{{ rsyslog_ovirt_config_dir }}"
     rsyslog_role_rules: "{{ rsyslog_ovirt_rules }}"
 
 - name: Install/Update role packages and generate role configuration files to role subdir

--- a/roles/rsyslog/roles/input_roles/viaq-k8s/defaults/main.yaml
+++ b/roles/rsyslog/roles/input_roles/viaq-k8s/defaults/main.yaml
@@ -2,11 +2,6 @@
 # Viaq configuration
 # ---------------------
 
-# .. envvar:: rsyslog_viaq_config_dir
-#
-# Viaq configuration directory
-rsyslog_viaq_config_dir: '{{rsyslog_config_dir}}/viaq'
-
 # .. envvar:: rsyslog_viaq_log_dir
 #
 # Viaq log directory
@@ -44,7 +39,7 @@ rsyslog_conf_viaq_mmk8s:
 
   - name: 'mmk8s'
     type: 'modules'
-    path: '{{rsyslog_viaq_config_dir }}'
+    path: '{{rsyslog_config_dir }}'
     sections:
 
       - options: |-
@@ -54,20 +49,20 @@ rsyslog_conf_viaq_mmk8s:
           # Parse logs to JSON
           module(load="mmjsonparse")
 
-          input(type="imfile" file="{{ rsyslog_viaq_log_dir }}/*.log" tag="kubernetes" addmetadata="on" reopenOnTruncate="on")
+          input(type="imfile" file="{{ rsyslog_log_dir }}/*.log" tag="kubernetes" addmetadata="on" reopenOnTruncate="on")
           
           if ((strlen($!CONTAINER_NAME) > 0) and (strlen($!CONTAINER_ID_FULL) > 0)) or
-              ((strlen($!metadata) > 0) and (strlen($!metadata!filename) > 0) and ($!metadata!filename startswith "{{rsyslog_viaq_log_dir}}/")) then {
-              if ((strlen($!metadata) > 0) and (strlen($!metadata!filename) > 0) and ($!metadata!filename startswith "{{rsyslog_viaq_log_dir}}/")) then {
+              ((strlen($!metadata) > 0) and (strlen($!metadata!filename) > 0) and ($!metadata!filename startswith "{{rsyslog_log_dir}}/")) then {
+              if ((strlen($!metadata) > 0) and (strlen($!metadata!filename) > 0) and ($!metadata!filename startswith "{{rsyslog_log_dir}}/")) then {
                   if $msg startswith "{" then {
                       action(type="mmjsonparse" cookie="") # parse entire message as json
                   } else {
-                      action(type="mmnormalize" rulebase="{{ rsyslog_viaq_config_dir }}/crio.rulebase")
+                      action(type="mmnormalize" rulebase="{{ rsyslog_config_dir }}/crio.rulebase")
                   }
               }
               action(type="mmkubernetes"
-                 filenamerulebase="{{ rsyslog_viaq_config_dir }}/k8s_filename.rulebase"
-                 containerrulebase="{{ rsyslog_viaq_config_dir }}/k8s_container_name.rulebase"
+                 filenamerulebase="{{ rsyslog_config_dir }}/k8s_filename.rulebase"
+                 containerrulebase="{{ rsyslog_config_dir }}/k8s_container_name.rulebase"
                  tls.cacert="{{logging_mmk8s_ca_cert}}"
                  tokenfile="{{logging_mmk8s_token}}" annotation_match=["."])
           }
@@ -77,19 +72,19 @@ rsyslog_rulebase_viaq_k8s_filename:
   - name: 'k8s_filename'
     filename: 'k8s_filename.rulebase'
     nocomment: 'true'
-    path: '{{rsyslog_viaq_config_dir }}'
+    path: '{{rsyslog_config_dir }}'
     sections:
 
       - options: |-
           version=2
-          rule=:{{ rsyslog_viaq_log_dir }}/%pod_name:char-to:_%_%namespace_name:char-to:_%_%container_name_and_id:char-to:.%.log
+          rule=:{{ rsyslog_log_dir }}/%pod_name:char-to:_%_%namespace_name:char-to:_%_%container_name_and_id:char-to:.%.log
 
 rsyslog_rulebase_viaq_k8s_container_name:
 
   - name: 'k8s_container_name'
     filename: 'k8s_container_name.rulebase'
     nocomment: 'true'
-    path: '{{rsyslog_viaq_config_dir }}'
+    path: '{{rsyslog_config_dir }}'
     sections:
 
       - options: |-
@@ -103,7 +98,7 @@ rsyslog_rulebase_viaq_crio:
   - name: 'crio'
     filename: 'crio.rulebase'
     nocomment: 'true'
-    path: '{{rsyslog_viaq_config_dir }}'
+    path: '{{rsyslog_config_dir }}'
     sections:
       - options: |-
           version=2

--- a/roles/rsyslog/roles/input_roles/viaq-k8s/tasks/cleanup.yaml
+++ b/roles/rsyslog/roles/input_roles/viaq-k8s/tasks/cleanup.yaml
@@ -2,7 +2,6 @@
 - name: Set Viaq-k8s facts
   set_fact:
     rsyslog_role_rules: "{{ rsyslog_viaq_k8s_rules }}"
-    rsyslog_role_config_dir: "{{ rsyslog_viaq_config_dir }}"
 
 - name: Remove Viaq-k8s role config files from subdir
   include_role:

--- a/roles/rsyslog/roles/input_roles/viaq-k8s/tasks/main.yaml
+++ b/roles/rsyslog/roles/input_roles/viaq-k8s/tasks/main.yaml
@@ -2,7 +2,6 @@
 - name: Set Viaq-k8s facts
   set_fact:
     rsyslog_role_packages: "{{ rsyslog_viaq_k8s_packages|flatten }}"
-    rsyslog_role_config_dir: "{{ rsyslog_viaq_config_dir }}"
     rsyslog_role_rules: "{{ rsyslog_viaq_k8s_rules }}"
 
 - name: Install/Update role packages and generate role configuration files to role subdir

--- a/roles/rsyslog/roles/input_roles/viaq/defaults/main.yaml
+++ b/roles/rsyslog/roles/input_roles/viaq/defaults/main.yaml
@@ -2,11 +2,6 @@
 # Viaq configuration
 # ---------------------
 
-# .. envvar:: rsyslog_viaq_config_dir
-#
-# Viaq configuration directory
-rsyslog_viaq_config_dir: '{{rsyslog_config_dir}}/viaq'
-
 # Viaq rpm packages
 # adding rsyslog_logging_packages
 # ------------------
@@ -69,21 +64,17 @@ rsyslog_conf_viaq_main_modules:
           # Normalize logs
           module(load="mmnormalize")
 
-      - options: |-
-          # Include viaq config files
-          $IncludeConfig {{ rsyslog_viaq_config_dir }}/*.conf
-
 rsyslog_conf_viaq_formatting:
 
   - name: 'viaq_formatting'
     type: 'template'
-    path: '{{rsyslog_viaq_config_dir }}'
+    path: '{{rsyslog_config_dir }}'
     sections:
 
       - options: |-
           # formatting
-          lookup_table(name="prio_to_level" file="{{ rsyslog_viaq_config_dir }}/prio_to_level.json")
-          lookup_table(name="normalize_level" file="{{ rsyslog_viaq_config_dir }}/normalize_level.json")
+          lookup_table(name="prio_to_level" file="{{ rsyslog_config_dir }}/prio_to_level.json")
+          lookup_table(name="normalize_level" file="{{ rsyslog_config_dir }}/normalize_level.json")
           
           template(name="cnvt_to_viaq_timestamp" type="list") {
               property(name="TIMESTAMP" dateFormat="rfc3339")
@@ -96,7 +87,7 @@ rsyslog_conf_viaq_formatting:
           # "message" in the outgoing record
           if strlen($!MESSAGE) > 0 then {
               set $!pipeline_metadata!collector!original_raw_message = $!MESSAGE;
-              action(type="mmnormalize" ruleBase="{{ rsyslog_viaq_config_dir }}/parse_json.rulebase" variable="$!MESSAGE")
+              action(type="mmnormalize" ruleBase="{{ rsyslog_config_dir }}/parse_json.rulebase" variable="$!MESSAGE")
               # ensure that $!message is set and $!MESSAGE is unset
               # if rsyslog is case sensitive, then $!MESSAGE == $!message
               if $!MESSAGE == $!message then {
@@ -115,7 +106,7 @@ rsyslog_conf_viaq_formatting:
           } else {
               if strlen($!log) > 0 then {
                   set $!pipeline_metadata!collector!original_raw_message = $!log;
-                  action(type="mmnormalize" ruleBase="{{ rsyslog_viaq_config_dir }}/parse_json.rulebase" variable="$!log")
+                  action(type="mmnormalize" ruleBase="{{ rsyslog_config_dir }}/parse_json.rulebase" variable="$!log")
                   if strlen($!message) == 0 then {
                       set $!message = $!log;
                   }
@@ -380,7 +371,7 @@ rsyslog_rulebase_viaq_parse_json:
   - name: 'parse_json'
     filename: 'parse_json.rulebase'
     nocomment: 'true'
-    path: '{{rsyslog_viaq_config_dir }}'
+    path: '{{rsyslog_config_dir }}'
     sections:
 
       - options: |-
@@ -392,7 +383,7 @@ rsyslog_json_viaq_normalize_level:
   - name: 'normalize_level'
     filename: 'normalize_level.json'
     nocomment: 'true'
-    path: '{{rsyslog_viaq_config_dir }}'
+    path: '{{rsyslog_config_dir }}'
     sections:
 
       - options: |-
@@ -422,7 +413,7 @@ rsyslog_json_viaq_prio_to_level:
   - name: 'prio_to_level'
     filename: 'prio_to_level.json'
     nocomment: 'true'
-    path: '{{rsyslog_viaq_config_dir }}'
+    path: '{{rsyslog_config_dir }}'
     sections:
 
       - options: |-

--- a/roles/rsyslog/roles/input_roles/viaq/tasks/cleanup.yaml
+++ b/roles/rsyslog/roles/input_roles/viaq/tasks/cleanup.yaml
@@ -1,17 +1,9 @@
 ---
-- name: Set ovirt_output_name
-  set_fact:
-    output_name: "{{ item.output_name }}"
-  with_items: "{{ rsyslog_logs_collections }}"
-  when: item.name == 'viaq'
-
 - name: Set Viaq facts
   set_fact:
     rsyslog_role_rules: "{{ rsyslog_viaq_rules }}"
-    rsyslog_role_config_dir: "{{ rsyslog_viaq_config_dir }}"
-    remove_role_config_dir: true
 
-- name: Remove Viaq role subdir
+- name: Remove viaq configs
   include_role:
     name: "{{ logging_role_path|d('logging') }}/roles/rsyslog"
     tasks_from: cleanup.yaml

--- a/roles/rsyslog/roles/input_roles/viaq/tasks/main.yaml
+++ b/roles/rsyslog/roles/input_roles/viaq/tasks/main.yaml
@@ -9,4 +9,3 @@
   include_role:
     name: "{{ logging_role_path|d('logging') }}/roles/rsyslog"
     tasks_from: deploy.yaml
-

--- a/roles/rsyslog/roles/input_roles/viaq/tasks/main.yaml
+++ b/roles/rsyslog/roles/input_roles/viaq/tasks/main.yaml
@@ -2,7 +2,6 @@
 - name: Set Viaq facts
   set_fact:
     rsyslog_role_packages: "{{rsyslog_viaq_prereq_packages|flatten|d([])}}+{{rsyslog_viaq_packages|flatten|d([])}}"
-    rsyslog_role_config_dir: "{{ rsyslog_viaq_config_dir }}"
     rsyslog_role_rules: "{{ rsyslog_viaq_rules }}"
 
 - name: Install/Update role packages and generate role configuration files to role subdir

--- a/roles/rsyslog/roles/output_roles/elasticsearch/defaults/main.yaml
+++ b/roles/rsyslog/roles/output_roles/elasticsearch/defaults/main.yaml
@@ -2,11 +2,6 @@
 # Elasticsearch configuration
 # ---------------------
 
-# .. envvar:: rsyslog_elasticsearch_config_dir
-#
-# Elsticsearch configuration directory
-rsyslog_elasticsearch_config_dir: '{{rsyslog_config_dir}}/elasticsearch'
-
 # .. envvar:: rsyslog_elasticsearch_package
 #
 # List of rpm packages for Elasticsearch output.
@@ -45,16 +40,11 @@ rsyslog_conf_es_main_modules:
           # Send to ElasticSearch
           module(load="omelasticsearch")
 
-      - options: |-
-          # Include elasticsearch config files
-          $IncludeConfig {{ rsyslog_elasticsearch_config_dir }}/*.conf
-
-
 rsyslog_conf_es_elasticsearch:
 
   - name: 'elasticsearch'
     type: 'output'
-    path: '{{ rsyslog_elasticsearch_config_dir }}'
+    path: '{{ rsyslog_config_dir }}'
     sections:
 
       - options: |-

--- a/roles/rsyslog/roles/output_roles/elasticsearch/defaults/main.yaml
+++ b/roles/rsyslog/roles/output_roles/elasticsearch/defaults/main.yaml
@@ -134,9 +134,7 @@ rsyslog_conf_es_elasticsearch:
                   dynbulkid="{{ res.dynbulkid | default("on") }}"
                   retryfailures="{{ res.retryfailures | default("on") }}"
                   allowUnsignedCerts = "{{ res.allowUnsignedCerts | default("off") }}"
-          {% if res.retryfailures|default("on") == "on" %}
                   retryruleset="{{ res.retryruleset | default("try_es") }}"
-          {% endif %}
                   usehttps="{{ res.usehttps | default("on") }}"
           {% if use_omelasticsearch_cert | default(False) %}
                   tls.cacert="{{ res.ca_cert|default("/etc/rsyslog.d/elasticsearch/es-ca.crt") }}"
@@ -162,9 +160,7 @@ rsyslog_conf_es_elasticsearch:
                     dynbulkid="{{ res.dynbulkid | default("on") }}"
                     retryfailures="{{ res.retryfailures | default("on") }}"
                     allowUnsignedCerts = "{{ res.allowUnsignedCerts | default("off") }}"
-          {% if res.retryfailures|default("on") == "on" %}
                     retryruleset="{{ res.retryruleset | default("try_es") }}"
-          {% endif %}
                     usehttps="{{ res.usehttps | default("on") }}"
           {% if use_omelasticsearch_cert | default(False) %}
                     tls.cacert="{{ res.ca_cert|default("/etc/rsyslog.d/elasticsearch/es-ca.crt") }}"

--- a/roles/rsyslog/roles/output_roles/elasticsearch/tasks/main.yaml
+++ b/roles/rsyslog/roles/output_roles/elasticsearch/tasks/main.yaml
@@ -1,37 +1,37 @@
 ---
 - block:
   # This block collect certificates from local location and copies them to /etc/rsyslog.d directory
-    - name: Copy local Elasticsearch ca_certs to elasticsearch directory in Rsyslog
+    - name: Copy local Elasticsearch ca_certs to /etc/rsyslog.d directory in Rsyslog
       copy:
         src: '{{ item.ca_cert_src }}'
-        dest: '{{ rsyslog_elasticsearch_config_dir }}'
+        dest: '{{ rsyslog_config_dir }}'
       with_items:
         - '{{ rsyslog_elasticsearch }}'
       when:
         - item.ca_cert_src is defined
         - item.ca_cert_src != ""
 
-    - name: Copy local Elasticsearch certs to elasticsearch directory in Rsyslog
+    - name: Copy local Elasticsearch certs to /etc/rsyslog.d directory in Rsyslog
       copy:
         src: '{{ item.cert_src }}'
-        dest: '{{ rsyslog_elasticsearch_config_dir }}'
+        dest: '{{ rsyslog_config_dir }}'
       with_items:
         - '{{ rsyslog_elasticsearch }}'
       when:
         - item.cert_src is defined
         - item.cert_src != ""
 
-    - name: Copy local Elasticsearch keys to elasticsearch directory in Rsyslog
+    - name: Copy local Elasticsearch keys to /etc/rsyslog.d directory in Rsyslog
       copy:
         src: '{{ item.key_src }}'
-        dest: '{{ rsyslog_elasticsearch_config_dir }}'
+        dest: '{{ rsyslog_config_dir }}'
       with_items:
         - '{{ rsyslog_elasticsearch }}'
       when:
         - item.key_src is defined
         - item.key_src != ""
 
-    - name: Update ca_cert path to elasticsearch directory in Rsyslog
+    - name: Update ca_cert path to /etc/rsyslog.d directory in Rsyslog
       set_fact:
         rsyslog_elasticsearch_temp: "{{ rsyslog_elasticsearch_temp|d([]) }} + {{ [  item | combine( { 'ca_cert': item.ca_cert_src| basename , 'cert': item.cert_src| basename, 'key': item.key_src| basename } ) ] }}"
       with_items:
@@ -48,13 +48,12 @@
   when:
     - rsyslog_elasticsearch is defined
     - rsyslog_elasticsearch != []
-    - use_local_omelasticsearch_cert|default(Flase)|bool
+    - use_local_omelasticsearch_cert|default(False)|bool
 
 # Deploy configuration files
 - name: Set Elasticsearch facts
   set_fact:
     rsyslog_role_packages: "{{rsyslog_elasticsearch_packages|flatten([])}}"
-    rsyslog_role_config_dir: "{{ rsyslog_elasticsearch_config_dir }}"
     rsyslog_role_rules: "{{ rsyslog_elasticsearch_rules }}"
 
 - name: Install/Update role packages and generate role configuration files to role subdir

--- a/roles/rsyslog/tasks/cleanup.yaml
+++ b/roles/rsyslog/tasks/cleanup.yaml
@@ -9,12 +9,3 @@
     - item.filename|d() or item.name|d()
     - item.options|d() or item.sections|d()
   notify: restart rsyslogd
-
-- name: Remove role subdir
-  file:
-    path: "{{ rsyslog_role_config_dir }}/"
-    state: 'absent'
-  when:
-    - rsyslog_role_config_dir|d(rsyslog_config_dir) != rsyslog_config_dir
-    - remove_role_config_dir|d(false)
-  notify: restart rsyslogd

--- a/roles/rsyslog/tasks/deploy.yaml
+++ b/roles/rsyslog/tasks/deploy.yaml
@@ -7,13 +7,6 @@
     - not use_rsyslog_image|default(False)|bool
   notify: restart rsyslogd
 
-- name: Create rsyslog role subdir
-  file:
-    path: "{{ rsyslog_role_config_dir }}"
-    state: directory
-    mode: 0700
-  notify: restart rsyslogd
-
 - name: Generate role configuration files in rsyslog.d and subdir
   template:
     src: 'etc/rsyslog.d/rules.conf.j2'


### PR DESCRIPTION
Updated required oVirt timestamp parsing.

Updated sub-roles default config directory to deploy all configuration files to /etc/rsyslog.d/ directory.
When having the pre sub-role directory, there was a problem with the ordering of the files containing the "$IncludeConfig" statement and caused the files to be run in a different order the expected.