### PR TITLE
Porting openshift/cluster-logging-operator rsyslog configuration into…

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,7 +10,8 @@ logging_custom_config_files: []
 
 logging_purge_confs: false
 
-# Configuration directory
-# Unless this is set, "Set rsyslog_elasticsearch" fails.
-rsyslog_config_dir: '/etc/rsyslog.d'
-
+# .. envvar:: can_mod_system
+#
+# Indicates if the ansible executer can do chmod, add user & group, etc.
+# It's checked by {{ lookup('env', 'USER') }} and set to True if the executer is root.
+can_mod_system: False

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,3 +9,8 @@ logging_outputs: []
 logging_custom_config_files: []
 
 logging_purge_confs: false
+
+# Configuration directory
+# Unless this is set, "Set rsyslog_elasticsearch" fails.
+rsyslog_config_dir: '/etc/rsyslog.d'
+

--- a/roles/rsyslog/README.md
+++ b/roles/rsyslog/README.md
@@ -165,27 +165,35 @@ Deployed Results
 ================
 Viaq role
 -----------------
-Once the command-line ansible-playbook is run with `viaq` in `rsyslog_logs_collections`, the following configuration files will be deployed.
+Once the command-line ansible-playbook is run with `viaq` and `viaq-k8s` in `rsyslog_logs_collections`, the following configuration files will be deployed.
 
 ```
 /etc/rsyslog.conf
      rsyslog.d/00-global.conf
                05-common-defaults.conf
+               10-elasticsearch_main.conf
                10-local-modules.conf
-               10-viaq_main.conf
-               viaq/10-mmk8s.conf
-                    20-viaq_formatting.conf
-                    k8s_container_name.rulebase
-                    k8s_filename.rulebase
-                    parse_json.rulebase
-                    normalize_level.json
-                    prio_to_level.json
-                elasticsearch/30-elasticsearch.conf
-                    es-ca.crt
-                    es-cert.pem
-                    es-key.pem
-                    mmk8s.ca.crt
-                    mmk8s.token
+               10-local-viaq-modules.conf
+               10-mmk8s.conf
+               10-viaq-modules.conf
+               20-elasticsearch-templates.conf
+               20-viaq-templates.conf
+               60-00-elasticsearch.conf.conf
+               60-10-mmk8s.conf
+               60-20-viaq-formatting.conf
+               60-30-elasticsearch.conf.conf
+               crio.rulebase
+               k8s_container_name.rulebase
+               k8s_filename.rulebase
+               multiline-json.rulebase
+               parse_json.rulebase
+               normalize_level.json
+               prio_to_level.json
+               es-ca.crt
+               es-cert.pem
+               es-key.pem
+               mmk8s.ca.crt
+               mmk8s.token
 ```
 
 Debops role
@@ -265,7 +273,11 @@ Variables in vars.yaml
 Common sub-variables
 --------------------
 - `rsyslog_system_log_dir`: System log directory.  Default to '/var/log'.
-- `rsyslog_config_dir`: Directory to store configuration files.  Default to '/etc/rsyslog.d'.
+- `rsyslog_config_dir`: Parent directory of the configuration files. Used inside of the config files.  Default to '/etc/rsyslog.d'.
+- `rsyslog_parent_config_dir`: Directory to store rsyslog.conf.  Default to '/etc'.
+- `rsyslog_files_config_dir`: Directory to locate rsyslog.conf. Used in deploying the config files.  Default to '/etc/rsyslog.d'.
+- `rsyslog_mode`:  Mode for the config files.  Default to '0400'
+- `rsyslog_max_message_size`: Maximum supported message size.  Default to 8k.
 - `rsyslog_work_dir`: Working directory.  Default to '/var/lib/rsyslog'.
 - `rsyslog_purge_original_conf`: By default, the Rsyslog configuration files are applied on top of pre-existing configuration files. To purge local files prior to setting new ones, set rsyslog_purge_original_conf variable to 'True', it will move all Rsyslog configuration files to a backup directory before deploying the new configuration files. Defaults to 'False'.
 - `rsyslog_backup_dir`: By default, the Rsyslog backs up the pre-existing configuration files in a temp dir as tar-gz format - /tmp/rsyslog.d-XXXXXX/backup.tgz.  By setting a path to rsyslog_backup_dir, the path is used as the backup directory.  Note that the directory should exist and have the permission to create the backup file both in the file mode and the selinux.
@@ -273,6 +285,8 @@ Common sub-variables
 - `rsyslog_unprivileged`: If set to True, you could specify non-root rsyslog_user and rsyslog_group.  If ansible_distribution is one of "CentOS", "RedHat", and "Fedora", default to True.  Otherwise, False.
 - `rsyslog_user`: Owner user of rsyslogd.  Default to 'syslog' if rsyslog_unprivileged is True.  Otherwise, 'root'.
 - `rsyslog_group`: Owner group of rsyslogd.  Default to 'syslog' if rsyslog_unprivileged is True.  Otherwise, 'root'.
+- `rsyslog_purge_confs`: If set to 'True', existing files in `rsyslog_config_dir` are purged.  Default to 'False'.
+- `use_rsyslog_image`: If set to 'True', the rsyslog is run in the OpenShift container.
 
 Viaq sub-variables
 ------------------

--- a/roles/rsyslog/defaults/main.yaml
+++ b/roles/rsyslog/defaults/main.yaml
@@ -17,15 +17,36 @@ rsyslog_default: True
 # Top directory to place logs
 rsyslog_system_log_dir: '/var/log'
 
-# .. envvar:: rsyslog_config_dir
+# .. envvar:: rsyslog_parent_config_dir
 #
-# Configuration directory
-rsyslog_config_dir: '/etc/rsyslog.d'
+# Parent configuration directory
+rsyslog_parent_config_dir: '/etc'
+
+# .. envvar:: rsyslog_file_config_dir
+#
+# Path the generated files are placed.  This is useful when generating config files
+# to be placed in an arbitrary directory for the later use.
+rsyslog_file_config_dir: '{{rsyslog_config_dir}}'
+
+# .. envvar:: rsyslog_mode
+#
+# Default mode for the config files
+rsyslog_mode: '0400'
 
 # .. envvar:: rsyslog_work_dir
 #
 # Rsyslog work directory
 rsyslog_work_dir: '/var/lib/rsyslog'
+
+# .. envvar:: rsyslog_max_message_size
+#
+# Rsyslog maximum supported message size
+rsyslog_max_message_size: '8192'
+
+# .. envvar:: use_rsyslog_image
+#
+# rsyslog is installed in a container
+use_rsyslog_image: false
 
 # .. envvar:: rsyslog_capabilities
 #
@@ -288,12 +309,12 @@ rsyslog_host_forward: []
 # .. envvar:: rsyslog_weight_map
 #
 # This is a dictionary map of different configuration "types" corresponding to
-# numbers used to sort configuration files in :file:`{{rsyslog_config_dir}}` directory
+# numbers used to sort configuration files in :file:`{{rsyslog_file_config_dir}}` directory
 # (configuration order is important). You can specify a type in the
 # configuration by using the ``item.type`` parameter.
 #
 # If you change the default weight map values, you will most likely need to
-# remove all files from :file:`{{rsyslog_config_dir}}` to reset the configuration.
+# remove all files from :file:`{{rsyslog_file_config_dir}}` to reset the configuration.
 #
 # See :ref:`rsyslog_rules` for more details.
 rsyslog_weight_map:
@@ -311,6 +332,7 @@ rsyslog_weight_map:
   'rules': '50'
   'ruleset': '50'
   'rulesets': '50'
+  'format': '60'
   'input': '90'
   'inputs': '90'
 
@@ -374,7 +396,13 @@ rsyslog_conf_global_options:
     options: |-
       global(
         defaultNetstreamDriver="{{ rsyslog_default_netstream_driver }}"
+      {% if use_rsyslog_image|bool %}
+        workDirectory=`echo $RSYSLOG_WORKDIRECTORY`
+      {% else %}
         workDirectory="{{ rsyslog_work_dir }}"
+      {% endif %}
+        oversizemsg.report="off"
+        oversizemsg.input.mode="accept"
       {% if rsyslog_pki|bool and "tls" in rsyslog_capabilities %}
         defaultNetstreamDriverCAFile="{{ rsyslog_pki_path + '/' + rsyslog_pki_realm + '/' + rsyslog_pki_ca }}"
       {%   if rsyslog_default_driver_authmode != "anon" or "network" in rsyslog_capabilities %}
@@ -471,8 +499,8 @@ rsyslog_conf_common_defaults:
 
       - comment: 'Set default permissions for all log files'
         options: |-
-          $FileOwner {{ rsyslog_file_owner }}
-          $FileGroup {{ rsyslog_file_group }}
+          $FileOwner {{ rsyslog_user }}
+          $FileGroup {{ rsyslog_group }}
           $FileCreateMode 0640
           $DirCreateMode 0755
           $Umask 0022

--- a/roles/rsyslog/defaults/main.yaml
+++ b/roles/rsyslog/defaults/main.yaml
@@ -22,6 +22,11 @@ rsyslog_system_log_dir: '/var/log'
 # Parent configuration directory
 rsyslog_parent_config_dir: '/etc'
 
+# .. envvar:: rsyslog_config_dir
+#
+# Config path used in the config files.
+rsyslog_config_dir: '/etc/rsyslog.d'
+
 # .. envvar:: rsyslog_file_config_dir
 #
 # Path the generated files are placed.  This is useful when generating config files

--- a/roles/rsyslog/handlers/main.yaml
+++ b/roles/rsyslog/handlers/main.yaml
@@ -3,3 +3,4 @@
   service:
     name: 'rsyslog'
     state: 'restarted'
+  when: rsyslog_file_owner == 'root'

--- a/roles/rsyslog/roles/input_roles/ovirt/defaults/main.yaml
+++ b/roles/rsyslog/roles/input_roles/ovirt/defaults/main.yaml
@@ -74,7 +74,7 @@ rsyslog_conf_ovirt_formatting:
 
   - name: 'ovirt_formatting'
     type: 'template'
-    path: '{{ rsyslog_config_dir }}'
+    path: '{{ rsyslog_file_config_dir }}'
     sections:
 
       - options: |-
@@ -155,7 +155,7 @@ rsyslog_rulebase_ovirt_engine:
   - name: 'ovirt_engine'
     filename: 'ovirt_engine.rulebase'
     nocomment: 'true'
-    path: '{{ rsyslog_config_dir }}'
+    path: '{{ rsyslog_file_config_dir }}'
     sections:
       - options: |-
           version=2
@@ -165,7 +165,7 @@ rsyslog_rulebase_ovirt_vdsm:
   - name: 'ovirt_vdsm'
     filename: 'ovirt_vdsm.rulebase'
     nocomment: 'true'
-    path: '{{ rsyslog_config_dir }}'
+    path: '{{ rsyslog_file_config_dir }}'
     sections:
       - options: |-
           version=2
@@ -177,7 +177,7 @@ rsyslog_rulebase_ovirt_parse_json:
   - name: 'parse_json'
     filename: 'parse_json.rulebase'
     nocomment: 'true'
-    path: '{{rsyslog_config_dir }}'
+    path: '{{rsyslog_file_config_dir }}'
     sections:
 
       - options: |-

--- a/roles/rsyslog/roles/input_roles/viaq-k8s/defaults/main.yaml
+++ b/roles/rsyslog/roles/input_roles/viaq-k8s/defaults/main.yaml
@@ -29,6 +29,7 @@ rsyslog_viaq_k8s_rules:
   - '{{ rsyslog_rulebase_viaq_k8s_filename }}'
   - '{{ rsyslog_rulebase_viaq_k8s_container_name }}'
   - '{{ rsyslog_rulebase_viaq_crio }}'
+  - '{{ rsyslog_rulebase_viaq_k8s_multiline }}'
 
 # Default Viaq-k8s configuration options
 # ---------------------------------
@@ -40,7 +41,7 @@ rsyslog_conf_viaq_mmk8s_module:
 
   - name: 'mmk8s'
     type: 'modules'
-    path: '{{rsyslog_config_dir}}'
+    path: '{{rsyslog_file_config_dir}}'
     sections:
 
       - options: |-
@@ -52,21 +53,64 @@ rsyslog_conf_viaq_mmk8s_module:
 
 rsyslog_conf_viaq_mmk8s_input:
 
-  - name: 'mmk8s'
-    type: 'templates'
-    path: '{{rsyslog_config_dir}}'
+  - name: '10-mmk8s'
+    type: 'format'
+    path: '{{rsyslog_file_config_dir}}'
     sections:
 
       - options: |-
+          {% if use_rsyslog_image|bool %}
+          # NOTE: endmsg.regex is available in 3.38.0 and newer
+          # for crio, the end of message is when the value "F" is in the logtag field
+          # for docker json-file, it is when the "log" field value ends with "\n"
+          # however, since imfile processing happens _before_ the field parsing, we have to
+          # rely on two regular expressions - basically look for the pattern \n"}$ for the
+          # string at the end of the message, or \n"," for the string in the middle of
+          # a message
+          input(type="imfile"
+                file="{{ rsyslog_viaq_log_dir }}/*.log"
+                tag="kubernetes" addmetadata="on" reopenOnTruncate="on"
+                discardTruncatedMsg="on" msgDiscardingError="off"
+                endmsg.regex="(^[^ ]+ (stdout|stderr) F )|(\\n\"}$)|(\\n\",\")") # "
+          {% else %}
           input(type="imfile" file="{{ rsyslog_viaq_log_dir }}/*.log" tag="kubernetes" addmetadata="on" reopenOnTruncate="on")
+          {% endif %}
 
           if ((strlen($!CONTAINER_NAME) > 0) and (strlen($!CONTAINER_ID_FULL) > 0)) or
               ((strlen($!metadata) > 0) and (strlen($!metadata!filename) > 0) and ($!metadata!filename startswith "{{rsyslog_viaq_log_dir}}/")) then {
               if ((strlen($!metadata) > 0) and (strlen($!metadata!filename) > 0) and ($!metadata!filename startswith "{{rsyslog_viaq_log_dir}}/")) then {
                   if $msg startswith "{" then {
-                      action(type="mmjsonparse" cookie="") # parse entire message as json
+                      action(type="mmnormalize" rulebase="{{ rsyslog_config_dir }}/multiline-json.rulebase")
+                      foreach ($.ii in $!multilinejson) do {
+                          if strlen($!@timestamp) == 0 then {
+                              set $!@timestamp = $.ii!time;
+                          }
+                          if strlen($!stream) == 0 then {
+                              set $!stream = $.ii!stream;
+                          }
+                          if strlen($!log) == 0 then {
+                              set $!log = $.ii!log;
+                          } else {
+                              reset $!log = $!log & $.ii!log;
+                          }
+                      }
+                      unset $!multilinejson;
                   } else {
                       action(type="mmnormalize" rulebase="{{ rsyslog_config_dir }}/crio.rulebase")
+                      foreach ($.ii in $!multilinecrio) do {
+                          if strlen($!@timestamp) == 0 then {
+                              set $!@timestamp = $.ii!time;
+                          }
+                          if strlen($!stream) == 0 then {
+                              set $!stream = $.ii!stream;
+                          }
+                          if strlen($!log) == 0 then {
+                              set $!log = $.ii!log;
+                          } else {
+                              reset $!log = $!log & $.ii!log;
+                          }
+                      }
+                      unset $!multilinecrio;
                   }
               }
               action(type="mmkubernetes"
@@ -81,7 +125,7 @@ rsyslog_rulebase_viaq_k8s_filename:
   - name: 'k8s_filename'
     filename: 'k8s_filename.rulebase'
     nocomment: 'true'
-    path: '{{rsyslog_config_dir }}'
+    path: '{{rsyslog_file_config_dir}}'
     sections:
 
       - options: |-
@@ -93,12 +137,11 @@ rsyslog_rulebase_viaq_k8s_container_name:
   - name: 'k8s_container_name'
     filename: 'k8s_container_name.rulebase'
     nocomment: 'true'
-    path: '{{rsyslog_config_dir }}'
+    path: '{{rsyslog_file_config_dir}}'
     sections:
 
       - options: |-
           version=2
-          rule=:%k8s_prefix:char-to:_%_%container_name:char-to:.%.%container_hash:char-to:_%_%pod_name:char-to:_%_%namespace_name:char-to:_%_%not_used_1:char-to:_%_%not_used_2:rest%
           rule=:%k8s_prefix:char-to:_%_%container_name:char-to:_%_%pod_name:char-to:_%_%namespace_name:char-to:_%_%not_used_1:char-to:_%_%not_used_2:rest%
           # not a kubernetes container
           rule=:%container_name:rest%
@@ -108,8 +151,39 @@ rsyslog_rulebase_viaq_crio:
   - name: 'crio'
     filename: 'crio.rulebase'
     nocomment: 'true'
-    path: '{{rsyslog_config_dir }}'
+    path: '{{rsyslog_file_config_dir}}'
     sections:
       - options: |-
           version=2
-          rule=:%time:word% %stream:word% %logtag:word% %log:rest%
+          rule=:%{"name":"multilinecrio", "type":"repeat",
+                      "parser":[
+                                 {"type":"word", "name":"time"},
+                                 {"type":"literal", "text":" "},
+                                 {"type":"word", "name":"stream"},
+                                 {"type":"literal", "text":" "},
+                                 {"type":"word", "name":"partial"},
+                                 {"type":"literal", "text":" "},
+                                 {"type":"char-sep", "name":"log", "extradata":"\n"}
+                               ],
+                      "while":[
+                                 {"type":"literal", "text":"\n"},
+                              ]
+                   }%
+
+rsyslog_rulebase_viaq_k8s_multiline:
+
+  - name: 'multiline'
+    filename: 'multiline-json.rulebase'
+    nocomment: 'true'
+    path: '{{rsyslog_file_config_dir}}'
+    sections:
+      - options: |-
+          version=2
+          rule=:%{"name":"multilinejson", "type":"repeat", "option.permitMismatchInParser": true,
+                      "parser":[
+                                 {"type":"json", "name":"."}
+                               ],
+                      "while":[
+                                 {"type":"char-sep", "extradata":"{"}
+                              ]
+                   }%

--- a/roles/rsyslog/roles/input_roles/viaq/defaults/main.yaml
+++ b/roles/rsyslog/roles/input_roles/viaq/defaults/main.yaml
@@ -24,6 +24,7 @@ rsyslog_viaq_rules:
 
   - '{{ rsyslog_conf_local_viaq_modules }}'
   - '{{ rsyslog_conf_viaq_main_modules }}'
+  - '{{ rsyslog_conf_viaq_templates }}'
   - '{{ rsyslog_conf_viaq_formatting }}'
   - '{{ rsyslog_rulebase_viaq_parse_json }}'
   - '{{ rsyslog_json_viaq_normalize_level }}'
@@ -48,7 +49,7 @@ rsyslog_conf_local_viaq_modules:
 
 rsyslog_conf_viaq_main_modules:
 
-  - name: 'viaq_main'
+  - name: 'viaq-modules'
     type: 'modules'
     sections:
 
@@ -58,27 +59,54 @@ rsyslog_conf_viaq_main_modules:
 
       - options: |-
           # Read from journal
+          {% if use_rsyslog_image|bool %}
+          module(load="imjournal" StateFile=`echo $RSYSLOG_IMJOURNAL_STATE` UsePid="both" RateLimit.Burst="{{ imjournal_ratelimit_burst|default(1000000) }}" RateLimit.Interval="{{ imjournal_ratelimit_interval|default(10) }}" PersistStateInterval="1000" WorkAroundJournalBug="on")
+          {% else %}
           module(load="imjournal" StateFile="{{ rsyslog_work_dir }}/imjournal.state" UsePid="both" RateLimit.Burst="{{ imjournal_ratelimit_burst|default(1000000) }}" RateLimit.Interval="{{ imjournal_ratelimit_interval|default(10) }}" PersistStateInterval="1000" WorkAroundJournalBug="on")
+          {% endif %}
 
       - options: |-
           # Normalize logs
           module(load="mmnormalize")
 
-rsyslog_conf_viaq_formatting:
+      - options: |-
+          # Stats for monitoring
+          {% if use_rsyslog_image|bool %}
+          module(load="impstats" interval="1" format="cee" log.syslog="off" log.file=`echo $RSYSLOG_IMPSTATS_FILE`)
+          {% else %}
+          module(load="impstats" interval="1" format="cee" log.syslog="off" log.file="{{ rsyslog_work_dir }}/impstats.json")
+          {% endif %}
 
-  - name: 'viaq_formatting'
-    type: 'template'
-    path: '{{rsyslog_config_dir }}'
+rsyslog_conf_viaq_templates:
+
+  - name: 'viaq-templates'
+    type: 'templates'
+    path: '{{ rsyslog_file_config_dir }}'
+    sections:
+
+      - options: |-
+          template(name="cnvt_to_viaq_timestamp" type="list") {
+              property(name="TIMESTAMP" dateFormat="rfc3339")
+          }
+
+          template(name="timegeneratedrfc3339" type="string" string="%timegenerated:::date-rfc3339%")
+
+rsyslog_conf_viaq_formatting:
+  - name: 'parse_json'
+    filename: 'parse_json.rulebase'
+    nocomment: 'true'
+    path: '{{ rsyslog_file_config_dir }}'
+    sections:
+
+  - name: '20-viaq-formatting'
+    type: 'format'
+    path: '{{ rsyslog_file_config_dir }}'
     sections:
 
       - options: |-
           # formatting
           lookup_table(name="prio_to_level" file="{{ rsyslog_config_dir }}/prio_to_level.json")
           lookup_table(name="normalize_level" file="{{ rsyslog_config_dir }}/normalize_level.json")
-
-          template(name="cnvt_to_viaq_timestamp" type="list") {
-              property(name="TIMESTAMP" dateFormat="rfc3339")
-          }
 
           # rsyslog 8.30.0 and later does case insensitive variable name comparison
           # which means $!MESSAGE is the same as $!message - HOWEVER - the case
@@ -271,13 +299,17 @@ rsyslog_conf_viaq_formatting:
               }
               unset $!PRIORITY;
               if strlen($!hostname) == 0 then {
-                  if (strlen($!kubernetes) > 0) and (strlen($!kubernetes!host)) > 0 then {
+                  if (strlen($!kubernetes) > 0) and (strlen($!kubernetes!host) > 0) then {
                       set $!hostname = $!kubernetes!host;
                   } else {
                       if strlen($!_HOSTNAME) > 0 then {
                           set $!hostname = $!_HOSTNAME;
                       } else {
-                          set $!hostname = $hostname;
+          {% if use_rsyslog_image|bool %}
+                          set $!hostname = `echo $HOSTNAME`;
+          {% else %}
+                          set $!hostname = $myhostname;
+          {% endif %}
                       }
                   }
               }
@@ -295,7 +327,11 @@ rsyslog_conf_viaq_formatting:
                   if strlen($!kubernetes!host) > 0 then {
                       set $!hostname = $!kubernetes!host;
                   } else {
-                      set $!hostname = $hostname;
+          {% if use_rsyslog_image|bool %}
+                      set $!hostname = `echo $HOSTNAME`;
+          {% else %}
+                      set $!hostname = $myhostname;
+          {% endif %}
                   }
               }
               if strlen($!@timestamp) == 0 then {
@@ -353,9 +389,12 @@ rsyslog_conf_viaq_formatting:
           # add pipeline_metadata
           set $!pipeline_metadata!collector!name = "rsyslog";
           set $!pipeline_metadata!collector!inputname = $inputname;
-          template(name="timegeneratedrfc3339" type="string" string="%timegenerated:::date-rfc3339%")
           set $!pipeline_metadata!collector!received_at = exec_template("timegeneratedrfc3339");
-          # not sure how to get hostname, ipaddr4, ipaddr6, version
+          {% if use_rsyslog_image|bool %}
+          set $!pipeline_metadata!collector!ipaddr4 = `echo $IPADDR4`;
+          set $!pipeline_metadata!collector!ipaddr6 = `echo $IPADDR6`;
+          set $!pipeline_metadata!collector!version = `echo $PIPELINE_VERSION`;
+          {% endif %}
           if (strlen($!file) == 0) and (strlen($!metadata) > 0) and (strlen($!metadata!filename) > 0) then {
               set $!file = $!metadata!filename;
           }
@@ -371,7 +410,7 @@ rsyslog_rulebase_viaq_parse_json:
   - name: 'parse_json'
     filename: 'parse_json.rulebase'
     nocomment: 'true'
-    path: '{{rsyslog_config_dir }}'
+    path: '{{ rsyslog_file_config_dir }}'
     sections:
 
       - options: |-
@@ -383,7 +422,7 @@ rsyslog_json_viaq_normalize_level:
   - name: 'normalize_level'
     filename: 'normalize_level.json'
     nocomment: 'true'
-    path: '{{rsyslog_config_dir }}'
+    path: '{{ rsyslog_file_config_dir }}'
     sections:
 
       - options: |-
@@ -413,7 +452,7 @@ rsyslog_json_viaq_prio_to_level:
   - name: 'prio_to_level'
     filename: 'prio_to_level.json'
     nocomment: 'true'
-    path: '{{rsyslog_config_dir }}'
+    path: '{{ rsyslog_file_config_dir }}'
     sections:
 
       - options: |-

--- a/roles/rsyslog/roles/output_roles/elasticsearch/defaults/main.yaml
+++ b/roles/rsyslog/roles/output_roles/elasticsearch/defaults/main.yaml
@@ -24,7 +24,9 @@ rsyslog_elasticsearch:
 rsyslog_elasticsearch_rules:
 
   - '{{ rsyslog_conf_es_main_modules }}'
+  - '{{ rsyslog_conf_es_elasticsearch_templates }}'
   - '{{ rsyslog_conf_es_elasticsearch }}'
+  - '{{ rsyslog_conf_es_elasticsearch_call_ruleset }}'
 
 # Default elasticsearch configuration options [[[
 # ---------------------------------
@@ -40,11 +42,11 @@ rsyslog_conf_es_main_modules:
           # Send to ElasticSearch
           module(load="omelasticsearch")
 
-rsyslog_conf_es_elasticsearch:
+rsyslog_conf_es_elasticsearch_templates:
 
-  - name: 'elasticsearch'
-    type: 'output'
-    path: '{{ rsyslog_config_dir }}'
+  - name: 'elasticsearch-templates'
+    type: 'template'
+    path: '{{ rsyslog_file_config_dir }}'
     sections:
 
       - options: |-
@@ -71,9 +73,22 @@ rsyslog_conf_es_elasticsearch:
 
           template(name="index_template" type="string" string="%$.index_name%")
           template(name="id_template" type="string" string="%$.es_msg_id%")
+          
+rsyslog_conf_es_elasticsearch:
 
+  - name: '00-elasticsearch.conf'
+    type: 'format'
+    path: '{{ rsyslog_file_config_dir }}'
+    sections:
+
+      - options: |-
+          # omelasticsearch
           ruleset(name="error_es") {
-              action(type="omfile" template="es_template_nl" file="{{rsyslog_work_dir}}/es-bulk-errors.log")
+          {% if use_rsyslog_image|bool %}
+            action(type="omfile" template="es_template_nl" file=`echo $RSYSLOG_BULK_ERRORS`)
+          {% else %}
+            action(type="omfile" template="es_template_nl" file="{{rsyslog_work_dir}}/es-bulk-errors.log")
+          {% endif %}
           }
 
           ruleset(name="try_es") {
@@ -111,9 +126,15 @@ rsyslog_conf_es_elasticsearch:
           {% if loop.length == 1 %}
               action(
                   type="omelasticsearch"
+          {% if use_rsyslog_image|bool %}
+                  name=`echo $ES_OUTPUT_NAME`
+                  server=`echo $ES_HOST`
+                  serverport=`echo $ES_PORT`
+          {% else %}
                   name="{{ res.name | default('viaq-elasticsearch') }}"
                   server="{{ res.server_host | default('logging-es') }}"
                   serverport="{{ res.server_port | default(9200) | int }}"
+          {% endif %}
                   template="{{ res.template | default("es_template") }}"
                   searchIndex="{{ res.searchIndex | default("index_template") }}"
                   dynSearchIndex="{{ res.dynSearchIndex | default("on") }}"
@@ -123,23 +144,49 @@ rsyslog_conf_es_elasticsearch:
                   bulkid="{{ res.bulkid | default("id_template") }}"
                   dynbulkid="{{ res.dynbulkid | default("on") }}"
                   retryfailures="{{ res.retryfailures | default("on") }}"
-                  allowUnsignedCerts = "{{ res.allowUnsignedCerts | default("off") }}"
+                  allowUnsignedCerts="{{ res.allowUnsignedCerts | default("off") }}"
                   retryruleset="{{ res.retryruleset | default("try_es") }}"
                   usehttps="{{ res.usehttps | default("on") }}"
           {% if use_omelasticsearch_cert | default(true) %}
-                  tls.cacert="{{ res.ca_cert|default("/etc/rsyslog.d/elasticsearch/es-ca.crt") }}"
-                  tls.mycert="{{ res.cert|default("/etc/rsyslog.d/elasticsearch/es-cert.pem") }}"
-                  tls.myprivkey="{{ res.key|default("/etc/rsyslog.d/elasticsearch/es-key.pem") }}"
+          {% if use_rsyslog_image|bool %}
+                  tls.cacert=`echo $ES_CA`
+                  tls.mycert=`echo $ES_CLIENT_CERT`
+                  tls.myprivkey=`echo $ES_CLIENT_KEY`
+          {% else %}
+                  tls.cacert="{{ res.ca_cert|default('/etc/rsyslog.d/elasticsearch/es-ca.crt') }}"
+                  tls.mycert="{{ res.cert|default('/etc/rsyslog.d/elasticsearch/es-cert.pem') }}"
+                  tls.myprivkey="{{ res.key|default('/etc/rsyslog.d/elasticsearch/es-key.pem') }}"
+          {% endif %}
+          {% endif %}
+          {% if use_rsyslog_image | default(true) %}
+                  queue.filename="es-app"
+                  queue.spoolDirectory=`echo $RSYSLOG_SPOOLDIRECTORY`
+                  queue.type=`echo $ES_QUEUE_TYPE`
+                  queue.maxDiskSpace=`echo $ES_QUEUE_MAXDISKSPACE`
+                  queue.maxFileSize=`echo $ES_QUEUE_MAXFILESIZE`
+                  queue.checkpointInterval=`echo $ES_QUEUE_CHECKPOINTINTERVAL`
+                  queue.syncqueuefiles="on"
           {% endif %}
               )
           {% else %}
           {% if loop.first %}
+          {% if use_rsyslog_image|bool %}
+              if ( $.logs_collection == "{{ res.logs_collections_name }}" ) and ($.index_prefix startswith "{{ res.index_prefix }}")
+                 or ((`echo $ES_HOST` == `echo $OPS_HOST`) and (`echo $ES_PORT` == `echo $OPS_PORT`)) then {
+          {% else %}
               if ( $.logs_collection == "{{ res.logs_collections_name }}" ) and ($.index_prefix startswith "{{ res.index_prefix }}") then {
+          {% endif %}
                 action(
                     type="omelasticsearch"
+          {% if use_rsyslog_image|bool %}
+                    name=`echo $ES_OUTPUT_NAME`
+                    server=`echo $ES_HOST`
+                    serverport=`echo $ES_PORT`
+          {% else %}
                     name="{{ res.name | default('viaq-elasticsearch') }}"
                     server="{{ res.server_host | default('logging-es') }}"
                     serverport="{{ res.server_port | default(9200) | int }}"
+          {% endif %}
                     template="{{ res.template | default("es_template") }}"
                     searchIndex="{{ res.searchIndex | default("index_template") }}"
                     dynSearchIndex="{{ res.dynSearchIndex | default("on") }}"
@@ -149,22 +196,43 @@ rsyslog_conf_es_elasticsearch:
                     bulkid="{{ res.bulkid | default("id_template") }}"
                     dynbulkid="{{ res.dynbulkid | default("on") }}"
                     retryfailures="{{ res.retryfailures | default("on") }}"
-                    allowUnsignedCerts = "{{ res.allowUnsignedCerts | default("off") }}"
+                    allowUnsignedCerts="{{ res.allowUnsignedCerts | default("off") }}"
                     retryruleset="{{ res.retryruleset | default("try_es") }}"
                     usehttps="{{ res.usehttps | default("on") }}"
           {% if use_omelasticsearch_cert | default(true) %}
-                    tls.cacert="{{ res.ca_cert|default("/etc/rsyslog.d/elasticsearch/es-ca.crt") }}"
-                    tls.mycert="{{ res.cert|default("/etc/rsyslog.d/elasticsearch/es-cert.pem") }}"
-                    tls.myprivkey="{{ res.key|default("/etc/rsyslog.d/elasticsearch/es-key.pem") }}"
+          {% if use_rsyslog_image|bool %}
+                    tls.cacert=`echo $ES_CA`
+                    tls.mycert=`echo $ES_CLIENT_CERT`
+                    tls.myprivkey=`echo $ES_CLIENT_KEY`
+          {% else %}
+                    tls.cacert="{{ res.ca_cert|default('/etc/rsyslog.d/elasticsearch/es-ca.crt') }}"
+                    tls.mycert="{{ res.cert|default('/etc/rsyslog.d/elasticsearch/es-cert.pem') }}"
+                    tls.myprivkey="{{ res.key|default('/etc/rsyslog.d/elasticsearch/es-key.pem') }}"
+          {% endif %}
+          {% endif %}
+          {% if use_rsyslog_image | default(true) %}
+                    queue.filename="es-app"
+                    queue.spoolDirectory=`echo $RSYSLOG_SPOOLDIRECTORY`
+                    queue.type=`echo $ES_QUEUE_TYPE`
+                    queue.maxDiskSpace=`echo $ES_QUEUE_MAXDISKSPACE`
+                    queue.maxFileSize=`echo $ES_QUEUE_MAXFILESIZE`
+                    queue.checkpointInterval=`echo $ES_QUEUE_CHECKPOINTINTERVAL`
+                    queue.syncqueuefiles="on"
           {% endif %}
                 )
           {% elif loop.last %}
               else {
                 action(
                     type="omelasticsearch"
+          {% if use_rsyslog_image|bool %}
+                    name=`echo $ES_OPS_OUTPUT_NAME`
+                    server=`echo $OPS_HOST`
+                    serverport=`echo $OPS_PORT`
+          {% else %}
                     name="{{ res.name | default('viaq-elasticsearch') }}"
                     server="{{ res.server_host | default('logging-es') }}"
                     serverport="{{ res.server_port | default(9200) | int }}"
+          {% endif %}
                     template="{{ res.template | default("es_template") }}"
                     searchIndex="{{ res.searchIndex | default("index_template") }}"
                     dynSearchIndex="{{ res.dynSearchIndex | default("on") }}"
@@ -174,24 +242,50 @@ rsyslog_conf_es_elasticsearch:
                     bulkid="{{ res.bulkid | default("id_template") }}"
                     dynbulkid="{{ res.dynbulkid | default("on") }}"
                     retryfailures="{{ res.retryfailures | default("on") }}"
-                    allowUnsignedCerts = "{{ res.allowUnsignedCerts | default("off") }}"
+                    allowUnsignedCerts="{{ res.allowUnsignedCerts | default("off") }}"
           {% if res.retryfailures|default("on") == "on" %}
                     retryruleset="{{ res.retryruleset | default("try_es") }}"
           {% endif %}
                     usehttps="{{ res.usehttps | default("on") }}"
           {% if use_omelasticsearch_cert | default(true) %}
-                    tls.cacert="{{ res.ca_cert|default("/etc/rsyslog.d/elasticsearch/es-ca.crt") }}"
-                    tls.mycert="{{ res.cert|default("/etc/rsyslog.d/elasticsearch/es-cert.pem") }}"
-                    tls.myprivkey="{{ res.key|default("/etc/rsyslog.d/elasticsearch/es-key.pem") }}"
+          {% if use_rsyslog_image|bool %}
+                    tls.cacert=`echo $OPS_CA`
+                    tls.mycert=`echo $OPS_CLIENT_CERT`
+                    tls.myprivkey=`echo $OPS_CLIENT_KEY`
+          {% else %}
+                    tls.cacert="{{ res.ca_cert|default('/etc/rsyslog.d/elasticsearch/es-ca.crt') }}"
+                    tls.mycert="{{ res.cert|default('/etc/rsyslog.d/elasticsearch/es-cert.pem') }}"
+                    tls.myprivkey="{{ res.key|default('/etc/rsyslog.d/elasticsearch/es-key.pem') }}"
+          {% endif %}
+          {% endif %}
+          {% if use_rsyslog_image|bool %}
+                    queue.filename="es-app"
+                    queue.spoolDirectory=`echo $RSYSLOG_SPOOLDIRECTORY`
+                    queue.type=`echo $ES_QUEUE_TYPE`
+                    queue.maxDiskSpace=`echo $ES_QUEUE_MAXDISKSPACE`
+                    queue.maxFileSize=`echo $ES_QUEUE_MAXFILESIZE`
+                    queue.checkpointInterval=`echo $ES_QUEUE_CHECKPOINTINTERVAL`
+                    queue.syncqueuefiles="on"
           {% endif %}
                 )
           {% else %}
+          {% if use_rsyslog_image|bool %}
+              else if ( $.logs_collection == "{{ res.logs_collections_name }}" ) and ($.index_prefix startswith "{{ res.index_prefix }}")
+                 or ((`echo $ES_HOST` == `echo $OPS_HOST`) and (`echo $ES_PORT` == `echo $OPS_PORT`)) then {
+          {% else %}
               else if ( $.logs_collection == "{{ res.logs_collections_name }}" ) and ($.index_prefix startswith "{{ res.index_prefix }}") then {
+          {% endif %}
                 action(
                     type="omelasticsearch"
+          {% if use_rsyslog_image|bool %}
+                    name=`echo $ES_OUTPUT_NAME`
+                    server=`echo $ES_HOST`
+                    serverport=`echo $ES_PORT`
+          {% else %}
                     name="{{ res.name | default('viaq-elasticsearch') }}"
                     server="{{ res.server_host | default('logging-es') }}"
                     serverport="{{ res.server_port | default(9200) | int }}"
+          {% endif %}
                     template="{{ res.template | default("es_template") }}"
                     searchIndex="{{ res.searchIndex | default("index_template") }}"
                     dynSearchIndex="{{ res.dynSearchIndex | default("on") }}"
@@ -201,15 +295,30 @@ rsyslog_conf_es_elasticsearch:
                     bulkid="{{ res.bulkid | default("id_template") }}"
                     dynbulkid="{{ res.dynbulkid | default("on") }}"
                     retryfailures="{{ res.retryfailures | default("on") }}"
-                    allowUnsignedCerts = "{{ res.allowUnsignedCerts | default("off") }}"
+                    allowUnsignedCerts="{{ res.allowUnsignedCerts | default("off") }}"
           {% if res.retryfailures|default("on") == "on" %}
                     retryruleset="{{ res.retryruleset | default("try_es") }}"
           {% endif %}
                     usehttps="{{ res.usehttps | default("on") }}"
           {% if use_omelasticsearch_cert | default(true) %}
-                    tls.cacert="{{ res.ca_cert|default("/etc/rsyslog.d/elasticsearch/es-ca.crt") }}"
-                    tls.mycert="{{ res.cert|default("/etc/rsyslog.d/elasticsearch/es-cert.pem") }}"
-                    tls.myprivkey="{{ res.key|default("/etc/rsyslog.d/elasticsearch/es-key.pem") }}"
+          {% if use_rsyslog_image|bool %}
+                    tls.cacert=`echo $ES_CA`
+                    tls.mycert=`echo $ES_CLIENT_CERT`
+                    tls.myprivkey=`echo $ES_CLIENT_KEY`
+          {% else %}
+                    tls.cacert="{{ res.ca_cert|default('/etc/rsyslog.d/elasticsearch/es-ca.crt') }}"
+                    tls.mycert="{{ res.cert|default('/etc/rsyslog.d/elasticsearch/es-cert.pem') }}"
+                    tls.myprivkey="{{ res.key|default('/etc/rsyslog.d/elasticsearch/es-key.pem') }}"
+          {% endif %}
+          {% endif %}
+          {% if use_rsyslog_image|bool %}
+                    queue.filename="es-app"
+                    queue.spoolDirectory=`echo $RSYSLOG_SPOOLDIRECTORY`
+                    queue.type=`echo $ES_QUEUE_TYPE`
+                    queue.maxDiskSpace=`echo $ES_QUEUE_MAXDISKSPACE`
+                    queue.maxFileSize=`echo $ES_QUEUE_MAXFILESIZE`
+                    queue.checkpointInterval=`echo $ES_QUEUE_CHECKPOINTINTERVAL`
+                    queue.syncqueuefiles="on"
           {% endif %}
                 )
           {% endif %}
@@ -218,4 +327,14 @@ rsyslog_conf_es_elasticsearch:
           {% endfor %}
           }
 
+rsyslog_conf_es_elasticsearch_call_ruleset:
+
+  - name: '30-elasticsearch.conf'
+    type: 'format'
+    path: '{{ rsyslog_file_config_dir }}'
+    sections:
+
+      - options: |-
+          # call the elasticsearch output ruleset
           call try_es
+

--- a/roles/rsyslog/roles/output_roles/elasticsearch/defaults/main.yaml
+++ b/roles/rsyslog/roles/output_roles/elasticsearch/defaults/main.yaml
@@ -22,7 +22,6 @@ rsyslog_elasticsearch:
 # ---------------------------
 
 rsyslog_elasticsearch_rules:
-
   - '{{ rsyslog_conf_es_main_modules }}'
   - '{{ rsyslog_conf_es_elasticsearch_templates }}'
   - '{{ rsyslog_conf_es_elasticsearch }}'
@@ -73,10 +72,10 @@ rsyslog_conf_es_elasticsearch_templates:
 
           template(name="index_template" type="string" string="%$.index_name%")
           template(name="id_template" type="string" string="%$.es_msg_id%")
-          
+
 rsyslog_conf_es_elasticsearch:
 
-  - name: '00-elasticsearch.conf'
+  - name: '00-elasticsearch'
     type: 'format'
     path: '{{ rsyslog_file_config_dir }}'
     sections:
@@ -158,7 +157,7 @@ rsyslog_conf_es_elasticsearch:
                   tls.myprivkey="{{ res.key|default('/etc/rsyslog.d/elasticsearch/es-key.pem') }}"
           {% endif %}
           {% endif %}
-          {% if use_rsyslog_image | default(true) %}
+          {% if use_rsyslog_image|bool %}
                   queue.filename="es-app"
                   queue.spoolDirectory=`echo $RSYSLOG_SPOOLDIRECTORY`
                   queue.type=`echo $ES_QUEUE_TYPE`
@@ -166,6 +165,14 @@ rsyslog_conf_es_elasticsearch:
                   queue.maxFileSize=`echo $ES_QUEUE_MAXFILESIZE`
                   queue.checkpointInterval=`echo $ES_QUEUE_CHECKPOINTINTERVAL`
                   queue.syncqueuefiles="on"
+          {% else %}
+                  queue.filename="{{ res.queue_filename|default('es-app') }}"
+                  queue.spoolDirectory="{{ res.queue_spooldir|default(rsyslog_es_q_spooldirectory) }}"
+                  queue.type="{{ res.queue_type|default(rsyslog_es_q_type) }}"
+                  queue.maxDiskSpace="{{ res.queue_max_disk_space|default(rsyslog_es_q_maxdiskspace) }}"
+                  queue.maxFileSize="{{ res.queue_max_file_size|default(rsyslog_es_q_maxfilesize) }}"
+                  queue.checkpointInterval="{{ res.queue_checkpoint_interval|default(rsyslog_es_q_checkpointinterval) }}"
+                  queue.syncqueuefiles="{{ res.queue_sync_files|default("on") }}"
           {% endif %}
               )
           {% else %}
@@ -210,7 +217,7 @@ rsyslog_conf_es_elasticsearch:
                     tls.myprivkey="{{ res.key|default('/etc/rsyslog.d/elasticsearch/es-key.pem') }}"
           {% endif %}
           {% endif %}
-          {% if use_rsyslog_image | default(true) %}
+          {% if use_rsyslog_image|bool %}
                     queue.filename="es-app"
                     queue.spoolDirectory=`echo $RSYSLOG_SPOOLDIRECTORY`
                     queue.type=`echo $ES_QUEUE_TYPE`
@@ -218,6 +225,14 @@ rsyslog_conf_es_elasticsearch:
                     queue.maxFileSize=`echo $ES_QUEUE_MAXFILESIZE`
                     queue.checkpointInterval=`echo $ES_QUEUE_CHECKPOINTINTERVAL`
                     queue.syncqueuefiles="on"
+          {% else %}
+                    queue.filename="{{ res.queue_filename|default('es-app') }}"
+                    queue.spoolDirectory="{{ res.queue_spooldir|default(rsyslog_es_q_spooldirectory) }}"
+                    queue.type="{{ res.queue_type|default(rsyslog_es_q_type) }}"
+                    queue.maxDiskSpace="{{ res.queue_max_disk_space|default(rsyslog_es_q_maxdiskspace) }}"
+                    queue.maxFileSize="{{ res.queue_max_file_size|default(rsyslog_es_q_maxfilesize) }}"
+                    queue.checkpointInterval="{{ res.queue_checkpoint_interval|default(rsyslog_es_q_checkpointinterval) }}"
+                    queue.syncqueuefiles="{{ res.queue_sync_files|default("on") }}"
           {% endif %}
                 )
           {% elif loop.last %}
@@ -266,6 +281,14 @@ rsyslog_conf_es_elasticsearch:
                     queue.maxFileSize=`echo $ES_QUEUE_MAXFILESIZE`
                     queue.checkpointInterval=`echo $ES_QUEUE_CHECKPOINTINTERVAL`
                     queue.syncqueuefiles="on"
+          {% else %}
+                    queue.filename="{{ res.queue_filename|default('es-app') }}"
+                    queue.spoolDirectory="{{ res.queue_spooldir|default(rsyslog_es_q_spooldirectory) }}"
+                    queue.type="{{ res.queue_type|default(rsyslog_es_q_type) }}"
+                    queue.maxDiskSpace="{{ res.queue_max_disk_space|default(rsyslog_es_q_maxdiskspace) }}"
+                    queue.maxFileSize="{{ res.queue_max_file_size|default(rsyslog_es_q_maxfilesize) }}"
+                    queue.checkpointInterval="{{ res.queue_checkpoint_interval|default(rsyslog_es_q_checkpointinterval) }}"
+                    queue.syncqueuefiles="{{ res.queue_sync_files|default("on") }}"
           {% endif %}
                 )
           {% else %}
@@ -319,6 +342,14 @@ rsyslog_conf_es_elasticsearch:
                     queue.maxFileSize=`echo $ES_QUEUE_MAXFILESIZE`
                     queue.checkpointInterval=`echo $ES_QUEUE_CHECKPOINTINTERVAL`
                     queue.syncqueuefiles="on"
+          {% else %}
+                    queue.filename="{{ res.queue_filename|default('es-app') }}"
+                    queue.spoolDirectory="{{ res.queue_spooldir|default(rsyslog_es_q_spooldirectory) }}"
+                    queue.type="{{ res.queue_type|default(rsyslog_es_q_type) }}"
+                    queue.maxDiskSpace="{{ res.queue_max_disk_space|default(rsyslog_es_q_maxdiskspace) }}"
+                    queue.maxFileSize="{{ res.queue_max_file_size|default(rsyslog_es_q_maxfilesize) }}"
+                    queue.checkpointInterval="{{ res.queue_checkpoint_interval|default(rsyslog_es_q_checkpointinterval) }}"
+                    queue.syncqueuefiles="{{ res.queue_sync_files|default("on") }}"
           {% endif %}
                 )
           {% endif %}
@@ -329,7 +360,7 @@ rsyslog_conf_es_elasticsearch:
 
 rsyslog_conf_es_elasticsearch_call_ruleset:
 
-  - name: '30-elasticsearch.conf'
+  - name: '30-elasticsearch'
     type: 'format'
     path: '{{ rsyslog_file_config_dir }}'
     sections:
@@ -337,4 +368,3 @@ rsyslog_conf_es_elasticsearch_call_ruleset:
       - options: |-
           # call the elasticsearch output ruleset
           call try_es
-

--- a/roles/rsyslog/roles/output_roles/elasticsearch/tasks/main.yaml
+++ b/roles/rsyslog/roles/output_roles/elasticsearch/tasks/main.yaml
@@ -4,7 +4,7 @@
     - name: Copy local Elasticsearch ca_certs to /etc/rsyslog.d directory in Rsyslog
       copy:
         src: '{{ item.ca_cert_src }}'
-        dest: '{{ rsyslog_config_dir }}'
+        dest: '{{ rsyslog_file_config_dir }}'
       with_items:
         - '{{ rsyslog_elasticsearch }}'
       when:
@@ -14,7 +14,7 @@
     - name: Copy local Elasticsearch certs to /etc/rsyslog.d directory in Rsyslog
       copy:
         src: '{{ item.cert_src }}'
-        dest: '{{ rsyslog_config_dir }}'
+        dest: '{{ rsyslog_file_config_dir }}'
       with_items:
         - '{{ rsyslog_elasticsearch }}'
       when:
@@ -24,7 +24,7 @@
     - name: Copy local Elasticsearch keys to /etc/rsyslog.d directory in Rsyslog
       copy:
         src: '{{ item.key_src }}'
-        dest: '{{ rsyslog_config_dir }}'
+        dest: '{{ rsyslog_file_config_dir }}'
       with_items:
         - '{{ rsyslog_elasticsearch }}'
       when:

--- a/roles/rsyslog/roles/output_roles/elasticsearch/tasks/main.yaml
+++ b/roles/rsyslog/roles/output_roles/elasticsearch/tasks/main.yaml
@@ -50,6 +50,21 @@
     - rsyslog_elasticsearch != []
     - use_local_omelasticsearch_cert|default(False)|bool
 
+- set_fact:
+    rsyslog_es_q_spooldirectory: "{{ lookup('env', 'RSYSLOG_SPOOLDIRECTORY' ) | ternary (lookup('env', 'RSYSLOG_SPOOLDIRECTORY' ), '/var/lib/rsyslog') }}"
+
+- set_fact:
+    rsyslog_es_q_type: "{{ lookup('env', 'RSYSLOG_QUEUE' ) | ternary (lookup('env', 'RSYSLOG_QUEUE' ), 'Disk') }}"
+
+- set_fact:
+    rsyslog_es_q_maxdiskspace: "{{ lookup('env', 'RSYSLOG_MAXDISKSPACE' ) | ternary (lookup('env', 'RSYSLOG_MAXDISKSPACE' ), '1073741824') }}"
+
+- set_fact:
+    rsyslog_es_q_maxfilesize: "{{ lookup('env', 'RSYSLOG_MAXFILESIZE' ) | ternary (lookup('env', 'RSYSLOG_MAXFILESIZE' ), '16777216') }}"
+
+- set_fact:
+    rsyslog_es_q_checkpointinterval: "{{ lookup('env', 'RSYSLOG_CHECKPOINTINTERVAL' ) | ternary (lookup('env', 'RSYSLOG_CHECKPOINTINTERVAL' ), '1000') }}"
+
 # Deploy configuration files
 - name: Set Elasticsearch facts
   set_fact:

--- a/roles/rsyslog/tasks/cleanup.yaml
+++ b/roles/rsyslog/tasks/cleanup.yaml
@@ -1,7 +1,7 @@
 ---
 - name: Remove role config files from subdir
   file:
-    path: '{{ item.path | d(rsyslog_config_dir) }}/{{ item.filename | d((item.weight if item.weight|d() else rsyslog_weight_map[item.type|d("rules")]) + "-" + (item.name|d("rules")) + "." + (item.suffix | d("conf"))) }}'
+    path: '{{ item.path | d(rsyslog_file_config_dir) }}/{{ item.filename | d((item.weight if item.weight|d() else rsyslog_weight_map[item.type|d("rules")]) + "-" + (item.name|d("rules")) + "." + (item.suffix | d("conf"))) }}'
     state: 'absent'
   with_flattened:
     - '{{ rsyslog_role_rules }}'

--- a/roles/rsyslog/tasks/deploy.yaml
+++ b/roles/rsyslog/tasks/deploy.yaml
@@ -5,19 +5,21 @@
     state: 'latest'
   when:
     - not use_rsyslog_image|default(False)|bool
+    - not rsyslog_unprivileged|default(False)|bool
   notify: restart rsyslogd
 
 - name: Generate role configuration files in rsyslog.d and subdir
   template:
     src: 'etc/rsyslog.d/rules.conf.j2'
-    dest: '{{ item.path | d(rsyslog_config_dir) }}/{{ item.filename | d((item.weight if item.weight|d() else rsyslog_weight_map[item.type|d("rules")]) + "-" + (item.name|d("rules")) + "." + (item.suffix |d ("conf"))) }}'
-    owner: '{{ item.owner | d("root") }}'
-    group: '{{ item.group | d("root") }}'
-    mode: '{{ item.mode  | d("0400") }}'
+    dest: '{{ item.path | d(rsyslog_file_config_dir) }}/{{ item.filename | d((item.weight if item.weight|d() else rsyslog_weight_map[item.type|d("rules")]) + "-" + (item.name|d("rules")) + "." + (item.suffix |d ("conf"))) }}'
+    owner: '{{rsyslog_file_owner}}'
+    group: '{{rsyslog_file_group}}'
+    mode: '{{rsyslog_mode}}'
   with_flattened:
     - '{{ rsyslog_role_rules }}'
   when:
     - item.filename|d() or item.name|d()
     - item.options|d() or item.sections|d()
     - item.state is undefined or item.state != 'absent'
+  ignore_errors: true
   notify: restart rsyslogd

--- a/roles/rsyslog/tasks/main.yaml
+++ b/roles/rsyslog/tasks/main.yaml
@@ -6,7 +6,7 @@
   when:
     - rsyslog_enabled|bool
     - not use_rsyslog_image|default(False)|bool
-    - ansible_user == 'root' or (remote_user is defined and remote_user == 'root')
+    - can_mod_system|bool or (remote_user is defined and remote_user == 'root')
   tags:
     - skip_ansible_lint
 
@@ -19,13 +19,13 @@
     msg: "Rsyslog_version is {{ rsyslog_version }}"
 
 - block:
-    - name: Set rsyslog version
+    - name: Set rsyslog version (installed)
       set_fact:
         rsyslog_version: "{{ rsyslog_version.results|selectattr('yumstate','match','installed')|map(attribute='version')|list|first }}-{{ rsyslog_version.results|selectattr('yumstate','match','installed')|map(attribute='release')|list|first }}"
       when: rsyslog_version.results|selectattr('yumstate','match','installed')|list|first is defined
       ignore_errors: true
 
-    - name: Set rsyslog version
+    - name: Set rsyslog version (available)
       set_fact:
         rsyslog_version: "{{ rsyslog_version.results|selectattr('yumstate','match','available')|map(attribute='version')|list|first }}-{{ rsyslog_version.results|selectattr('yumstate','match','available')|map(attribute='release')|list|first }}"
       when: rsyslog_version.results|selectattr('yumstate','match','available')|list|first is defined
@@ -54,7 +54,7 @@
         system: True
       when:
         - rsyslog_unprivileged|bool
-        - ansible_user == 'root'
+        - can_mod_system|bool
         - getent_group == []
 
     - name: Get information about the group
@@ -74,56 +74,54 @@
         system: True
       when:
         - rsyslog_unprivileged|bool
-        - ansible_user == 'root'
+        - can_mod_system|bool
         - getent_passwd == []
+
+    - debug:
+        msg: "WORKDIR {{ rsyslog_work_dir }} - {{ can_mod_system }}"
 
     # Creating a work directory
     - name: Create a work directory
       file:
         state: directory
         path: '{{ rsyslog_work_dir }}'
-        owner: '{{ rsyslog_user }}'
+        owner: '{{ rsyslog_file_owner }}'
         group: '{{ rsyslog_file_group }}'
         mode: 0700
-      when:
-        - ansible_user == 'root'
+      when: can_mod_system|bool
       changed_when: False
 
     # Creating a backup dir for rsyslog.d
     - name: Set backup dir name
       set_fact:
         backupdir: '{{ rsyslog_backup_dir|default("/tmp") }}/rsyslog.d-{{ ansible_date_time.iso8601_basic_short }}'
-      when:
-        - ansible_user == 'root'
+      when: can_mod_system|bool
 
     - name: Create a backup dir
       file:
         state: directory
         path: '{{ backupdir }}'
-        owner: '{{ rsyslog_user }}'
+        owner: '{{ rsyslog_file_owner }}'
         group: '{{ rsyslog_file_group }}'
         mode: 0755
-      when:
-        - ansible_user == 'root'
+      when: can_mod_system|bool
       changed_when: False
 
     # Back up the pre-existing rsyslog config files in the backup dir,
     # then removing the files/dirs in rsyslog.d.
     - name: Archive the contents of {{rsyslog_file_config_dir}} to the backup dir
       archive:
-        path: ["{{rsyslog_file_config_dir}}",/etc/rsyslog.conf]
+        path: ["{{rsyslog_file_config_dir}}", /etc/rsyslog.conf]
         dest: "{{ backupdir }}/backup.tgz"
         remove: '{{ true if rsyslog_purge_original_conf|bool else false }}'
-      when:
-        - ansible_user == 'root'
+      when: can_mod_system|bool
       changed_when: False
 
     - name: Update directory and file permissions
       shell: |
         [ ! -d {{ rsyslog_system_log_dir }} ] || ( [ "$(stat -c '%G' {{ rsyslog_system_log_dir }})" = "{{ rsyslog_group }}" ] || ( chown -v root:{{ rsyslog_group }} {{ rsyslog_system_log_dir }} ; chmod -v 775 {{ rsyslog_system_log_dir }} ) )
       register: rsyslog_register_file_permissions
-      when: 
-        - ansible_user == 'root'
+      when: can_mod_system|bool
       changed_when: rsyslog_register_file_permissions.stdout != ''
 
     - name: Generate main rsyslog configuration
@@ -133,7 +131,7 @@
         owner: '{{rsyslog_file_owner}}'
         group: '{{rsyslog_file_group}}'
         mode: '{{rsyslog_mode}}'
-      when: 
+      when:
         - rsyslog_enabled|bool
         - not rsyslog_unprivileged|default(False)|bool
 
@@ -219,7 +217,7 @@
       when:
         - rsyslog_enabled|bool
         - not use_rsyslog_image|default(False)|bool
-        - ansible_user == 'root'
+        - can_mod_system|bool
 
     - name: Disable rsyslog service
       systemd:

--- a/roles/rsyslog/tasks/main.yaml
+++ b/roles/rsyslog/tasks/main.yaml
@@ -6,6 +6,7 @@
   when:
     - rsyslog_enabled|bool
     - not use_rsyslog_image|default(False)|bool
+    - ansible_user == 'root' or (remote_user is defined and remote_user == 'root')
   tags:
     - skip_ansible_lint
 
@@ -40,6 +41,12 @@
   when: use_rsyslog_image|default(False)|bool
 
 - block:
+    - name: Get information about the group
+      getent:
+        key: "{{rsyslog_group}}"
+        database: group
+      ignore_errors: true
+
     - name: Create required system group
       group:
         name: '{{ rsyslog_group }}'
@@ -47,7 +54,14 @@
         system: True
       when:
         - rsyslog_unprivileged|bool
-        - rsyslog_group != 'root'
+        - ansible_user == 'root'
+        - getent_group == []
+
+    - name: Get information about the group
+      getent:
+        key: "{{rsyslog_user}}"
+        database: passwd
+      ignore_errors: true
 
     - name: Create required system user
       user:
@@ -60,7 +74,8 @@
         system: True
       when:
         - rsyslog_unprivileged|bool
-        - rsyslog_user != 'root'
+        - ansible_user == 'root'
+        - getent_passwd == []
 
     # Creating a work directory
     - name: Create a work directory
@@ -70,12 +85,16 @@
         owner: '{{ rsyslog_user }}'
         group: '{{ rsyslog_file_group }}'
         mode: 0700
+      when:
+        - ansible_user == 'root'
       changed_when: False
 
     # Creating a backup dir for rsyslog.d
     - name: Set backup dir name
       set_fact:
         backupdir: '{{ rsyslog_backup_dir|default("/tmp") }}/rsyslog.d-{{ ansible_date_time.iso8601_basic_short }}'
+      when:
+        - ansible_user == 'root'
 
     - name: Create a backup dir
       file:
@@ -84,41 +103,47 @@
         owner: '{{ rsyslog_user }}'
         group: '{{ rsyslog_file_group }}'
         mode: 0755
+      when:
+        - ansible_user == 'root'
       changed_when: False
 
     # Back up the pre-existing rsyslog config files in the backup dir,
     # then removing the files/dirs in rsyslog.d.
-    - name: Archive the contents of {{rsyslog_config_dir}} to the backup dir
+    - name: Archive the contents of {{rsyslog_file_config_dir}} to the backup dir
       archive:
-        path: ["{{rsyslog_config_dir}}", /etc/rsyslog.conf]
+        path: ["{{rsyslog_file_config_dir}}",/etc/rsyslog.conf]
         dest: "{{ backupdir }}/backup.tgz"
         remove: '{{ true if rsyslog_purge_original_conf|bool else false }}'
+      when:
+        - ansible_user == 'root'
       changed_when: False
 
     - name: Update directory and file permissions
       shell: |
         [ ! -d {{ rsyslog_system_log_dir }} ] || ( [ "$(stat -c '%G' {{ rsyslog_system_log_dir }})" = "{{ rsyslog_group }}" ] || ( chown -v root:{{ rsyslog_group }} {{ rsyslog_system_log_dir }} ; chmod -v 775 {{ rsyslog_system_log_dir }} ) )
       register: rsyslog_register_file_permissions
-      when: rsyslog_unprivileged|bool
+      when: 
+        - ansible_user == 'root'
       changed_when: rsyslog_register_file_permissions.stdout != ''
 
     - name: Generate main rsyslog configuration
       template:
         src: 'etc/rsyslog.conf.j2'
-        dest: '/etc/rsyslog.conf'
-        owner: '{{rsyslog_user}}'
-        group: '{{rsyslog_group}}'
-        mode: '0400'
-      when: rsyslog_enabled|bool
-      notify: restart rsyslogd
+        dest: '{{rsyslog_parent_config_dir}}/rsyslog.conf'
+        owner: '{{rsyslog_file_owner}}'
+        group: '{{rsyslog_file_group}}'
+        mode: '{{rsyslog_mode}}'
+      when: 
+        - rsyslog_enabled|bool
+        - not rsyslog_unprivileged|default(False)|bool
 
     - name: Generate common rsyslog configuration files in rsyslog.d
       template:
         src: 'etc/rsyslog.d/rules.conf.j2'
-        dest: '{{rsyslog_config_dir}}/{{ item.filename | d((item.weight if item.weight|d() else rsyslog_weight_map[item.type|d("rules")]) + "-" + (item.name|d("rules")) + "." + (item.suffix |d ("conf"))) }}'
-        owner: '{{ item.owner | d("root") }}'
-        group: '{{ item.group | d("root") }}'
-        mode: '{{ item.mode  | d("0400") }}'
+        dest: '{{rsyslog_file_config_dir}}/{{ item.filename | d((item.weight if item.weight|d() else rsyslog_weight_map[item.type|d("rules")]) + "-" + (item.name|d("rules")) + "." + (item.suffix |d ("conf"))) }}'
+        owner: '{{rsyslog_file_owner}}'
+        group: '{{rsyslog_file_group}}'
+        mode: '{{rsyslog_mode}}'
       with_flattened:
         - '{{ rsyslog_common_rules }}'
       when:
@@ -127,11 +152,10 @@
         - item.filename|d() or item.name|d()
         - item.state is undefined or item.state != 'absent'
         - item.options|d() or item.sections|d()
-      notify: restart rsyslogd
 
     - name: Remove common config files in rsyslog.d
       file:
-        path: '{{rsyslog_config_dir}}/{{ item.filename | d((item.weight if item.weight|d() else rsyslog_weight_map[item.type|d("rules")]) + "-" + (item.name|d("rules")) + "." + (item.suffix | d("conf"))) }}'
+        path: '{{rsyslog_file_config_dir}}/{{ item.filename | d((item.weight if item.weight|d() else rsyslog_weight_map[item.type|d("rules")]) + "-" + (item.name|d("rules")) + "." + (item.suffix | d("conf"))) }}'
         state: 'absent'
       with_flattened:
         - '{{ rsyslog_common_rules }}'
@@ -150,14 +174,13 @@
     - name: Copy custom config files if they are specified in rsyslog_custom_config_files variable array.
       copy:
         src: '{{ item }}'
-        dest: '{{ rsyslog_config_dir }}'
-        owner: '{{ item.owner | d("root") }}'
-        group: '{{ item.group | d("root") }}'
-        mode: '{{ item.mode  | d("0400") }}'
+        dest: '{{ rsyslog_file_config_dir }}'
+        owner: '{{rsyslog_file_owner}}'
+        group: '{{rsyslog_file_group}}'
+        mode: '{{rsyslog_mode}}'
       with_flattened:
         - '{{ rsyslog_custom_config_files }}'
       when: (rsyslog_enabled|bool)
-      notify: restart rsyslogd
 
     - name: Run deploy input sub-roles configs
       include_role:
@@ -196,6 +219,7 @@
       when:
         - rsyslog_enabled|bool
         - not use_rsyslog_image|default(False)|bool
+        - ansible_user == 'root'
 
     - name: Disable rsyslog service
       systemd:

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -7,6 +7,11 @@
       set_fact:
         rsyslog_enabled: "{{ logging_enabled|d(true) }}"
 
+    - name: Check if we can change the user, group and filesystem
+      set_fact:
+        can_mod_system=True
+      when: ansible_user is defined and ansible_user == 'root'
+
     - name: Set rsyslog_elasticsearch
       set_fact:
         rsyslog_elasticsearch: "{{ rsyslog_elasticsearch|d([]) }} + {{ [  item.0 |combine( {'logs_collections_name': item.1.name} )] }}"
@@ -58,8 +63,8 @@
 
     - name: Set rsyslog_purge_original_conf fact to purge all configuration files before saving the new ones.
       set_fact:
-        rsyslog_purge_original_conf: yes
-      when: logging_purge_confs|d(no)
+        rsyslog_purge_original_conf: true
+      when: logging_purge_confs|d(false)
 
     - name: Set custom_config_files fact
       set_fact:


### PR DESCRIPTION
… linux-system-roles.

Along with this effort, cluster-logging-operator is being updated to
generate rsyslog configuration files from linux-system-roles/logging.
The generated files are placed in the working directory once and will
be deployed in the containers.  To support the ability to place files
in a directory which is different from the final location, additional
config_dir rsyslog_file_config_dir has been introduced.
1) rsyslog_config_dir for the path in the config files, and
2) rsyslog_file_config_dir for the path to place the config files.

New variables:
- `rsyslog_parent_config_dir`: Directory to store rsyslog.conf.
  Default to '/etc'.
- `rsyslog_files_config_dir`: Directory to locate rsyslog.conf.
  Used in deploying the config files.  Default to '/etc/rsyslog.d'.
- `rsyslog_mode`:  Mode for the config files.  Default to '0400'
- `rsyslog_max_message_size`: Maximum supported message size.
  Default to 8k.
- `use_rsyslog_image`: If set to 'True', the rsyslog is run in the
  OpenShift container.

Rsyslog allows to use environment variables as string constants as follows.
  key=`echo $ENVVAR`
It is used in the script to start the rsyslog container.  They are
activated only when use_rsyslog_image is true.
  {% if use_rsyslog_image|bool %}
    key=`echo $ENVVAR`
  {% endif %}

Another requirement is the include order. It turned out it is crucial
to keep the include order of the configuration files.  To support it,
'format' type is introduced, which sets the prefix 60- to the filename.
To maintain the order more precisely, some files have the secondary
prefix, e.g., 00-elasticsearch.  With the type 'format', it generates
60-00-elasticsearch.conf which is included prior to 60-10-mmk8s.conf.