### PR TITLE
Add in-tree tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,38 @@ Variables in vars.yaml
       - `type`: Type of the output element.
       - `custom_config_files`: List of custom configuration files are deployed to /etc/rsyslog.d. [ '/path/to/custom_A.conf', '/path/to/custom_B.conf' ]. Default to none.
 
+Testing
+-------
+In-tree tests are provided that use molecule to test the role against docker containers.
+These tests are designed to be used by CI, but they can also be run locally to test it
+out while developing.  This is best done by installing molecule in a virtualenv:
+
+  `$ virtualenv .venv`
+  `$ source .venv/bin/activate`
+  `$ pip install molecule docker`
+
+It is required to run the tests as a user who is authorized to run the 'docker' command
+without using sudo.  This is typically accomplished by adding your user to the 'docker'
+group on your system.
+
+Additionally, there is a challenge around python-libselinux on platforms that use SELinux.
+If you are using a virtualenv, you need to make sure that the selinux python module is
+available in the virtualenv.  Even if it is installed on your ansible controller host
+and the target host, some of the tasks that are delegated to the locahost will use the
+virtualenv.  The selinux module can't be installed via pip.  A workaround for this is
+to copy the entire `selinux` directory from your system site-packages location into
+the virtualenv site-packages.  You also need to copy the `_selinux.so` file from
+site-locations as well.
+
+Once your virtualenv is properly set up, the tests can be run with these commands:
+
+  `$ molecule test`
+
+By default, the test target will be the latest `centos` image from Docker Hub.  You
+can test against a different image/tag like so:
+
+  `$ MOLECULE_DISTRO="fedora:28" molecule test`
+
 Planned Flows:
 --------------
   - `Rsyslog` -> `Local` (RHEL Default) / `Viaq` [1] / `Elasticsearch` / `Remote Rsyslog` / `message Queue (kafka, amqp)`

--- a/molecule/default/Dockerfile.j2
+++ b/molecule/default/Dockerfile.j2
@@ -1,0 +1,14 @@
+# Molecule managed
+
+{% if item.registry is defined %}
+FROM {{ item.registry.url }}/{{ item.image }}
+{% else %}
+FROM {{ item.image }}
+{% endif %}
+
+RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get install -y python sudo bash ca-certificates && apt-get clean; \
+    elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python sudo python-devel python2-dnf bash && dnf clean all; \
+    elif [ $(command -v yum) ]; then yum makecache fast && yum install -y python sudo yum-plugin-ovl bash && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
+    elif [ $(command -v zypper) ]; then zypper refresh && zypper install -y python sudo bash python-xml && zypper clean -a; \
+    elif [ $(command -v apk) ]; then apk update && apk add --no-cache python sudo bash ca-certificates; \
+    elif [ $(command -v xbps-install) ]; then xbps-install -Syu && xbps-install -y python sudo bash ca-certificates && xbps-remove -O; fi

--- a/molecule/default/INSTALL.rst
+++ b/molecule/default/INSTALL.rst
@@ -1,0 +1,16 @@
+*******
+Docker driver installation guide
+*******
+
+Requirements
+============
+
+* General molecule dependencies (see https://molecule.readthedocs.io/en/latest/installation.html)
+* Docker Engine
+* docker-py
+* docker
+
+Install
+=======
+
+    $ sudo pip install docker-py

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,0 +1,24 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+lint:
+  name: yamllint
+  options:
+    config-file: molecule/default/yaml-lint.yml
+platforms:
+  - name: instance
+    image: ${MOLECULE_DISTRO:-"centos:7"}
+    command: /sbin/init
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+provisioner:
+  name: ansible
+  lint:
+    name: ansible-lint
+verifier:
+  name: testinfra
+  lint:
+    name: flake8

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -1,0 +1,5 @@
+---
+- name: Converge
+  hosts: all
+  roles:
+    - role: logging

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -1,0 +1,14 @@
+import os
+
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
+
+
+def test_hosts_file(host):
+    f = host.file('/etc/hosts')
+
+    assert f.exists
+    assert f.user == 'root'
+    assert f.group == 'root'

--- a/molecule/default/yaml-lint.yml
+++ b/molecule/default/yaml-lint.yml
@@ -1,13 +1,5 @@
 ---
 extends: default
 rules:
-  brackets: disable
-  colons: disable
-  commas: disable
-  comments: disable
-  comments-indentation: disable
-  empty-lines: disable
-  indentation: disable
   line-length: disable
   truthy: disable
-  trailing-spaces: disable

--- a/molecule/default/yaml-lint.yml
+++ b/molecule/default/yaml-lint.yml
@@ -1,0 +1,13 @@
+---
+extends: default
+rules:
+  brackets: disable
+  colons: disable
+  commas: disable
+  comments: disable
+  comments-indentation: disable
+  empty-lines: disable
+  indentation: disable
+  line-length: disable
+  truthy: disable
+  trailing-spaces: disable

--- a/roles/rsyslog/defaults/main.yaml
+++ b/roles/rsyslog/defaults/main.yaml
@@ -37,7 +37,7 @@ rsyslog_capabilities: []
 #
 # Enable or disable unprivileged ``rsyslogd`` operation. Warning, enabling this
 # option requires additional configuration outside of the ``rsyslog``
-# role. 
+# role.
 rsyslog_unprivileged: '{{ "True"
                            if (ansible_distribution in [ "CentOS", "RedHat", "Fedora" ])
                            else "False" }}'
@@ -61,12 +61,12 @@ rsyslog_purge_original_conf: False
 # .. envvar:: rsyslog_base_packages
 #
 # List of default rpm packages to install.
-rsyslog_base_packages: [ 'rsyslog', 'libselinux-python' ]
+rsyslog_base_packages: ['rsyslog', 'libselinux-python']
 
 # .. envvar:: rsyslog_tls_packages
 #
 # List of rpm packages required for TLS support.
-rsyslog_tls_packages: [ 'rsyslog-gnutls', 'ca-certificates' ]
+rsyslog_tls_packages: ['rsyslog-gnutls', 'ca-certificates']
 
 # .. envvar:: rsyslog_packages
 #
@@ -209,7 +209,7 @@ rsyslog_domain: '{{ ansible_domain if ansible_domain else ansible_hostname }}'
 #
 # List of hostnames, IP addresses or wildcard DNS domains which will be allowed
 # by the ``rsyslogd`` server to connect and send logs over TLS.
-rsyslog_permitted_peers: [ '*.{{ rsyslog_domain }}' ]
+rsyslog_permitted_peers: ['*.{{ rsyslog_domain }}']
 
 # .. envvar:: rsyslog_send_permitted_peers
 #
@@ -256,7 +256,7 @@ rsyslog_group_allow: []
 # List of IP addresses or CIDR subnets which should be allowed to connect to
 # ``rsyslogd`` ports by the firewall. This variable should be used for specific
 # hosts in the inventory.
-rsyslog_host_allow: [ '192.168.122.100/24' ]
+rsyslog_host_allow: ['192.168.122.100/24']
 
 
 # Log forwarding
@@ -297,22 +297,22 @@ rsyslog_host_forward: []
 #
 # See :ref:`rsyslog_rules` for more details.
 rsyslog_weight_map:
-  'global':    '05'
-  'globals':   '05'
-  'module':    '10'
-  'modules':   '10'
-  'template':  '20'
+  'global': '05'
+  'globals': '05'
+  'module': '10'
+  'modules': '10'
+  'template': '20'
   'templates': '20'
-  'output':    '30'
-  'outputs':   '30'
-  'service':   '30'
-  'services':  '30'
-  'rule':      '50'
-  'rules':     '50'
-  'ruleset':   '50'
-  'rulesets':  '50'
-  'input':     '90'
-  'inputs':    '90'
+  'output': '30'
+  'outputs': '30'
+  'service': '30'
+  'services': '30'
+  'rule': '50'
+  'rules': '50'
+  'ruleset': '50'
+  'rulesets': '50'
+  'input': '90'
+  'inputs': '90'
 
 # .. envvar:: rsyslog_rules
 #
@@ -353,10 +353,10 @@ rsyslog_dependent_rules: []
 # role.
 rsyslog_common_rules:
 
-   - '{{ rsyslog_conf_global_options }}'
-   - '{{ rsyslog_conf_local_modules }}'
-   - '{{ rsyslog_conf_network_modules }}'
-   - '{{ rsyslog_conf_common_defaults }}'
+  - '{{ rsyslog_conf_global_options }}'
+  - '{{ rsyslog_conf_local_modules }}'
+  - '{{ rsyslog_conf_network_modules }}'
+  - '{{ rsyslog_conf_common_defaults }}'
 
 
 # Default configuration options

--- a/roles/rsyslog/roles/input_roles/debops/defaults/main.yaml
+++ b/roles/rsyslog/roles/input_roles/debops/defaults/main.yaml
@@ -5,7 +5,7 @@ rsyslog_pki: 'True'
 
 rsyslog_unprivileged: 'False'
 
-rsyslog_capabilities: [ 'network', 'remote-files', 'tls' ]
+rsyslog_capabilities: ['network', 'remote-files', 'tls']
 
 # .. envvar:: rsyslog_debops_rules
 #

--- a/roles/rsyslog/roles/input_roles/debops/tasks/cleanup.yaml
+++ b/roles/rsyslog/roles/input_roles/debops/tasks/cleanup.yaml
@@ -7,4 +7,3 @@
   include_role:
     name: "{{ logging_role_path|d('logging') }}/roles/rsyslog"
     tasks_from: cleanup.yaml
-

--- a/roles/rsyslog/roles/input_roles/debops/tasks/main.yaml
+++ b/roles/rsyslog/roles/input_roles/debops/tasks/main.yaml
@@ -8,4 +8,3 @@
   include_role:
     name: "{{ logging_role_path|d('logging') }}/roles/rsyslog"
     tasks_from: deploy.yaml
-

--- a/roles/rsyslog/roles/input_roles/ovirt/defaults/main.yaml
+++ b/roles/rsyslog/roles/input_roles/ovirt/defaults/main.yaml
@@ -9,7 +9,7 @@
 # .. envvar:: rsyslog_logging_packages
 #
 # List of rpm packages for Common Logging.
-rsyslog_ovirt_packages: [ 'rsyslog-mmnormalize', 'rsyslog-mmjsonparse', 'libfastjson', 'liblognorm', 'libestr' ]
+rsyslog_ovirt_packages: ['rsyslog-mmnormalize', 'rsyslog-mmjsonparse', 'libfastjson', 'liblognorm', 'libestr']
 rsyslog_ovirt_prereq_packages: []
 
 # Available configuration set

--- a/roles/rsyslog/roles/input_roles/viaq-k8s/defaults/main.yaml
+++ b/roles/rsyslog/roles/input_roles/viaq-k8s/defaults/main.yaml
@@ -14,7 +14,7 @@ rsyslog_viaq_log_dir: '{{rsyslog_system_log_dir}}/containers'
 # .. envvar:: rsyslog_viaq_k8s_packages
 #
 # List of rpm packages for Common Logging.
-rsyslog_viaq_k8s_packages: [ 'rsyslog-mmjsonparse', 'rsyslog-mmkubernetes' ]
+rsyslog_viaq_k8s_packages: ['rsyslog-mmjsonparse', 'rsyslog-mmkubernetes']
 
 # Available configuration set
 # ----------------------------
@@ -46,7 +46,7 @@ rsyslog_conf_viaq_mmk8s_module:
       - options: |-
           # mmkubernetes
           module(load="mmkubernetes")
-          
+
           # Parse logs to JSON
           module(load="mmjsonparse")
 
@@ -59,7 +59,7 @@ rsyslog_conf_viaq_mmk8s_input:
 
       - options: |-
           input(type="imfile" file="{{ rsyslog_viaq_log_dir }}/*.log" tag="kubernetes" addmetadata="on" reopenOnTruncate="on")
-          
+
           if ((strlen($!CONTAINER_NAME) > 0) and (strlen($!CONTAINER_ID_FULL) > 0)) or
               ((strlen($!metadata) > 0) and (strlen($!metadata!filename) > 0) and ($!metadata!filename startswith "{{rsyslog_viaq_log_dir}}/")) then {
               if ((strlen($!metadata) > 0) and (strlen($!metadata!filename) > 0) and ($!metadata!filename startswith "{{rsyslog_viaq_log_dir}}/")) then {

--- a/roles/rsyslog/roles/input_roles/viaq-k8s/tasks/cleanup.yaml
+++ b/roles/rsyslog/roles/input_roles/viaq-k8s/tasks/cleanup.yaml
@@ -7,4 +7,3 @@
   include_role:
     name: "{{ logging_role_path|d('logging') }}/roles/rsyslog"
     tasks_from: cleanup.yaml
-

--- a/roles/rsyslog/roles/input_roles/viaq-k8s/tasks/main.yaml
+++ b/roles/rsyslog/roles/input_roles/viaq-k8s/tasks/main.yaml
@@ -8,4 +8,3 @@
   include_role:
     name: "{{ logging_role_path|d('logging') }}/roles/rsyslog"
     tasks_from: deploy.yaml
-

--- a/roles/rsyslog/roles/input_roles/viaq/defaults/main.yaml
+++ b/roles/rsyslog/roles/input_roles/viaq/defaults/main.yaml
@@ -9,8 +9,8 @@
 # .. envvar:: rsyslog_viaq_packages
 #
 # List of rpm packages for Common Logging.
-rsyslog_viaq_prereq_packages: [ 'nmap-ncat', 'systemd-python', 'policycoreutils', 'checkpolicy', 'policycoreutils-python' ]
-rsyslog_viaq_packages: [ 'rsyslog-mmnormalize' ]
+rsyslog_viaq_prereq_packages: ['nmap-ncat', 'systemd-python', 'policycoreutils', 'checkpolicy', 'policycoreutils-python']
+rsyslog_viaq_packages: ['rsyslog-mmnormalize']
 
 # Available configuration set
 # ----------------------------
@@ -75,11 +75,11 @@ rsyslog_conf_viaq_formatting:
           # formatting
           lookup_table(name="prio_to_level" file="{{ rsyslog_config_dir }}/prio_to_level.json")
           lookup_table(name="normalize_level" file="{{ rsyslog_config_dir }}/normalize_level.json")
-          
+
           template(name="cnvt_to_viaq_timestamp" type="list") {
               property(name="TIMESTAMP" dateFormat="rfc3339")
           }
-          
+
           # rsyslog 8.30.0 and later does case insensitive variable name comparison
           # which means $!MESSAGE is the same as $!message - HOWEVER - the case
           # of the variable name is preserved when outputting, so we need to "normalize"
@@ -115,11 +115,11 @@ rsyslog_conf_viaq_formatting:
               unset $!originalmsg;
               unset $!unparsed-data;
           }
-          
+
           if strlen($!_MACHINE_ID) > 0 then {
               # convert from imjournal to viaq systemd format
               # https://github.com/ViaQ/elasticsearch-templates/blob/master/namespaces/systemd.yml
-          
+
               set $!systemd!t!MACHINE_ID = $!_MACHINE_ID;
               unset $!_MACHINE_ID;
               if strlen($!CODE_FILE) > 0 then {
@@ -262,7 +262,7 @@ rsyslog_conf_viaq_formatting:
                   set $!systemd!k!UDEV_DEVLINK = $!_UDEV_DEVLINK;
               }
               unset $!_UDEV_DEVLINK;
-          
+
               # these fields require special handling
               if strlen($!level) == 0 then {
                   if strlen($!PRIORITY) > 0 then {
@@ -307,7 +307,7 @@ rsyslog_conf_viaq_formatting:
                   }
               }
           }
-          
+
           # normalize level
           if strlen($!level) > 0 then {
               set $.lclevel = tolower($!level);
@@ -330,9 +330,9 @@ rsyslog_conf_viaq_formatting:
                   }
               }
           }
-          
+
           # add eventrouter
-          
+
           if (strlen($!kubernetes) > 0) and (strlen($!kubernetes!namespace_name) > 0) then {
               # see if this is an operations namespace
               if ($!kubernetes!namespace_name == "default") or ($!kubernetes!namespace_name == "openshift") or
@@ -345,11 +345,11 @@ rsyslog_conf_viaq_formatting:
                   } else {
                       set $.index_prefix = ".orphaned.";
                   }
-              } 
+              }
           } else {
               set $.index_prefix = ".operations.";
           }
-          
+
           # add pipeline_metadata
           set $!pipeline_metadata!collector!name = "rsyslog";
           set $!pipeline_metadata!collector!inputname = $inputname;

--- a/roles/rsyslog/roles/output_roles/elasticsearch/defaults/main.yaml
+++ b/roles/rsyslog/roles/output_roles/elasticsearch/defaults/main.yaml
@@ -5,7 +5,7 @@
 # .. envvar:: rsyslog_elasticsearch_package
 #
 # List of rpm packages for Elasticsearch output.
-rsyslog_elasticsearch_packages: [ 'rsyslog-elasticsearch' ]
+rsyslog_elasticsearch_packages: ['rsyslog-elasticsearch']
 
 
 # Available configuration set
@@ -56,7 +56,7 @@ rsyslog_conf_es_elasticsearch:
               property(name="$!all-json-plain")
               constant(value="\n")
           }
-          
+
           # Add date to the end of the index name - index_prefix.yyyy-mm-dd,
           # based on the log timestamp.
           # This template sets "index_name"
@@ -71,11 +71,11 @@ rsyslog_conf_es_elasticsearch:
 
           template(name="index_template" type="string" string="%$.index_name%")
           template(name="id_template" type="string" string="%$.es_msg_id%")
-          
+
           ruleset(name="error_es") {
               action(type="omfile" template="es_template_nl" file="{{rsyslog_work_dir}}/es-bulk-errors.log")
           }
-          
+
           ruleset(name="try_es") {
               if strlen($.omes!status) > 0 then {
                   # retry case
@@ -217,5 +217,5 @@ rsyslog_conf_es_elasticsearch:
           {% endif %}
           {% endfor %}
           }
-          
+
           call try_es

--- a/roles/rsyslog/roles/output_roles/elasticsearch/tasks/main.yaml
+++ b/roles/rsyslog/roles/output_roles/elasticsearch/tasks/main.yaml
@@ -1,6 +1,6 @@
 ---
 - block:
-  # This block collect certificates from local location and copies them to /etc/rsyslog.d directory
+    # This block collect certificates from local location and copies them to /etc/rsyslog.d directory
     - name: Copy local Elasticsearch ca_certs to /etc/rsyslog.d directory in Rsyslog
       copy:
         src: '{{ item.ca_cert_src }}'

--- a/roles/rsyslog/tasks/deploy.yaml
+++ b/roles/rsyslog/tasks/deploy.yaml
@@ -13,7 +13,7 @@
     dest: '{{ item.path | d(rsyslog_config_dir) }}/{{ item.filename | d((item.weight if item.weight|d() else rsyslog_weight_map[item.type|d("rules")]) + "-" + (item.name|d("rules")) + "." + (item.suffix |d ("conf"))) }}'
     owner: '{{ item.owner | d("root") }}'
     group: '{{ item.group | d("root") }}'
-    mode:  '{{ item.mode  | d("0400") }}'
+    mode: '{{ item.mode  | d("0400") }}'
   with_flattened:
     - '{{ rsyslog_role_rules }}'
   when:

--- a/roles/rsyslog/tasks/main.yaml
+++ b/roles/rsyslog/tasks/main.yaml
@@ -93,7 +93,7 @@
     # then removing the files/dirs in rsyslog.d.
     - name: Archive the contents of {{rsyslog_config_dir}} to the backup dir
       archive:
-        path: ["{{rsyslog_config_dir}}",/etc/rsyslog.conf]
+        path: ["{{rsyslog_config_dir}}", /etc/rsyslog.conf]
         dest: "{{ backupdir }}/backup.tgz"
         remove: '{{ true if rsyslog_purge_original_conf|bool else false }}'
       changed_when: False
@@ -121,7 +121,7 @@
         dest: '{{rsyslog_config_dir}}/{{ item.filename | d((item.weight if item.weight|d() else rsyslog_weight_map[item.type|d("rules")]) + "-" + (item.name|d("rules")) + "." + (item.suffix |d ("conf"))) }}'
         owner: '{{ item.owner | d("root") }}'
         group: '{{ item.group | d("root") }}'
-        mode:  '{{ item.mode  | d("0400") }}'
+        mode: '{{ item.mode  | d("0400") }}'
       with_flattened:
         - '{{ rsyslog_common_rules }}'
       when:
@@ -156,7 +156,7 @@
         dest: '{{ rsyslog_config_dir }}'
         owner: '{{ item.owner | d("root") }}'
         group: '{{ item.group | d("root") }}'
-        mode:  '{{ item.mode  | d("0400") }}'
+        mode: '{{ item.mode  | d("0400") }}'
       with_flattened:
         - '{{ rsyslog_custom_config_files }}'
       when: (rsyslog_enabled|bool)

--- a/roles/rsyslog/tasks/main.yaml
+++ b/roles/rsyslog/tasks/main.yaml
@@ -195,7 +195,7 @@
         name: rsyslog.service
         daemon_reload: yes
         enabled: yes
-        state: restarted
+        state: started
       when:
         - rsyslog_enabled|bool
         - not use_rsyslog_image|default(False)|bool

--- a/roles/rsyslog/tasks/main.yaml
+++ b/roles/rsyslog/tasks/main.yaml
@@ -6,6 +6,8 @@
   when:
     - rsyslog_enabled|bool
     - not use_rsyslog_image|default(False)|bool
+  tags:
+    - skip_ansible_lint
 
 - name: Get rsyslog version
   yum:
@@ -185,6 +187,8 @@
       when:
         - rsyslog_enabled|bool
         - item is defined and item != []
+      tags:
+        - skip_ansible_lint
 
     - name: Enable rsyslog service
       systemd:

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -49,7 +49,7 @@
 
     - name: Set rsyslog_default
       set_fact:
-         rsyslog_default: false
+        rsyslog_default: false
       when: (rsyslog_default_check|d([]) != []) or (rsyslog_outputs|d([]) != [])
 
     - name: Set rsyslog_unprivileged fact
@@ -76,7 +76,7 @@
 
     - name: Create rsyslog debug dir
       file:
-        path:  "{{ logging_role_path|d('logging') }}/debug"
+        path: "{{ logging_role_path|d('logging') }}/debug"
         state: 'directory'
         mode: '0700'
       when: logging_debug|d(false)

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -36,6 +36,8 @@
 
     - set_fact:
         rsyslog_outputs: "{{ rsyslog_outputs|d([]) | unique }}"
+      tags:
+        - skip_ansible_lint
 
     - name: Check if need to deploy default configuration
       set_fact:


### PR DESCRIPTION
This adds in-tree tests that utilize molecule to test the logging
role.  We use the molecule's docker driver, which will handle the
provisioning and cleanup of containers to use as the target hosts
when testing the roles.  The tests will use a CentOS 7 container
by default, but other targets can easily be specified when the
tests are launched.

The test playbook that we use for now just tests the logging role
defaults.  We can add additional test scenarios in future patches.

Note that there are a number of lint issues with the current role.
For this initial commit, I have disabled the lint tests that fail
so the tests will progress to actually executing the test playbook.
These lint issues should be cleaned up in future commits, and we
should re-enable those lint tests to catch future issues.