### PR TITLE
Add meta information for Galaxy and fix bug in Elasticsearch output

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,15 @@
+---
+galaxy_info:
+  author: Shirly Radco <sradco@redhat.com>
+  description: Configure logging collection
+  galaxy_tags: ['system', 'logging', 'redhat', 'rhel', 'fedora', 'centos']
+  company: Red Hat, Inc.
+  license: GPL-3.0+
+  min_ansible_version: 2.7
+  platforms:
+  - name: Fedora
+    versions: [27, 28]
+  - name: EL
+    versions: [7]
+
+allow_duplicates: true

--- a/molecule/default/yaml-lint.yml
+++ b/molecule/default/yaml-lint.yml
@@ -1,5 +1,26 @@
 ---
 extends: default
+
 rules:
+  braces:
+    level: warning
+    max-spaces-inside: 1
+  brackets:
+    level: warning
+    max-spaces-inside: 1
+  colons:
+    level: warning
+  commas:
+    level: warning
+  comments: disable
+  comments-indentation: disable
+  document-start: disable
+  empty-lines:
+    level: warning
+  hyphens:
+    level: warning
+  indentation:
+    level: warning
+    indent-sequences: consistent
   line-length: disable
   truthy: disable

--- a/roles/rsyslog/roles/output_roles/elasticsearch/defaults/main.yaml
+++ b/roles/rsyslog/roles/output_roles/elasticsearch/defaults/main.yaml
@@ -123,7 +123,7 @@ rsyslog_conf_es_elasticsearch:
                   bulkid="{{ res.bulkid | default("id_template") }}"
                   dynbulkid="{{ res.dynbulkid | default("on") }}"
                   retryfailures="{{ res.retryfailures | default("on") }}"
-                  allowUnsignedCerts = "{{ res.allowUnsignedCerts | default("off") }}"
+                  allowUnsignedCerts="{{ res.allowUnsignedCerts | default("off") }}"
                   retryruleset="{{ res.retryruleset | default("try_es") }}"
                   usehttps="{{ res.usehttps | default("on") }}"
           {% if use_omelasticsearch_cert | default(true) %}
@@ -149,7 +149,7 @@ rsyslog_conf_es_elasticsearch:
                     bulkid="{{ res.bulkid | default("id_template") }}"
                     dynbulkid="{{ res.dynbulkid | default("on") }}"
                     retryfailures="{{ res.retryfailures | default("on") }}"
-                    allowUnsignedCerts = "{{ res.allowUnsignedCerts | default("off") }}"
+                    allowUnsignedCerts="{{ res.allowUnsignedCerts | default("off") }}"
                     retryruleset="{{ res.retryruleset | default("try_es") }}"
                     usehttps="{{ res.usehttps | default("on") }}"
           {% if use_omelasticsearch_cert | default(true) %}
@@ -174,7 +174,7 @@ rsyslog_conf_es_elasticsearch:
                     bulkid="{{ res.bulkid | default("id_template") }}"
                     dynbulkid="{{ res.dynbulkid | default("on") }}"
                     retryfailures="{{ res.retryfailures | default("on") }}"
-                    allowUnsignedCerts = "{{ res.allowUnsignedCerts | default("off") }}"
+                    allowUnsignedCerts="{{ res.allowUnsignedCerts | default("off") }}"
           {% if res.retryfailures|default("on") == "on" %}
                     retryruleset="{{ res.retryruleset | default("try_es") }}"
           {% endif %}
@@ -201,7 +201,7 @@ rsyslog_conf_es_elasticsearch:
                     bulkid="{{ res.bulkid | default("id_template") }}"
                     dynbulkid="{{ res.dynbulkid | default("on") }}"
                     retryfailures="{{ res.retryfailures | default("on") }}"
-                    allowUnsignedCerts = "{{ res.allowUnsignedCerts | default("off") }}"
+                    allowUnsignedCerts="{{ res.allowUnsignedCerts | default("off") }}"
           {% if res.retryfailures|default("on") == "on" %}
                     retryruleset="{{ res.retryruleset | default("try_es") }}"
           {% endif %}


### PR DESCRIPTION
Add meta information for Galaxy
Fix bug in Elasticsearch output when using allowUnsignedCerts variable

Fixes #58 

Signed-off-by: Shirly Radco <sradco@redhat.com>