### PR TITLE
Add ovirt.entity to ovirt collectd records

### DIFF
--- a/roles/rsyslog/roles/input_roles/ovirt/defaults/main.yaml
+++ b/roles/rsyslog/roles/input_roles/ovirt/defaults/main.yaml
@@ -90,6 +90,11 @@ rsyslog_conf_ovirt_formatting:
               action(type="mmjsonparse" cookie="") # parse entire message as json
               set $!@timestamp = exec_template('cnvt_to_viaq_timestamp');
               unset $!time;
+              if $!collectd!plugin == 'virt' then {
+                  set $!ovirt!entity == 'vms';
+              } else {
+                  set $!ovirt!entity == 'hosts';
+              }
           }
 
           # add eventrouter


### PR DESCRIPTION
When moving to Rsyslog we removed the ovirt.entity
field that caused the VMS dashboard and VMs related
visualizations to break.
Adding the field back for backwards compatibility.

Bug-Url: https://bugzilla.redhat.com/1717974
Signed-off-by: Shirly Radco <sradco@redhat.com>