### PR TITLE
Remove the check for rsyslog_default

### DIFF
--- a/roles/rsyslog/templates/etc/rsyslog.conf.j2
+++ b/roles/rsyslog/templates/etc/rsyslog.conf.j2
@@ -43,7 +43,7 @@ global(workDirectory="{{rsyslog_work_dir}}")
 module(load="builtin:omfile" Template="RSYSLOG_TraditionalFileFormat")
 
 # Include all config files in {{rsyslog_config_dir}}
-include(file="{{rsyslog_config_dir}}/*.conf" mode="optional")
+$IncludeConfig {{rsyslog_config_dir}}/*.conf
 
 #### RULES ####
 

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -39,19 +39,6 @@
       tags:
         - skip_ansible_lint
 
-    - name: Check if need to deploy default configuration
-      set_fact:
-        rsyslog_default_check: "{{ rsyslog_default_check|d([]) }} + {{ [ { 'name': item.1.name } ] }}"
-      with_subelements:
-        - "{{ logging_outputs }}"
-        - logs_collections
-      when: item.1.state|d('present') == 'present'
-
-    - name: Set rsyslog_default
-      set_fact:
-        rsyslog_default: false
-      when: (rsyslog_default_check|d([]) != []) or (rsyslog_outputs|d([]) != [])
-
     - name: Set rsyslog_unprivileged fact
       set_fact:
         rsyslog_unprivileged: "{{ logging_unprivileged|d(false) }}"


### PR DESCRIPTION
Removed the check for rsyslog_default,
So the default configuration will be deployed
unless the user will set the rsyslog_default
variable to false.

If rsyslog_default is set to false the rsyslog.conf
will only include the
$IncludeConfig {{rsyslog_config_dir}}/*.conf line.

Signed-off-by: Shirly Radco <sradco@redhat.com>