### PR TITLE
Workaround for ansible/molecule#1727

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ env:
     - MOLECULE_DISTRO="fedora:29"
 install:
   - pip install molecule docker
+  # workaround until https://github.com/ansible/molecule/issues/1727 is fixed
+  - pip uninstall -y testinfra
+  - pip install testinfra
 script:
   - molecule test
 branches:


### PR DESCRIPTION
This works around an issue with ansible and molecule that breaks
our CI.  This issue was recently fixed upstream, but is not yet
available in the packages used during testing.

Signed-off-by: Shirly Radco <sradco@redhat.com>