### PR TITLE
Update oVirt config with default logs handling

### DIFF
--- a/roles/rsyslog/roles/input_roles/ovirt/defaults/main.yaml
+++ b/roles/rsyslog/roles/input_roles/ovirt/defaults/main.yaml
@@ -55,6 +55,14 @@ rsyslog_conf_ovirt_main_modules:
     sections:
 
       - options: |-
+          # Read from systemd journal
+          module(load="imjournal" StateFile="imjournal.state")
+
+      - options: |-
+          # Use default timestamp format
+          module(load="builtin:omfile" Template="RSYSLOG_TraditionalFileFormat")
+
+      - options: |-
           # Read from file with inotify enabled
           module(load="imfile" mode="inotify")
 
@@ -152,6 +160,28 @@ rsyslog_conf_ovirt_formatting:
               }
           }
           {% endif %}
+
+          if not ($syslogtag startswith "ovirt" or $syslogtag startswith "collectd") then {
+              # Log all kernel messages to the console.
+              # Logging much else clutters up the screen.
+              #kern.*                                                 /dev/console
+              # Log anything (except mail) of level info or higher.
+              # Don't log private authentication messages!
+              *.info;mail.none;authpriv.none;cron.none                /var/log/messages
+              # The authpriv file has restricted access.
+              authpriv.*                                              /var/log/secure
+              # Log all the mail messages in one place.
+              mail.*                                                  -/var/log/maillog
+
+              # Log cron stuff
+              cron.*                                                  /var/log/cron
+              # Everybody gets emergency messages
+              *.emerg                                                 :omusrmsg:*
+              # Save news errors of level crit and higher in a special file.
+              uucp,news.crit                                          /var/log/spooler
+              # Save boot messages also to boot.log
+              local7.*                                                /var/log/boot.log
+        }
 
 rsyslog_rulebase_ovirt_engine:
 

--- a/roles/rsyslog/roles/output_roles/elasticsearch/defaults/main.yaml
+++ b/roles/rsyslog/roles/output_roles/elasticsearch/defaults/main.yaml
@@ -77,7 +77,7 @@ rsyslog_conf_es_elasticsearch:
           }
 
           ruleset(name="try_es") {
-              if strlen($.omes!status) > 0 then {
+              if (strlen($.omes) > 0) and (strlen($.omes!status) > 0) then {
                   # retry case
                   if ($.omes!status == 200) or ($.omes!status == 201) or (($.omes!status == 409) and ($.omes!writeoperation == "create")) then {
                       stop # successful
@@ -94,14 +94,14 @@ rsyslog_conf_es_elasticsearch:
               }
               if strlen($!es_msg_id) > 0 then {
                   set $.es_msg_id = $!es_msg_id;
-              } else if strlen($.omes!_id) > 0 then {
+              } else if (strlen($.omes) > 0) and (strlen($.omes!_id) > 0) then {
                   # retry
                   set $.es_msg_id = $.omes!_id;
               } else {
                   # NOTE: depends on rsyslog being compiled with --enable-uuid
                   set $.es_msg_id = $uuid;
               }
-              if strlen($.omes!_index) > 0 then {
+              if (strlen($.omes) > 0) and ( strlen($.omes!_index) > 0) then {
                   # retry
                   set $.index_name = $.omes!_index;
               } else {

--- a/roles/rsyslog/templates/etc/rsyslog.conf.j2
+++ b/roles/rsyslog/templates/etc/rsyslog.conf.j2
@@ -22,7 +22,7 @@ module(load="imuxsock"    # provides support for local system logging (e.g. via 
 module(load="imjournal"   # provides access to the systemd journal
        StateFile="imjournal.state") # File to store the position in the journal
 #module(load="imklog") # reads kernel messages (the same are read from journald)
-#module(load"immark") # provides --MARK-- message capability
+#module(load="immark") # provides --MARK-- message capability
 
 # Provides UDP syslog reception
 # for parameters see http://www.rsyslog.com/doc/imudp.html


### PR DESCRIPTION
Added to oVirt formatting config the handling of
general logs, other the Collectd and oVirt vdsm and engine
logs.

This patch also fixes an issue in the default rsyslog.conf.

Signed-off-by: Shirly Radco <sradco@redhat.com>

Please review my patch: @richm @pcahyna @nhosoi @sandrobonazzola @didib