### PR TITLE
Revert commit #68 Remove the check for rsyslog_default

### DIFF
--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -39,6 +39,19 @@
       tags:
         - skip_ansible_lint
 
+    - name: Check if need to deploy default configuration
+      set_fact:
+        rsyslog_default_check: "{{ rsyslog_default_check|d([]) }} + {{ [ { 'name': item.1.name } ] }}"
+      with_subelements:
+        - "{{ logging_outputs }}"
+        - logs_collections
+      when: item.1.state|d('present') == 'present'
+
+    - name: Set rsyslog_default
+      set_fact:
+        rsyslog_default: false
+      when: (rsyslog_default_check|d([]) != []) or (rsyslog_outputs|d([]) != [])
+
     - name: Set rsyslog_unprivileged fact
       set_fact:
         rsyslog_unprivileged: "{{ logging_unprivileged|d(false) }}"


### PR DESCRIPTION
This patch reverts #68 since the default rsyslog.conf
can't be used when input sub-roles are defined.

It introduced a regression in oVirt and a proper
handling of system logs should be provided in a new patch.

Signed-off-by: Shirly Radco <sradco@redhat.com>