### PR TITLE
Add send_targets_only variable

### DIFF
--- a/roles/rsyslog/README.md
+++ b/roles/rsyslog/README.md
@@ -261,6 +261,8 @@ Variables in vars.yaml
 - `rsyslog_enabled` : When 'True' rsyslog role will deploy specified configuration file set. Default to 'True'.
 - `rsyslog_pki` : When 'True' pki related variables are configured.  In addition, if 'tls' is included in 'rsyslog_capabilities', it enables to forward logs over TLS.  Default to 'False'.
 - `rsyslog_capabilities` : List of capabilities to configure.  [ 'network', 'remote-files', 'tls' ] are predefined.
+- `rsyslog_default`: If set as `True`, rsyslog.conf will be configured with default configurations and rules.
+  If set to `False`, rsyslog.conf will be updated and only include the includes /etc/rsyslod.d/ statement. Default to `True`.
 
 Common sub-variables
 --------------------

--- a/roles/rsyslog/defaults/main.yaml
+++ b/roles/rsyslog/defaults/main.yaml
@@ -357,6 +357,7 @@ rsyslog_common_rules:
   - '{{ rsyslog_conf_local_modules }}'
   - '{{ rsyslog_conf_network_modules }}'
   - '{{ rsyslog_conf_common_defaults }}'
+  - '{{ rsyslog_conf_send_targets_only }}'
 
 
 # Default configuration options
@@ -374,7 +375,9 @@ rsyslog_conf_global_options:
     options: |-
       global(
         defaultNetstreamDriver="{{ rsyslog_default_netstream_driver }}"
+      {% if not rsyslog_default|default(true)|bool %}
         workDirectory="{{ rsyslog_work_dir }}"
+      {% endif %}
       {% if rsyslog_pki|bool and "tls" in rsyslog_capabilities %}
         defaultNetstreamDriverCAFile="{{ rsyslog_pki_path + '/' + rsyslog_pki_realm + '/' + rsyslog_pki_ca }}"
       {%   if rsyslog_default_driver_authmode != "anon" or "network" in rsyslog_capabilities %}
@@ -484,3 +487,14 @@ rsyslog_conf_common_defaults:
       - comment: 'Log every message'
         options: |-
           $RepeatedMsgReduction {{ "on" if rsyslog_message_reduction|bool else "off" }}
+
+rsyslog_conf_send_targets_only:
+
+  - filename: '40-send-targets-only.conf'
+    comment: 'Stops logs that should only be sent to defined targets'
+    options: |-
+      if ( strlen($.send_targets_only) > 0 ) then {
+          if ( $.send_targets_only == 'true' ) then {
+              stop
+          }
+      }

--- a/roles/rsyslog/roles/README.md
+++ b/roles/rsyslog/roles/README.md
@@ -1,0 +1,39 @@
+linux-system-roles-rsyslog/roles
+======================================
+
+# Guidelines for Using Rsyslog Input and Output Roles
+
+The input roles include Rsyslog configurations, for different projects, that user can collectd logs on.
+
+The projects are called `logs_collections` and the user can choose to deploy several projects at the same time.
+Each project adds a sub-role to ./logging/roles/rsyslog/roles/input_roles/.
+
+The sub-role usually includes `tasks` and `defaults` directories.
+The `defaults` directory includes:
+  - List of required packages that are **not** the base rsyslog_base_packages: ['rsyslog', 'libselinux-python']
+  - List of modules to load  like `imfile`, `imtcp`, etc.
+  - Defines the formatting and the rulebases for parsing the logs.
+  - It is required to set for all logs the project identfier for pipelining:
+    set $.logs_collection = "project name";
+    For example: In `ovirt` input role, in the default/main.yaml, for every log `$.logs_collection` is set to `ovirt`.
+  - If rsyslog_default equals to`"true, It is required to set for all logs you don't want to be processed by the default rules:
+    set $.send_targets_only = "true";
+
+The `tasks` directory includes 2 tasks file:
+  - `main.yaml` - tasks for deploying the config files
+    This file is sets `rsyslog_role_packages` and `rsyslog_role_rules` and includes the task that deploys the files.
+  - `cleanup.yml` - tasks that cleanup the files deployed for this project.
+
+Examples can be found in the existing projects.
+
+The available outputs are defined in /logging/roles/rsyslog/roles/output_roles/.
+Currently, It supports Elasticsearch output.
+Additional output will be added.
+
+Planned Flows:
+--------------
+  - `Rsyslog` -> `Local` (RHEL Default) / `Viaq` [1] / `Elasticsearch` / `Remote Rsyslog` / `message Queue (kafka, amqp)`
+
+[1] Rsyslog to Viaq currently means doing output to the OCP Elasticsearch using client cert auth.
+    In the future we want to support Rsyslog to OCP rsyslog using RELP, or Rsyslog to mux using fluent relp input plugin, or message queue.
+

--- a/roles/rsyslog/roles/input_roles/ovirt/defaults/main.yaml
+++ b/roles/rsyslog/roles/input_roles/ovirt/defaults/main.yaml
@@ -42,6 +42,9 @@ rsyslog_conf_local_ovirt_modules:
 
   - name: 'local-ovirt-modules'
     type: 'modules'
+    state: '{{ "present"
+              if not (rsyslog_default|default(true)|bool)
+              else "absent" }}'
     sections:
 
       - comment: 'Log messages sent to local UNIX socket with use=off'
@@ -105,6 +108,7 @@ rsyslog_conf_ovirt_formatting:
               set $.index_prefix = "{{ rsyslog_elasticsearch_index_prefix_metrics|d("project.ovirt-metrics") }}" & "-" & "{{ ovirt_env_name|d("engine") }}" & ".";
           {% endif %}
               set $.logs_collection = "ovirt";
+              set $.send_targets_only = "true";
           }
 
           {% if collect_ovirt_engine_log %}
@@ -144,6 +148,7 @@ rsyslog_conf_ovirt_formatting:
               set $.logs_collection = "ovirt";
               set $!ovirt!class = $.ovirt!class;
               set $!ovirt!thread = $.ovirt!thread;
+              set $.send_targets_only = "true";
 
               unset $!metadata;
 

--- a/roles/rsyslog/tasks/main.yaml
+++ b/roles/rsyslog/tasks/main.yaml
@@ -177,10 +177,10 @@
         - item is defined and item != []
         - item.state|d('present') == 'absent'
 
-    - name: Run output sub-roles
+    - name: Run output sub-roles configs
       include_role:
         name: "{{ logging_role_path|d('logging') }}/roles/rsyslog/roles/output_roles/{{ item }}"
-      with_items: " {{ rsyslog_outputs }}"
+      with_items: "{{ rsyslog_outputs }}"
       when:
         - rsyslog_enabled|bool
         - item is defined and item != []


### PR DESCRIPTION
Added send_targets_only variable and
40-send-targets-only.conf config file.

The config file contains a filter that will filter
logs with 'send_targets_only' set to 'true'
and discard them after all output targets were processed
and before the default rsyslog.conf rules.

Signed-off-by: Shirly Radco <sradco@redhat.com>

Please review: @pcahyna @nhosoi 