### PR TITLE
Remove the use_python3 variable and fact

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,5 +9,3 @@ logging_outputs: []
 logging_custom_config_files: []
 
 logging_purge_confs: false
-
-use_python3: true

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -7,15 +7,6 @@
       set_fact:
         rsyslog_enabled: "{{ logging_enabled|d(true) }}"
 
-    - name: Set use_python3 to false if python3 is not installed.
-      set_fact:
-        use_python3: false
-      when: "ansible_python_version is version('3', '<')"
-
-    - name: Check python version
-      debug:
-        msg: "Python version is {{ ansible_python_version }}; use_python3 is {{ use_python3 }}"
-
     - name: Set rsyslog_elasticsearch
       set_fact:
         rsyslog_elasticsearch: "{{ rsyslog_elasticsearch|d([]) }} + {{ [  item.0 |combine( {'logs_collections_name': item.1.name} )] }}"
@@ -84,14 +75,6 @@
       when:
         - item.type|d('') == 'custom'
         - logging_enabled|d(true)
-
-    - name: Install python selinux library for logging_debug
-      yum:
-        name: '{{ "python3-libselinux" if use_python3 else "libselinux-python" }}'
-        state: 'latest'
-      when: logging_debug|d(false)
-      tags:
-        - skip_ansible_lint
 
     - name: Re-read facts after adding custom fact
       setup:


### PR DESCRIPTION
- it is redundant: there is ansible_python_version for this
- no other role needs it, so it is doubful that it is actually needed
  (the role does not even contain any Python code)
- it is not even properly namespaced
- should not be in defaults: it is not supposed to be set by user
  and a fact is not supposed to shadow a default
- a fact is not scoped and will persist in the namespace after the role finishes
- libselinux-python is nothing specific to this role and no other role (except
  selinux) installs it - if it is really needed, it should be solved in a common
  way