### PR TITLE
RHELPLAN-33869 - Changing the default value of rsyslog_default from t…

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,40 +105,42 @@ logging_purge_confs: true
 2) Deploying basic LSR/Logging config files in /etc/rsyslog.d, which handle inputs from the local system and outputs into the local files.
 ```
 logging_enabled: true
-rsyslog_default: false
 logging_purge_confs: true
 logging_outputs:
   - name: local-files
     type: files
     logs_collections:
-      - name: basics
+      - name: system-input
+        type: basics
 ```
 
 3) Deploying basic LSR/Logging config files in /etc/rsyslog.d, which handle inputs from the local system and remote rsyslog and outputs into the local files.
 ```
 logging_enabled: true
-rsyslog_default: false
 rsyslog_capabilities: [ 'network', 'remote-files' ]
 logging_purge_confs: true
 logging_outputs:
   - name: local-files
     type: files
     logs_collections:
-      - name: basics
+      - name: system-and-remote-input
+        type: basics
 ```
 
 4) Deploying config files for collecting logs from OpenShift pods as well as RHV and forwarding them to elasticsearch.
 ```
 logging_enabled: true
-rsyslog_default: false
 logging_outputs:
   - name: viaq-elasticsearch
     type: elasticsearch
     logs_collections:
-      - name: viaq
-    # 'state' is not a mandatory field. Defaults to `present`.
-      - name: viaq-k8s
+      - name: viaq-input
+        type: viaq
+    # 'state' is not a mandatory field. Defaults to 'present'.
+      - name: viaq-k8s-input
+        type: viaq-k8s
       - name: ovirt
+        type: ovirt-input
         state: absent
     server_host: logging-es
     server_port: 9200
@@ -149,7 +151,8 @@ logging_outputs:
   - name: ovirt-elasticsearch
     type: elasticsearch
     logs_collections:
-      - name: ovirt
+      - name: ovirt-input
+        type: ovirt
     server_host: logging-es-ovirt
     server_port: 9200
     index_prefix: project.ovirt-logs
@@ -180,8 +183,9 @@ Variables in vars.yaml
    -  **If `type: elasticsearch`**, send logs to one or more remote elasticsearch or Viaq installations.
       - `name`: Name of the elasticsearch element.
       - `type`: Type of the output element. Optional values: `elasticsearch`, `local`, `custom_files`.
-      - `logs_collections` : List of optional logs collections, dictionaries with `name` and `state` attributes, that were pre-configured.
-        - `name`: The name of the pre-configured logs to collect. **Note:** Currently only ['viaq', 'viaq-k8s', 'ovirt'] are supported for the elasticsearch output.
+      - `logs_collections` : List of optional logs collections, dictionaries with `name`, `type` and `state` attributes, that were pre-configured.
+        - `name`: Unique name of the input.
+          `type`: The type of the pre-configured logs to collect. **Note:** Currently ['viaq', 'viaq-k8s', 'ovirt'] are supported for the elasticsearch output.
           
           `state`: The state of the configuration files states if they should be `present` or `absent`. Default to `present`.
       - `server_host`: Hostname elasticsearch is running on.

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -1,5 +1,7 @@
 ---
 - name: Converge
   hosts: all
+  vars:
+    rsyslog_default: true
   roles:
     - role: logging

--- a/roles/rsyslog/README.md
+++ b/roles/rsyslog/README.md
@@ -57,11 +57,14 @@ logging_outputs:
    type: <output_type0>
    logs_collections:
      - name: <input_role_nameA>
+       type: <input_role_typeA>
      - name: <input_role_nameB>
+       type: <input_role_typeB>
   -name: <output_role_name1>
    type: <output_type1>
    logs_collections:
      - name: <input_role_nameC>
+       type: <input_role_typeC>
 ```
 
 See the [variables section](#variables) for each variable.
@@ -83,27 +86,27 @@ rsyslog_backup_dir: /tmp/rsyslog_backup
 1. Deploying basic LSR/Logging config files in /etc/rsyslog.d, which handle inputs from the local system and outputs into the local files.  Pre-existing config files are copied to the directory specified by `rsyslog_backup_dir`.
 ```
 rsyslog_enabled: true
-rsyslog_default: false
 rsyslog_purge_original_conf: true
 rsyslog_backup_dir: /tmp/rsyslog_backup
 logging_outputs:
   - name: local-files
     type: files
     logs_collections:
-      - name: basics
+      - name: system-input
+        type: basics
 ```
 
 2. Deploying basic LSR/Logging config files in /etc/rsyslog.d, which handle inputs from the local system and remote rsyslog and outputs into the local files.
 ```
 rsyslog_enabled: true
-rsyslog_default: false
 rsyslog_capabilities: [ 'network', 'remote-files' ]
 rsyslog_purge_original_conf: true
 logging_outputs:
   - name: local-files
     type: files
     logs_collections:
-      - name: basics
+      - name: system-and-remote-input
+        type: basics
 ```
 
 3. Sample vars.yaml file for the viaq case.
@@ -113,7 +116,8 @@ rsyslog_elasticsearch:
   - name: viaq-elasticsearch
     type: elasticsearch
     logs_collections:
-      - name: viaq
+      - name: viaq-input
+        type: viaq
     server_host: es-hostname
     server_port: 9200
 ```
@@ -132,9 +136,11 @@ rsyslog_outputs:
   - name: viaq-elasticsearch
     type: elasticsearch
     rsyslog_logs_collections:
-      - name: viaq
+      - name: viaq-input
+        type: viaq
         state: present
-      - name: viaq-k8s
+      - name: viaq-k8s-input'
+        type: viaq-k8s'
         state: present
     server_host: logging-es
     server_port: 9200
@@ -148,9 +154,11 @@ rsyslog_outputs:
   - name: viaq-elasticsearch-ops
     type: elasticsearch
     rsyslog_logs_collections:
-      - name: viaq
+      - name: viaq-input
+        type: viaq
         state: present
-      - name: viaq-k8s
+      - name: viaq-k8s-input
+        type: viaq-k8s
         state: present
     server_host: logging-es-ops
     server_port: 9200
@@ -270,37 +278,6 @@ The basic framework is based on debops.rsyslog and adjusted to the RHEL/Fedora s
 
 - tasks/main.yaml contains the sceries of tasks to deploy specified set of configuration files.
 
-If viaq is in `rsyslog_logs_collections`, the following tasks are executed.
-```
-TASK [rsyslog : Install/Update required packages]
-TASK [rsyslog : Create required system group]
-TASK [rsyslog : Create required system user]
-TASK [rsyslog : Create a work directory]
-TASK [rsyslog : Create a temp directory for rsyslog.d backup]
-TASK [rsyslog : Set backup dir name]
-TASK [rsyslog : Create a backup dir]
-TASK [rsyslog : Moving the contents of /etc/rsyslog.d to the backup dir]
-TASK [rsyslog : create rsyslog viaq subdir]
-TASK [rsyslog : Update directory and file permissions]
-TASK [rsyslog : Generate main rsyslog configuration]
-TASK [rsyslog : Generate viaq configuration files in rsyslog.d]
-TASK [rsyslog : Generate rsyslog viaq configuration files in rsyslog.d/viaq]
-```
-If basics is in `rsyslog_logs_collections` the following tasks are executed.
-```
-TASK [rsyslog : Install/Update required packages]
-TASK [rsyslog : Create required system group]
-TASK [rsyslog : Create required system user]
-TASK [rsyslog : Create a work directory]
-TASK [rsyslog : Create a temp directory for rsyslog.d backup]
-TASK [rsyslog : Set backup dir name]
-TASK [rsyslog : Create a backup dir]
-TASK [rsyslog : Moving the contents of /etc/rsyslog.d to the backup dir]
-TASK [rsyslog : create rsyslog viaq subdir]
-TASK [rsyslog : Update directory and file permissions]
-TASK [rsyslog : Generate main rsyslog configuration]
-TASK [rsyslog : Generate exaple configuration files in rsyslog.d]
-```
 WARNING: Pre-existing rsyslog.conf and configuration files in /etc/rsyslog.d are moved to the backup directory /tmp/rsyslog.d-XXXXXX.  If the pre-existing files need to be merged with the newly deployed files, you need to do it manually.
 
 -defaults/main.yaml defines variables to switch the deployment paths, variables to specify the locations to deploy and the configurations to be deployed.

--- a/roles/rsyslog/defaults/main.yaml
+++ b/roles/rsyslog/defaults/main.yaml
@@ -9,8 +9,9 @@ rsyslog_enabled: true
 
 # rsyslog_default
 #
-# Diploy default ``rsyslog`` configuration file.
-rsyslog_default: true
+# Diploy default ``rsyslog`` configuration file /etc/rsyslog.conf if it is set to true.
+# Otherwise, rsyslog.conf just includes configuration files in /etc/rsyslog.d.
+rsyslog_default: false
 
 # rsyslog_system_log_dir
 #
@@ -360,7 +361,7 @@ rsyslog_conf_global_options:
     options: |-
       global(
         defaultNetstreamDriver="{{ rsyslog_default_netstream_driver }}"
-      {% if not rsyslog_default | default(true) | bool %}
+      {% if not rsyslog_default | bool %}
         workDirectory="{{ rsyslog_work_dir }}"
       {% endif %}
       {% if rsyslog_pki | bool and "tls" in rsyslog_capabilities %}

--- a/roles/rsyslog/roles/input_roles/ovirt/defaults/main.yaml
+++ b/roles/rsyslog/roles/input_roles/ovirt/defaults/main.yaml
@@ -43,7 +43,7 @@ rsyslog_conf_local_ovirt_modules:
   - name: 'local-ovirt-modules'
     type: 'modules'
     state: '{{ "present"
-              if not (rsyslog_default | default(true) | bool)
+              if not (rsyslog_default | bool)
               else "absent" }}'
     sections:
 

--- a/roles/rsyslog/tasks/main.yaml
+++ b/roles/rsyslog/tasks/main.yaml
@@ -6,6 +6,7 @@
   when:
     - rsyslog_enabled | bool
     - not use_rsyslog_image | default(false) | bool
+  ignore_errors: yes
   tags:
     - skip_ansible_lint
 
@@ -159,7 +160,7 @@
 
     - name: Run deploy input sub-roles configs
       include_role:
-        name: "{{ role_path }}/roles/input_roles/{{ input_item.name }}"
+        name: "{{ role_path }}/roles/input_roles/{{ input_item.type }}"
       loop: "{{ rsyslog_logs_collections | flatten(1) }}"
       loop_control:
         loop_var: input_item
@@ -170,7 +171,7 @@
 
     - name: Run remove input sub-roles configs
       include_role:
-        name: "{{ role_path }}/roles/input_roles/{{ input_item.name }}"
+        name: "{{ role_path }}/roles/input_roles/{{ input_item.type }}"
         tasks_from: cleanup.yaml
       loop: "{{ rsyslog_logs_collections | flatten(1) }}"
       loop_control:

--- a/roles/rsyslog/templates/etc/rsyslog.conf.j2
+++ b/roles/rsyslog/templates/etc/rsyslog.conf.j2
@@ -1,6 +1,6 @@
 # {{ ansible_managed }}
 
-{% if not rsyslog_default | default(true) | bool %}
+{% if not rsyslog_default | bool %}
 #
 # Include all config files in {{ rsyslog_config_dir }}
 #

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -39,7 +39,7 @@
 
     - name: Set rsyslog_logs_collections
       set_fact:
-        rsyslog_logs_collections: "{{ rsyslog_logs_collections | d([]) }} + {{ [ { 'name': item.1.name, 'state': item.1.state | d('present'), 'output_name': item.0.name } ] }}"
+        rsyslog_logs_collections: "{{ rsyslog_logs_collections | d([]) }} + {{ [ { 'name': item.1.name, 'type': item.1.type, 'state': item.1.state | d('present'), 'output_name': item.0.name } ] }}"
       with_subelements:
         - "{{ logging_outputs }}"
         - logs_collections

--- a/tests/tests_enabled.yml
+++ b/tests/tests_enabled.yml
@@ -2,6 +2,8 @@
 - name: Ensure that the role runs with rsyslog_enabled=true
   hosts: all
   become: true
+  vars:
+    rsyslog_default: True
 
   tasks:
     - name: default run (deploy rsyslog.conf)

--- a/tests/tests_files.yml
+++ b/tests/tests_files.yml
@@ -7,12 +7,12 @@
     - name: deploy config to output into local files
       vars:
         logging_enabled: true
-        rsyslog_default: false
         logging_outputs:
           - name: files-output
             type: files
             logs_collections:
-              - name: basics
+              - name: input
+                type: basics
       include_role:
         name: linux-system-roles.logging
 

--- a/tests/tests_listen.yml
+++ b/tests/tests_listen.yml
@@ -8,13 +8,13 @@
       vars:
         logging_enabled: true
         logging_purge_confs: true
-        rsyslog_default: false
         rsyslog_capabilities: [ 'network', 'remote-files' ]
         logging_outputs:
           - name: files-output
             type: files
             logs_collections:
-              - name: basics
+              - name: input
+                type: basics
 
       include_role:
         name: linux-system-roles.logging


### PR DESCRIPTION
…rue to false

If rsyslog_default is set to true, it deploys the default rsyslog.conf to /etc.
The rsyslog.conf contains the initial input and output plugins for the system logs.
The logging role adds the functionality to process logs including the system logs. 
For instance, which input roles to be used, which output roles to be used, how the
log messages are normalized and distributed.  The default rsyslog.conf could conflict
with the functionality. There is one particular use case which needs rsyslog_default
set to true.  Ovirt already relies on the default rsyslog.conf for the system log
handling. To guarantee it does not break the ovirt logging deployment, we chose to
keep the rsyslog_default var and ability to deploy the default rsyslog.conf for now.

Additionally, Changing logs_collection parameter(s) as follows:
[current]
```
logging_outputs:
  -name: <output_role_name>
   type: <output_role_type>  # type of the output_role
   logs_collections:
     - name: <input_role_name>  # type of the input_role
```
[new]
```
logging_outputs:
  -name: <output_role_name>  # unique name
   type: <output_role_type>  # type of the output_role
   logs_collections:
     - name: <input_role_name>  # unique name
       type: <input_role_type>  # type of the input_role
```

where <input_role_name> in the "current" format specifies the type of
the input_role in the sense of the output_role convention.  To reduce
the confusion, it'd be preferable that "name" and "type" have the same
meaning between output_role (logging_outputs) and input_role (logs_collections).