### PR TITLE
RHELPLAN-32351 - Add an ability to distribute messages to different o…

### DIFF
--- a/design_docs/README.md
+++ b/design_docs/README.md
@@ -1,0 +1,10 @@
+Design Doc Contents
+===================
+
+[logging subsystem structure](logging_subsystem.md)
+
+### rsyslog
+
+[templates](rsyslog_templates.md)
+
+[input and output roles](rsyslog_input_output_roles.md)

--- a/design_docs/logging_subsystem.md
+++ b/design_docs/logging_subsystem.md
@@ -1,0 +1,126 @@
+# Current logging subsystem structure
+
+It is designed to satisfy following requirements.
+
+- Adding more logging systems such as fluentd, grafana loki, etc.
+- Supporting flexible combinations of input_role and output_role such as input from files and/or journald and output to files and/or elasticsearch.
+- More inputs and outputs could be added.
+- The existing scenario, especially input_role ovirt + output_role elasticsearch should not be affected by the other roles.
+
+```
+linux-system-roles
+|
+|- logging
+   |
+   |- meta
+   |- molecule: tests using molecule
+   |- tasks: common tasks
+   |- tests: tests using test-harness
+   |- roles
+      |
+      |- rsyslog
+         |
+         |- defaults
+         |- handlers
+         |- tasks
+         |- templates: template for the default rsyslog.conf and config files to generate in rsyslog.d
+         |- roles
+            |
+            |- input_roles
+            |  |
+            |  |- basics: reads logs from systemd-journald or unix socket or input tcp/udp
+            |  |  |
+            |  |  |- tasks
+            |  |  |- defaults
+            |  |
+            |  |- ovirt: reads logs from ovirt and processes the logs to send them to elasticsearch)
+            |  |  |
+            |  |  |- tasks
+            |  |  |- defaults
+            |  |
+            |  |- viaq: reads logs from systemd-journald and processes the logs to send them to elasticsearch
+            |  |  |
+            |  |  |- tasks
+            |  |  |- defaults
+            |  |
+            |  |- viaq-k8s: reads log files from k8s and processes the logs to send them to elasticsearch
+            |     |
+            |     |- tasks
+            |     |- defaults
+            |
+            |- output_roles
+               |
+               |- files: writes logs to local files
+               |  |
+               |  |- tasks
+               |  |- defaults
+               |
+               |- forwards: forwards logs to remote hosts
+               |  |
+               |  |- tasks
+               |  |- defaults
+               |
+               |- elasticsearch: sends logs to elasticsearch
+                  |
+                  |- tasks
+                  |- defaults
+```
+
+# How Logging role starts
+
+When ansible-playbook is executed with a playbook pointing to the logging role,
+it starts with tasks in logging/tasks/main.yaml.
+In the tasks, it evaluates the `logging_outputs`, `logs_collections` parameters in the loop
+to pass the dictionaries to each subsystem.
+If the `logging_output` is `files`, `rsyslog_files_actions` is evaluated.
+If the `logging_putput` is `forwards`, `rsyslog_forwards_action` is evaluated.
+The following is a format of the outputs/inputs/action parameters for the `files` and `forwards` output.
+
+## input/files output/action
+```
+logging_outputs: [1]
+  - name: unique_output_name
+    type: files [2]
+    logs_collections: [3]
+      - name: unique_input_name
+        type: input_type [4]
+    rsyslog_files_actions:
+      - name: unique_name
+        severity: severity [5]
+        facility: facility [6]
+        exclude: exclude_string [7]
+        path: fullpath [8]
+      - name: unique_name
+        .................
+```
+
+## input/forwards output/action
+```
+logging_outputs: [1]
+  - name: unique_output_name
+    type: forwards [2]
+    logs_collections: [3]
+      - name: unique_input_name
+        type: input_type [4]
+    rsyslog_forwards_actions:
+      - name: unique_name
+        severity: severity [5]
+        facility: facility [6]
+        exclude: exclude_string [7]
+        protocol: protocol [9]
+        target: target_host [10]
+        port: port_number [11]
+      - name: unique_name
+        .................
+```
+[1]: logging_outputs are implemented in ./logging/roles/rsyslog/roles/output_roles/.<br>
+[2]: output type is one of [elasticsearch, files, forwards]; the type matches the directory name in output_roles.<br>
+[3]: logs_collections are implemented in ./logging/roles/rsyslog/roles/input_roles/.<br>
+[4]: input_type is one of [basics, ovirt, viaq, viaq-k8s]; the type matches the directory name in input_roles.<br>
+[5]: severity: logs higher than or equal to the value match; e.g., info.  Default to `*`.<br>
+[6]: facility: e.g., auth,authpriv,mail. Default to `*`.<br>
+[7]: exclude: string to be added as facility.severity;exclude in the filter. The format is facility0.none,facility1.none,...  E.g., authpriv.none;auth.none;cron.none;mail.none.  Default to none.<br>
+[8]: fullpath to store logs.<br>
+[9]: tcp or udp.  Default to tcp.<br>
+[10]: fqdn or IP address of the target host.<br>
+[11]: port number.  Default to 514<br>

--- a/design_docs/rsyslog_input_output_roles.md
+++ b/design_docs/rsyslog_input_output_roles.md
@@ -1,0 +1,38 @@
+# Rsyslog
+
+## Input Roles
+
+### basics
+
+Basics input role handles following inputs.
+
+#### Local inputs
+- `imuxsock` - reads system logs from unix socket.  `off`, by default.  If `rsyslog_use_imuxsock` is set to `true`, `on`.
+- `imjournal` - reads system logs from `systemd-journald`.
+- `imklog` - reads kernel messages.  If `kernel-message` is in `rsyslog_capabilities`, `imklog` is enabled.  Disabled, by default.
+- `imfile` - reads messages from file. If `file-input` is in `rsyslog_capabilities`, `imfile` is enabled.  Disabled, by default.  Plus, when rsyslog_elasticsearch is configured, the messages are passed to the elasticsearch output config.  (Note: normalizing/reformatting is TBD.)
+
+Basically, these system lots are handled by \*.system output roles, that `files` and `forwards` belong to.
+
+#### Remote inputs
+- `imudp` - receives remote logs via the udp socket. If `network` is in `rsyslog_capabilities` _and_ `rsyslog_send_over_tls_only` is `off`, `imudp` is enabled.  Disabled, by default.
+- `imptcp` - receives remote logs via the plain tcp socket. If `network` is in `rsyslog_capabilities` _and_ `rsyslog_send_over_tls_only` is `off`, `imptcp` is enabled.  Disabled, by default.
+- `imtcp` - receives remote logs via the tcp socket. If both `network` and `tls` are in `rsyslog_capabilities`, `imtdp` is enabled.  Disabled, by default
+
+The remote logs are handed to \*.remote via remote ruleset.  Then, the logs are stored in separated files based on the source host name, program name, which is implemented in the output_roles/files.  (See also [tests_listen.yml](../tests/tests_listen.yml) for an example.)
+
+### ovirt
+
+### viaq
+
+### viaq-k8s
+
+## Output Roles
+
+### elasticsearch
+
+### files
+- `builtin:omfile` - configure outputs to the local files.  If rsyslog_files_actions is not defined or empty, the default configuration - same as the file outputs to the part in rsyslog.conf in the rsyslog rpm package.  If rsyslog_files_actions are configured, the file outputs are generated according to the config params (See also [input/files output/action](logging_subsystem.md#inputfiles-outputaction) as well as [tests_files.yml](../tests/tests_files.yml) and [tests_files_forwards.yml](../tests/tests_files_forwards.yml) for examples.)
+
+### forwards
+- `omfwd` - configure outputs to forward over tcp or udp to the remote host.  If rsyslog_forwards_actions is not defined or empty, no omfwd is configured.  If rsyslog_forwards_actions are configured, the forwards outputs are generated according to the config params (See also [input/forwards output/action](logging_subsystem.md#inputforwards-outputaction) as well as [tests_forwards.yml](../tests/tests_forwards.yml) and [tests_files_forwards.yml](../tests/tests_files_forwards.yml) for examples.)

--- a/design_docs/rsyslog_templates.md
+++ b/design_docs/rsyslog_templates.md
@@ -1,0 +1,64 @@
+# Rsyslog
+
+## templates
+
+### rsyslog.conf
+
+The primary configurarion file rsyslog.conf is managed by the rsyslog_default parameter.
+If it is set to `true`, the default rsyslog.conf from the rsyslog rpm package is copied to /etc.
+If it is set to `false`, just the rsyslog.conf file only contains `$IncludeConfig /config/path/*.conf`
+and all the configurations are done in the sub-configuration files in rsyslog.d.
+
+### Sub-configuration files in rsyslog.d
+
+The [rules.conf.j2](../roles/rsyslog/templates/etc/rsyslog.d/rules.conf.j2) is a template to generate
+sub-configuration files based on the rules defined in the file.  Rsyslog configurations are implemented
+as a combination of small pieces.
+
+Each piece is defined in the logging role default yaml files as follows (a simple example):
+```
+- name: filename
+  type: type
+  options: |-
+    configure_line0
+    configure_line1
+    .....
+```
+
+It is deployed to /etc/rsyslog.d/[0-9][0-9]-filename.conf, where [0-9][0-9] is determined with the type [1].  The "filename" is from the value of `name`.  By default, the suffix is `conf`.
+
+[1] - rsyslog_weight_map:
+| type                           | value |
+| ------------------------------ | -----:|
+| global, globals                | 05    |
+| module, modules                | 10    |
+| template, templates            | 20    |
+| output, outputs                | 30    |
+| service, services              | 30    |
+| rule, rules, ruleset, rulesets | 50    |
+| input, inputs                  | 90    |
+
+The contents of the file:
+```
+configure_line0
+configure_line1
+.....
+```
+
+Further controles are available.
+To change the file suffix to `system`:
+```
+- name: filename
+  type: type
+  suffix: 'system'
+```
+To change the preceding digits to 99:
+```
+- name: filename
+  type: type
+  weight: '99'
+```
+To use completely pre-determined filename:
+```
+- filename: 'fixed-filename.conf'
+```

--- a/roles/rsyslog/defaults/main.yaml
+++ b/roles/rsyslog/defaults/main.yaml
@@ -245,28 +245,19 @@ rsyslog_group_allow: []
 rsyslog_host_allow: ['192.168.122.100/24']
 
 
-# Log forwarding
-# --------------
+# Files and Forwards outputs
+# --------------------------
 
-# rsyslog_forwards
+# rsyslog_files_actions
 #
-# List of ``rsyslogd`` options that configure log forwarding for all hosts in
-# the inventory.
-rsyslog_forwards: []
+# Array of dictionary to specify files to store logs for files outputs.
+rsyslog_files_actions: []
 
-# rsyslog_group_forwards
+# rsyslog_forwards_actions
 #
-# List of ``rsyslogd`` options that configure log forwarding for hosts in
-# a specific group.
-rsyslog_group_forwards: []
-
-# rsyslog_host_forwards
-#
-# List of ``rsyslogd`` options that configure log forwarding for specific hosts
-# in Ansible inventory.
-# rsyslog_host_forwards: [ '*.* @other.{{ ansible_domain }}' ]
-rsyslog_host_forwards: []
-
+# Array of dictionary to specify files to forward target host to redirect
+# the logs to the remote rsyslog servers for forwards output.
+rsyslog_forwards_actions: []
 
 # Rsyslog configuration rules
 # ---------------------------
@@ -341,7 +332,6 @@ rsyslog_common_rules:
 
   - '{{ rsyslog_conf_global_options }}'
   - '{{ rsyslog_conf_local_modules }}'
-  - '{{ rsyslog_conf_network_modules }}'
   - '{{ rsyslog_conf_common_defaults }}'
   - '{{ rsyslog_conf_send_targets_only }}'
 
@@ -391,52 +381,6 @@ rsyslog_conf_local_modules:
           module(load="immark" interval={{ (60 * 60) }})
         state: '{{ "present"
                   if ("mark" in rsyslog_capabilities)
-                  else "absent" }}'
-
-# rsyslog_conf_network_modules
-#
-# List of ``rsyslogd`` modules that receive logs from remote systems over the
-# network. They are enabled by the ``network`` capability.
-rsyslog_conf_network_modules:
-
-  - name: 'network-modules'
-    type: 'modules'
-    state: '{{ "present"
-              if ("network" in rsyslog_capabilities)
-              else "absent" }}'
-    sections:
-
-      - comment: 'Enable UDP support'
-        options: |-
-          module(load="imudp")
-        state: '{{ "present"
-                  if (rsyslog_send_over_tls_only)
-                  else "absent" }}'
-
-      - comment: 'Enable TCP support'
-        options: |-
-          module(load="imptcp")
-        state: '{{ "present"
-                  if (rsyslog_send_over_tls_only)
-                  else "absent" }}'
-
-      - comment: 'Enable Secure TCP support based on rsyslog_default_netstream_driver'
-        options: |-
-          module(
-            load="imtcp"
-            streamDriver.name="{{ rsyslog_default_netstream_driver }}"
-            streamDriver.mode="1"
-            streamDriver.authMode="{{ rsyslog_default_driver_authmode }}"
-          {% if rsyslog_default_driver_authmode != "anon" %}
-            {% if rsyslog_permitted_peers is string %}
-              permittedPeer="{{ rsyslog_permitted_peers }}"
-            {% else %}
-              permittedPeer=["{{ rsyslog_permitted_peers | join('","') }}"]
-            {% endif %}
-          {% endif %}
-          )
-        state: '{{ "present"
-                  if ("tls" in rsyslog_capabilities)
                   else "absent" }}'
 
 # rsyslog_conf_common_defaults

--- a/roles/rsyslog/roles/input_roles/basics/defaults/main.yaml
+++ b/roles/rsyslog/roles/input_roles/basics/defaults/main.yaml
@@ -12,8 +12,15 @@ rsyslog_unprivileged: false
 #       Note: unles rsyslog_send_over_tls_only is set to true, insecure network connection
 #       is also allowed.
 rsyslog_capabilities: []
+rsyslog_basics_packages: ['rsyslog-gnutls']
 
 rsyslog_use_imuxsock: false
+
+# rsyslog_input_log_{path,tag} are parameters for the imfile.
+# rsyslog_input_log_path specifies the files to read. Wildcard '*' is allowed in the path
+# rsyslog_input_log_tag specifies the tag to be added to the logs.
+rsyslog_input_log_path: "/var/log/containers/*.log"
+rsyslog_input_log_tag: "container"
 
 # rsyslog_basics_rules
 #
@@ -64,6 +71,25 @@ rsyslog_conf_local_basics_modules:
           module(load="imptcp")
         state: '{{ "present"
                   if ("network" in rsyslog_capabilities) and (not rsyslog_send_over_tls_only)
+                  else "absent" }}'
+
+      - comment: 'Read messages sent over Secure TCP with TLS'
+        options: |-
+          module(
+            load="imtcp"
+            streamDriver.name="{{ rsyslog_default_netstream_driver }}"
+            streamDriver.mode="1"
+            streamDriver.authMode="{{ rsyslog_default_driver_authmode }}"
+          {% if rsyslog_default_driver_authmode != "anon" %}
+            {% if rsyslog_permitted_peers is string %}
+              permittedPeer="{{ rsyslog_permitted_peers }}"
+            {% else %}
+              permittedPeer=["{{ rsyslog_permitted_peers | join('","') }}"]
+            {% endif %}
+          {% endif %}
+          )
+        state: '{{ "present"
+                  if ("network" in rsyslog_capabilities) and ("tls" in rsyslog_capabilities)
                   else "absent" }}'
 
 # rsyslog_conf_default_rulesets

--- a/roles/rsyslog/roles/input_roles/basics/tasks/cleanup.yaml
+++ b/roles/rsyslog/roles/input_roles/basics/tasks/cleanup.yaml
@@ -5,5 +5,5 @@
 
 - name: Remove basics example config files from rsyslog.d
   include_role:
-    name: "{{ role_path }}/roles/rsyslog"
+    name: "{{ role_path }}/../../../"
     tasks_from: cleanup.yaml

--- a/roles/rsyslog/roles/input_roles/basics/tasks/main.yaml
+++ b/roles/rsyslog/roles/input_roles/basics/tasks/main.yaml
@@ -1,7 +1,7 @@
 ---
 - name: Set basics facts
   set_fact:
-    rsyslog_role_packages: rsyslog-gnutls
+    rsyslog_role_packages: "{{rsyslog_basics_packages | flatten | d([])}}"
     rsyslog_role_rules: "{{ rsyslog_basics_rules }}"
 
 - name: Install/Update basics role packages and generate example configuration files to role subdir

--- a/roles/rsyslog/roles/input_roles/files/defaults/main.yaml
+++ b/roles/rsyslog/roles/input_roles/files/defaults/main.yaml
@@ -1,0 +1,111 @@
+---
+# Imfile configuration setting
+# ----------------------------
+
+rsyslog_unprivileged: False
+
+# rsyslog_capabilities is an array which takes 'network', 'remote-files', 'tls'
+# 'network' enables input and output over network.
+# 'remote-files' allows input from remote hosts are separately stored from the local logs.
+# 'tls' specifies the input and output could be processed over tls.
+#       Note: unles rsyslog_send_over_tls_only is set to true, insecure network connection
+#       is also allowed.
+rsyslog_capabilities: []
+rsyslog_files_input_packages: []
+
+rsyslog_input_log_path: "/var/log/containers/*.log"
+rsyslog_input_log_tag: "container"
+
+# rsyslog_files_input_rules
+#
+# List of YAML dictionaries, each dictionary should contain ``rsyslogd``
+# configuration in a special format. See :ref:`rsyslog_rules` for more
+# details. This list specifies imfile ``rsyslogd`` example configuration.
+rsyslog_files_input_rules:
+  - '{{ rsyslog_conf_imfile_modules }}'
+  - '{{ rsyslog_conf_imfile_rulesets }}'
+  - '{{ rsyslog_conf_imfile_inputs }}'
+
+# Debops example configuration options
+# --------------------------------------------
+
+# rsyslog_conf_local_modules
+#
+# List of ``rsyslogd`` modules that enable logs from the local system to be
+# received and parsed by the ``rsyslogd`` daemon.
+rsyslog_conf_imfile_modules:
+
+  - name: 'imfile-modules'
+    type: 'modules'
+    sections:
+
+      - comment: 'Reads log messages from file'
+        options: |-
+          module(load="imfile" mode="inotify")
+
+# rsyslog_conf_imfile_rulesets
+#
+rsyslog_conf_imfile_rulesets:
+
+  - name: 'imfile-rulesets'
+    type: 'rules'
+    sections:
+
+      - comment: 'Rules for the messages from log files'
+        options: |-
+          ruleset(name="files") {
+            $IncludeConfig {{rsyslog_config_dir}}/*.files
+          }
+
+# rsyslog_conf_system_inputs
+#
+rsyslog_conf_imfile_inputs:
+
+  - name: 'imfile-input'
+    type: 'input'
+    sections:
+
+      - comment: 'Log messages from log files'
+        options: |-
+          # FIXME: Need to normalize a log before passing it to elasticsearch output
+          {% if rsyslog_elasticsearch is defined and rsyslog_elasticsearch|length > 0 %}
+
+          {% for element in rsyslog_logs_collections %}
+          {% if element.name is defined and element.type == "files" %}
+          {% if element.rsyslog_input_log_path is defined %}
+          {% if element.rsyslog_input_log_tag is defined %}
+          input(type="imfile" file="{{ element.rsyslog_input_log_path }}" tag="{{ element.rsyslog_input_log_tag }}" ruleset="try_es")
+          {% else %}
+          input(type="imfile" file="{{ element.rsyslog_input_log_path }}" tag="{{ rsyslog_input_log_tag }}" ruleset="try_es")
+          {% endif %}
+          {% else %}
+          {% if element.rsyslog_input_log_tag is defined %}
+          input(type="imfile" file="{{ rsyslog_input_log_path }}" tag="{{ element.rsyslog_input_log_tag }}" ruleset="try_es")
+          {% else %}
+          input(type="imfile" file="{{ rsyslog_input_log_path }}" tag="{{ rsyslog_input_log_tag }}" ruleset="try_es")
+          {% endif %}
+          {% endif %}
+          {% endif %}
+          {% endfor %}
+
+          {% else %}
+
+          {% for element in rsyslog_logs_collections %}
+          {% if element.name is defined and element.type == "files" %}
+          {% if element.rsyslog_input_log_path is defined %}
+          {% if element.rsyslog_input_log_tag is defined %}
+          input(type="imfile" file="{{ element.rsyslog_input_log_path }}" tag="{{ element.rsyslog_input_log_tag }}")
+          {% else %}
+          input(type="imfile" file="{{ element.rsyslog_input_log_path }}" tag="{{ rsyslog_input_log_tag }}")
+          {% endif %}
+          {% else %}
+          {% if element.rsyslog_input_log_tag is defined %}
+          input(type="imfile" file="{{ rsyslog_input_log_path }}" tag="{{ element.rsyslog_input_log_tag }}")
+          {% else %}
+          input(type="imfile" file="{{ rsyslog_input_log_path }}" tag="{{ rsyslog_input_log_tag }}")
+          {% endif %}
+          {% endif %}
+          {% endif %}
+          {% endfor %}
+
+          {% endif %}

--- a/roles/rsyslog/roles/input_roles/files/tasks/cleanup.yaml
+++ b/roles/rsyslog/roles/input_roles/files/tasks/cleanup.yaml
@@ -1,0 +1,10 @@
+---
+- name: Set input files facts
+  set_fact:
+    rsyslog_role_packages: "{{ rsyslog_files_input_packages|flatten }}"
+    rsyslog_role_rules: "{{ rsyslog_files_input_rules }}"
+
+- name: Remove input files example config files from rsyslog.d
+  include_role:
+    name: "{{ role_path }}/../../../"
+    tasks_from: cleanup.yaml

--- a/roles/rsyslog/roles/input_roles/files/tasks/main.yaml
+++ b/roles/rsyslog/roles/input_roles/files/tasks/main.yaml
@@ -1,0 +1,10 @@
+---
+- name: Set input files facts
+  set_fact:
+    rsyslog_role_packages: "{{ rsyslog_files_input_packages|flatten }}"
+    rsyslog_role_rules: "{{ rsyslog_files_input_rules }}"
+
+- name: Install/Update input files role packages and generate example configuration files to role subdir
+  include_role:
+    name: "{{ role_path }}/../../../"
+    tasks_from: deploy.yaml

--- a/roles/rsyslog/roles/input_roles/ovirt/tasks/cleanup.yaml
+++ b/roles/rsyslog/roles/input_roles/ovirt/tasks/cleanup.yaml
@@ -5,5 +5,5 @@
 
 - name: Remove oVirt configs
   include_role:
-    name: "{{ role_path }}/roles/rsyslog"
+    name: "{{ role_path }}/../../../"
     tasks_from: cleanup.yaml

--- a/roles/rsyslog/roles/input_roles/ovirt/tasks/main.yaml
+++ b/roles/rsyslog/roles/input_roles/ovirt/tasks/main.yaml
@@ -6,7 +6,7 @@
 
 - name: Install/Update role packages and generate role configuration files to role subdir
   include_role:
-    name: "{{ role_path }}/roles/rsyslog"
+    name: "{{ role_path }}/../../../"
     tasks_from: deploy.yaml
 
 - name: Allow rsyslog to listen on collectd port

--- a/roles/rsyslog/roles/input_roles/viaq-k8s/tasks/cleanup.yaml
+++ b/roles/rsyslog/roles/input_roles/viaq-k8s/tasks/cleanup.yaml
@@ -5,5 +5,5 @@
 
 - name: Remove Viaq-k8s role config files from subdir
   include_role:
-    name: "{{ role_path }}/roles/rsyslog"
+    name: "{{ role_path }}/../../../"
     tasks_from: cleanup.yaml

--- a/roles/rsyslog/roles/input_roles/viaq-k8s/tasks/main.yaml
+++ b/roles/rsyslog/roles/input_roles/viaq-k8s/tasks/main.yaml
@@ -6,5 +6,5 @@
 
 - name: Install/Update role packages and generate role configuration files to role subdir
   include_role:
-    name: "{{ role_path }}/roles/rsyslog"
+    name: "{{ role_path }}/../../../"
     tasks_from: deploy.yaml

--- a/roles/rsyslog/roles/input_roles/viaq/tasks/cleanup.yaml
+++ b/roles/rsyslog/roles/input_roles/viaq/tasks/cleanup.yaml
@@ -5,5 +5,5 @@
 
 - name: Remove viaq configs
   include_role:
-    name: "{{ role_path }}/roles/rsyslog"
+    name: "{{ role_path }}/../../../"
     tasks_from: cleanup.yaml

--- a/roles/rsyslog/roles/input_roles/viaq/tasks/main.yaml
+++ b/roles/rsyslog/roles/input_roles/viaq/tasks/main.yaml
@@ -6,5 +6,5 @@
 
 - name: Install/Update role packages and generate role configuration files to role subdir
   include_role:
-    name: "{{ role_path }}/roles/rsyslog"
+    name: "{{ role_path }}/../../../"
     tasks_from: deploy.yaml

--- a/roles/rsyslog/roles/output_roles/elasticsearch/tasks/main.yaml
+++ b/roles/rsyslog/roles/output_roles/elasticsearch/tasks/main.yaml
@@ -58,5 +58,5 @@
 
 - name: Install/Update role packages and generate role configuration files (elasticsearch)
   include_role:
-    name: "{{ role_path }}/roles/rsyslog"
+    name: "{{ role_path }}/../../../"
     tasks_from: deploy.yaml

--- a/roles/rsyslog/roles/output_roles/files/defaults/main.yaml
+++ b/roles/rsyslog/roles/output_roles/files/defaults/main.yaml
@@ -38,44 +38,69 @@ rsyslog_conf_files_output_rules:
     path: '{{ rsyslog_config_dir }}'
     sections:
 
-      - comment: |-
-          Log all kernel messages to the console.
-          Logging much else clutters up the screen.
-        options: |-
-          kern.*                                                 /dev/console
-        state: '{{ "present"
-                  if ("kernel-message" in rsyslog_capabilities)
-                  else "absent" }}'
+      - options: |-
+          {% if rsyslog_files_actions is defined and rsyslog_files_actions|length > 0 %}
+          {% for element in rsyslog_files_actions %}
+          {% if element.name is defined and element.path is defined %}
+          {% if element.severity is defined %}
+          {% if element.facility is defined %}
+          {% if element.exclude is defined %}
+          {{ element.facility }}.{{ element.severity }};{{ element.exclude }} {{ element.path }}
+          {% else %}
+          {{ element.facility }}.{{ element.severity }} {{ element.path }}
+          {% endif %}
+          {% else %}
+          {% if element.exclude is defined %}
+          *.{{ element.severity }};{{ element.exclude }} {{ element.path }}
+          {% else %}
+          *.{{ element.severity }} {{ element.path }}
+          {% endif %}
+          {% endif %}
+          {% else %}
+          {% if element.facility is defined %}
+          {% if element.exclude is defined %}
+          {{ element.facility }}.*;{{ element.exclude }} {{ element.path }}
+          {% else %}
+          {{ element.facility }}.* {{ element.path }}
+          {% endif %}
+          {% else %}
+          {% if element.exclude is defined %}
+          *.*;{{ element.exclude }} {{ element.path }}
+          {% else %}
+          *.* {{ element.path }}
+          {% endif %}
+          {% endif %}
+          {% endif %}
+          {% endif %}
 
-      - comment: |-
-          Log anything (except mail) of level info or higher.
-          Don't log private authentication messages!
-        options: |-
+          {% endfor %}
+          {% else %}
+          # Log all kernel messages to the console.
+          # Logging much else clutters up the screen.
+          kern.*                                                 /dev/console
+
+          # Log anything (except mail) of level info or higher.
+          # Don't log private authentication messages!
           *.info;mail.none;authpriv.none;cron.none                {{ rsyslog_system_log_dir }}/messages
 
-      - comment: 'The authpriv file has restricted access.'
-        options: |-
+          # The authpriv file has restricted access.
           authpriv.*                                              {{ rsyslog_system_log_dir }}/secure
 
-      - comment: 'Log all the mail messages in one place.'
-        options: |-
+          # Log all the mail messages in one place.
           mail.*                                                  -{{ rsyslog_system_log_dir }}/maillog
 
-      - comment: 'Log cron stuff'
-        options: |-
+          # Log cron stuff
           cron.*                                                  -{{ rsyslog_system_log_dir }}/cron
 
-      - comment: 'Everybody gets emergency messages'
-        options: |-
+          # Everybody gets emergency messages
           *.emerg                                                  :omusrmsg:*
 
-      - comment: 'Save news errors of level crit and higher in a special file.'
-        options: |-
+          # Save news errors of level crit and higher in a special file.
           uucp,news.crit                                          {{ rsyslog_system_log_dir }}/spooler
 
-      - comment: 'Save boot messages also to boot.log'
-        options: |-
+          # Save boot messages also to boot.log
           local7.*                                                {{ rsyslog_system_log_dir }}/boot.log
+          {% endif %}
 
 # rsyslog_conf_remote_templates
 #

--- a/roles/rsyslog/roles/output_roles/forwards/defaults/main.yaml
+++ b/roles/rsyslog/roles/output_roles/forwards/defaults/main.yaml
@@ -9,16 +9,14 @@ rsyslog_forwards_output_rules:
 
 # rsyslog_conf_forwards_output_rules:
 #
-# Enable log forwarding to another ``rsyslogd`` instance if it's enabled in
-# `rsyslog_forwards` variables.
+# Enable log forwarding to another ``rsyslogd`` instance if `rsyslog_forwards_actions` variables are defined.
 rsyslog_conf_forwards_output_rules:
 
   - name: 'output-forwards'
     type: 'output'
     suffix: 'system'
     path: '{{ rsyslog_config_dir }}'
-    state: '{{ "present"
-               if (rsyslog_forwards | d() or rsyslog_group_forwards | d() or rsyslog_host_forwards | d())
+    state: '{{ "present" if (rsyslog_forwards_actions | d())
                else "absent" }}'
     sections:
 
@@ -29,9 +27,37 @@ rsyslog_conf_forwards_output_rules:
 
       - comment: 'Forward logs to specified hosts'
         options: |-
-          {% for element in (rsyslog_forwards + rsyslog_group_forwards + rsyslog_host_forwards) %}
-          # start forwarding
-          {{ element }}
-          # end forwarding
+          {% for element in rsyslog_forwards_actions %}
+          {% if element.name is defined and element.target is defined %}
+          {% if element.severity is defined %}
+          {% if element.facility is defined %}
+          {% if element.exclude is defined %}
+          {{ element.facility }}.{{ element.severity }};{{ element.exclude }} action(name="{{ element.name }}" type="omfwd" Target="{{ element.target }}" Port="{{ element.port|d(514) }}" Protocol="{{ element.protocol|d('tcp') }}")
+          {% else %}
+          {{ element.facility }}.{{ element.severity }} action(name="{{ element.name }}" type="omfwd" Target="{{ element.target }}" Port="{{ element.port|d(514) }}" Protocol="{{ element.protocol|d('tcp') }}")
+          {% endif %}
+          {% else %}
+          {% if element.exclude is defined %}
+          *.{{ element.severity }};{{ element.exclude }} action(name="{{ element.name }}" type="omfwd" Target="{{ element.target }}" Port="{{ element.port|d(514) }}" Protocol="{{ element.protocol|d('tcp') }}")
+          {% else %}
+          *.{{ element.severity }} action(name="{{ element.name }}" type="omfwd" Target="{{ element.target }}" Port="{{ element.port|d(514) }}" Protocol="{{ element.protocol|d('tcp') }}")
+          {% endif %}
+          {% endif %}
+          {% else %}
+          {% if element.facility is defined %}
+          {% if element.exclude is defined %}
+          {{ element.facility }}.*;{{ element.exclude }} action(name="{{ element.name }}" type="omfwd" Target="{{ element.target }}" Port="{{ element.port|d(514) }}" Protocol="{{ element.protocol|d('tcp') }}")
+          {% else %}
+          {{ element.facility }}.* action(name="{{ element.name }}" type="omfwd" Target="{{ element.target }}" Port="{{ element.port|d(514) }}" Protocol="{{ element.protocol|d('tcp') }}")
+          {% endif %}
+          {% else %}
+          {% if element.exclude is defined %}
+          *.*;{{ element.exclude }} action(name="{{ element.name }}" type="omfwd" Target="{{ element.target }}" Port="{{ element.port|d(514) }}" Protocol="{{ element.protocol|d('tcp') }}")
+          {% else %}
+          *.* action(name="{{ element.name }}" type="omfwd" Target="{{ element.target }}" Port="{{ element.port|d(514) }}" Protocol="{{ element.protocol|d('tcp') }}")
+          {% endif %}
+          {% endif %}
+          {% endif %}
+          {% endif %}
 
           {% endfor %}

--- a/roles/rsyslog/roles/output_roles/forwards/tasks/main.yaml
+++ b/roles/rsyslog/roles/output_roles/forwards/tasks/main.yaml
@@ -6,5 +6,5 @@
 
 - name: Install/Update role packages and generate role configuration files for forwarding outputs
   include_role:
-    name: "{{ role_path }}/roles/rsyslog"
+    name: "{{ role_path }}/../../../"
     tasks_from: deploy.yaml

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -9,7 +9,7 @@
 
     - name: Set rsyslog_elasticsearch
       set_fact:
-        rsyslog_elasticsearch: "{{ rsyslog_elasticsearch | d([]) }} + {{ [  item.0 |combine( {'logs_collections_name': item.1.name} )] }}"
+        rsyslog_elasticsearch: "{{ rsyslog_elasticsearch | d([]) }} + {{ [ item.0 | combine( {'logs_collections_name': item.1.name} )] }}"
       with_subelements:
         - "{{ logging_outputs }}"
         - logs_collections
@@ -17,29 +17,31 @@
         - item.0.type | d('') == 'elasticsearch'
         - item.1.state | d('present') == 'present'
 
-    - name: Set rsyslog_files
+    - name: Set rsyslog_files_actions
       set_fact:
-        rsyslog_files: "{{ rsyslog_files | d([]) }} + {{ [  item.0|combine( {'logs_collections_name': item.1.name} )] }}"
+        rsyslog_files_actions: "{{ rsyslog_files_actions | d([]) }} + {{ item.0.rsyslog_files_actions }}"
       with_subelements:
         - "{{ logging_outputs }}"
         - logs_collections
       when:
         - item.0.type | d('') == 'files'
+        - item.0.rsyslog_files_actions is defined
         - item.1.state | d('present') == 'present'
 
-    - name: Set rsyslog_forwards
+    - name: Set rsyslog_forwards_actions
       set_fact:
-        rsyslog_forwards: "{{ rsyslog_forwards | d([]) }} + {{ [  item.0|combine( {'logs_collections_name': item.1.name} )] }}"
+        rsyslog_forwards_actions: "{{ rsyslog_forwards_actions | d([]) }} + {{ item.0.rsyslog_forwards_actions }}"
       with_subelements:
         - "{{ logging_outputs }}"
         - logs_collections
       when:
         - item.0.type | d('') == 'forwards'
+        - item.0.rsyslog_forwards_actions is defined
         - item.1.state | d('present') == 'present'
 
     - name: Set rsyslog_logs_collections
       set_fact:
-        rsyslog_logs_collections: "{{ rsyslog_logs_collections | d([]) }} + {{ [ { 'name': item.1.name, 'type': item.1.type, 'state': item.1.state | d('present'), 'output_name': item.0.name } ] }}"
+        rsyslog_logs_collections: "{{ rsyslog_logs_collections | d([]) }} + {{ [ item.1 | combine( {'output_name': item.0.name} )] }}"
       with_subelements:
         - "{{ logging_outputs }}"
         - logs_collections

--- a/tests/tests_default_files.yml
+++ b/tests/tests_default_files.yml
@@ -6,24 +6,11 @@
   tasks:
     - name: deploy config to output into local files
       vars:
-        logging_enabled: true
+        logging_enabled: True
+        rsyslog_default: False
         logging_outputs:
           - name: files-output
             type: files
-            rsyslog_files_actions:
-              - name: test0
-                severity: info
-                exclude: authpriv.none;auth.none;cron.none;mail.none
-                path: /var/log/messages
-              - name: test1
-                facility: authpriv,auth
-                path: /var/log/secure
-              - name: test2
-                severity: emerg
-                path: :omusrmsg:*
-              - name: test3
-                facility: local7
-                path: /var/log/boot.log
             logs_collections:
               - name: basic_input
                 type: basics
@@ -54,17 +41,22 @@
         path: "{{ test_files_conf }}"
       register: stat_output_files_system
 
+    - name: Get the forwarding config stat
+      stat:
+        path: "{{ test_files_conf }}"
+      register: stat_output_files_system
+
     - name: Check if the files config exists
       assert:
         that: stat_output_files_system.stat.exists == True
 
     - name: Grep output to messages line
-      command: /bin/grep ".var.log.messages" {{ test_files_conf }}
+      command: /bin/grep "\/var\/log\/messages" {{ test_files_conf }}
       register: files_conf_messages
 
     - name: Check the filter
       assert:
-        that: files_conf_messages.stdout is match("\*.info;*authpriv.none;auth.none;cron.none;mail.none.*.var.log.messages")
+        that: files_conf_messages.stdout is match("\*.info;mail.none;authpriv.none;cron.none.*messages")
 
     - name: Run logger to generate a test log message
       command: /bin/logger -i -p local6.info -t testTag0 testMessage0000

--- a/tests/tests_files_files.yml
+++ b/tests/tests_files_files.yml
@@ -1,0 +1,94 @@
+
+- name: Ensure that the role runs with parameters to output into local files
+  hosts: all
+  become: true
+
+  tasks:
+    - name: Set input file dir
+      set_fact:
+        test_inputfiles_dir: "/var/log/inputdirectory"
+
+    - name: deploy config to output into local files
+      vars:
+        logging_enabled: True
+        rsyslog_default: False
+        logging_outputs:
+          - name: files-output
+            type: files
+            rsyslog_files_actions:
+              - name: test0
+                severity: info
+                exclude: authpriv.none;auth.none;cron.none;mail.none
+                path: /var/log/messages
+              - name: test1
+                facility: authpriv,auth
+                path: /var/log/secure
+            logs_collections:
+              - name: files_input
+                type: files
+                rsyslog_input_log_path: "{{ test_inputfiles_dir }}/*.log"
+                rsyslog_input_log_tag: "newtag"
+      include_role:
+        name: linux-system-roles.logging
+
+    - include: set_rsyslog_variables.yml
+
+    # notify restart rsyslogd is executed at the end of this test task.
+    # thus we have to force to invoke handlers
+    - name: Force all notified handlers to run at this point, not waiting for normal sync points
+      meta: flush_handlers
+
+    - name: Check rsyslog.conf size
+      assert:
+        that: rsyslog_conf_line_count.stdout.0|int <= 7
+
+    - name: Check file counts in rsyslog.d
+      assert:
+        that: rsyslog_d_file_count.matched >= 9
+
+    - name: Set files config path
+      set_fact:
+        test_outputfiles_conf: "/etc/rsyslog.d/30-output-files.system"
+
+    - name: Get the output files config stat
+      stat:
+        path: "{{ test_outputfiles_conf }}"
+      register: stat_output_files_system
+
+    - name: Check if the output files config exists
+      assert:
+        that: stat_output_files_system.stat.exists == True
+
+    - name: Grep output to messages line
+      command: /bin/grep ".var.log.messages" {{ test_outputfiles_conf }}
+      register: files_conf_messages
+
+    - name: Set input files config path
+      set_fact:
+        test_inputfiles_conf: "/etc/rsyslog.d/90-imfile-input.conf"
+
+    - name: Get the files config stat
+      stat:
+        path: "{{ test_inputfiles_conf }}"
+      register: stat_input_files_conf
+
+    - name: Check if the input files config exists
+      assert:
+        that: stat_input_files_conf.stat.exists == True
+
+    - name: CAt input file
+      command: /bin/cat {{ test_inputfiles_conf }}
+      register: cat_file
+
+    - name: CAt input file 2
+      debug:
+        msg: cat_file.stdout
+
+    - name: Grep input file
+      command: /bin/grep 'inputdirectory' {{ test_inputfiles_conf }}
+      register: files_conf_input_file
+
+    - name: Check the filter
+      assert:
+        that: files_conf_input_file.stdout is match("input\(type=\"imfile\" file=\"\/var\/log\/inputdirectory\/\*\.log\" tag=\"newtag\"\)")
+

--- a/tests/tests_files_forwards.yml
+++ b/tests/tests_files_forwards.yml
@@ -6,9 +6,10 @@
   tasks:
     - name: deploy config to output into local files
       vars:
-        logging_enabled: true
+        logging_enabled: True
+        rsyslog_default: False
         logging_outputs:
-          - name: files-output
+          - name: output-files
             type: files
             rsyslog_files_actions:
               - name: test0
@@ -18,14 +19,25 @@
               - name: test1
                 facility: authpriv,auth
                 path: /var/log/secure
-              - name: test2
-                severity: emerg
-                path: :omusrmsg:*
-              - name: test3
-                facility: local7
-                path: /var/log/boot.log
             logs_collections:
-              - name: basic_input
+              - name: basic_input0
+                type: basics
+          - name: output-forwards
+            type: forwards
+            rsyslog_forwards_actions:
+              - name: severity_and_facility
+                facility: local1
+                severity: info
+                protocol: tcp
+                target: host.domain
+                port: 1514
+              - name: facility_only
+                facility: local2
+                protocol: tcp
+                target: host.domain
+                port: 2514
+            logs_collections:
+              - name: basic_input1
                 type: basics
       include_role:
         name: linux-system-roles.logging
@@ -76,4 +88,25 @@
     - name: Check if the test message is in /var/log/messages
       assert:
         that: testMessage0000.stdout != ""
+
+    - name: Set forwarding config path
+      set_fact:
+        test_forward_conf: "/etc/rsyslog.d/30-output-forwards.system"
+
+    - name: Get the forwarding config stat
+      stat:
+        path: "{{ test_forward_conf }}"
+      register: stat_output_forwards_system
+
+    - name: Check if the forwarding config exists
+      assert:
+        that: stat_output_forwards_system.stat.exists == True
+
+    - name: Grep severity_and_facility
+      command: /bin/grep "\<severity_and_facility\>" {{ test_forward_conf }}
+      register: severity_and_facility
+
+    - name: Check severity_and_facility
+      assert:
+        that: severity_and_facility.stdout is match("local1\.info action.name=.severity_and_facility.* Target=.host.domain. Port=.1514. Protocol=.tcp.*")
 

--- a/tests/tests_forwards.yml
+++ b/tests/tests_forwards.yml
@@ -1,0 +1,134 @@
+
+- name: Deploy rsyslog conf on the target host as a client
+  hosts: all
+  become: true
+
+  tasks:
+    - name: Deploy rsyslog config on the target host
+      vars:
+        logging_enabled: True
+        logging_purge_confs: True
+        rsyslog_default: False
+        logging_outputs:
+          - name: output-forwards
+            type: forwards
+            rsyslog_forwards_actions:
+              - name: severity_and_facility
+                facility: local1
+                severity: info
+                protocol: tcp
+                target: host.domain
+                port: 1514
+              - name: facility_only
+                facility: local2
+                protocol: tcp
+                target: host.domain
+                port: 2514
+              - name: severity_only
+                severity: err
+                protocol: tcp
+                target: host.domain
+                port: 3514
+              - name: no_severity_and_facility
+                protocol: tcp
+                target: host.domain
+                port: 4514
+              - name: no_severity_and_facility_protocol
+                target: host.domain
+                port: 5514
+              - name: no_severity_and_facility_udp
+                protocol: udp
+                target: host.domain
+                port: 6514
+              - name: no_severity_and_facility_protocol_port
+                target: host.domain
+              - name: no_severity_and_facility_protocol_port_target
+              - target: no_name.localdomain
+            logs_collections:
+              - name: basic_input
+                type: basics
+
+      include_role:
+        name: linux-system-roles.logging
+
+    - name: Set forwarding config path
+      set_fact:
+        test_forward_conf: "/etc/rsyslog.d/30-output-forwards.system"
+
+    - name: Get the forwarding config stat
+      stat:
+        path: "{{ test_forward_conf }}"
+      register: stat_output_forwards_system
+
+    - name: Check if the forwarding config exists
+      assert:
+        that: stat_output_forwards_system.stat.exists == True
+
+    - name: Grep severity_and_facility
+      command: /bin/grep "\<severity_and_facility\>" {{ test_forward_conf }}
+      register: severity_and_facility
+
+    - name: Check severity_and_facility
+      assert:
+        that: severity_and_facility.stdout is match("local1\.info action.name=.severity_and_facility.* Target=.host.domain. Port=.1514. Protocol=.tcp.*")
+
+    - name: Grep facility_only
+      command: /bin/grep "\<facility_only\>" {{ test_forward_conf }}
+      register: facility_only
+
+    - name: Check facility_only
+      assert:
+        that: facility_only.stdout is match("local2\.\* action.name=.facility_only.* Target=.host.domain. Port=.2514. Protocol=.tcp.")
+
+    - name: Grep severity_only
+      command: /bin/grep "\<severity_only\>" {{ test_forward_conf }}
+      register: severity_only
+
+    - name: Check severity_only
+      assert:
+        that: severity_only.stdout is match("\*\.err action.name=.severity_only.* Target=.host.domain. Port=.3514. Protocol=.tcp.*")
+
+    - name: Grep no_severity_and_facility
+      command: /bin/grep "\<no_severity_and_facility\>" {{ test_forward_conf }}
+      register: no_severity_and_facility
+
+    - name: Check no_severity_and_facility
+      assert:
+        that: no_severity_and_facility.stdout is match("\*\.\* action.name=.no_severity_and_facility.* Target=.host.domain. Port=.4514. Protocol=.tcp.")
+
+    - name: Grep no_severity_and_facility_protocol
+      command: /bin/grep "\<no_severity_and_facility_protocol\>" {{ test_forward_conf }}
+      register: no_severity_and_facility_protocol
+
+    - name: Check no_severity_and_facility_protocol
+      assert:
+        that: no_severity_and_facility_protocol.stdout is match("\*\.\* action.name=.no_severity_and_facility_protocol.* Target=.host.domain. Port=.5514. Protocol=.tcp.")
+
+    - name: Grep no_severity_and_facility_udp
+      command: /bin/grep "\<no_severity_and_facility_udp\>" {{ test_forward_conf }}
+      register: no_severity_and_facility_udp
+
+    - name: Check no_severity_and_facility_udp
+      assert:
+        that: no_severity_and_facility_udp.stdout is match("\*\.\* action.name=.no_severity_and_facility_udp.* Target=.host.domain. Port=.6514. Protocol=.udp.")
+
+    - name: Grep no_severity_and_facility_protocol_port
+      command: /bin/grep "\<no_severity_and_facility_protocol_port\>" {{ test_forward_conf }}
+      register: no_severity_and_facility_protocol_port
+
+    - name: Check no_severity_and_facility_protocol_port
+      assert:
+        that: no_severity_and_facility_protocol_port.stdout is match("\*\.\* action.name=.no_severity_and_facility_protocol_port.* Target=.host.domain. Port=.514. Protocol=.tcp.")
+
+    - name: Grep no_severity_and_facility_protocol_port_target
+      command: /bin/grep "\<no_severity_and_facility_protocol_port_target\>" {{ test_forward_conf }}
+      register: result
+      failed_when: result.rc != 1
+
+    - name: Grep no_name
+      command: /bin/grep "\<no_name\.localdomain\>" {{ test_forward_conf }}
+      register: result
+      failed_when: result.rc != 1
+
+# - name: no_severity_and_facility_protocol_port_target
+# - target: no_name.localdomain

--- a/tests/tests_listen.yml
+++ b/tests/tests_listen.yml
@@ -13,7 +13,7 @@
           - name: files-output
             type: files
             logs_collections:
-              - name: input
+              - name: basic_input
                 type: basics
 
       include_role:


### PR DESCRIPTION
…utputs based on severity and facility

- Adding rsyslog_filter_actions, which is an array of dictionary to specify
  files to store logs for files outputs or forward target host to redirect
  the logs to the remote rsyslog servers for forwards output.
- Adding test cases:
  tests_default_files.yml - outputs to default local files
  tests_files.yml - outputs to configured local files
  tests_forwards.yml - sends to remote hosts