### PR TITLE
Fixing package module related issues.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
     - MOLECULE_DISTRO="fedora:30"
     - MOLECULE_DISTRO="fedora:31"
 install:
-  - pip install molecule docker
+  - pip install 'molecule<3' docker
   # workaround until https://github.com/ansible/molecule/issues/1727 is fixed
   - pip uninstall -y testinfra
   - pip install testinfra

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ The `defaults` directory includes:
 
 The `tasks` directory includes 2 tasks file:
   - `main.yaml` - tasks for deploying the config files
-    This file is sets `rsyslog_role_packages` and `rsyslog_role_rules` and includes the task that deploys the files.
+    This file is sets `__rsyslog_packages` and `__rsyslog_rules` and includes the task that deploys the files.
   - `cleanup.yml` - tasks that cleanup the files deployed for this project.
 
 Examples can be found in the existing projects.

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ out while developing.  This is best done by installing molecule in a virtualenv:
 ```
 $ virtualenv .venv
 $ source .venv/bin/activate
-$ pip install molecule docker
+$ pip install 'molecule<3' docker
 ```
 
 It is required to run the tests as a user who is authorized to run the 'docker' command

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ Each project adds a sub-role to [input_roles](https://github.com/linux-system-ro
 
 The sub-role usually includes `tasks` and `defaults` directories.
 The `defaults` directory includes:
-  - List of required packages that are **not** the base rsyslog_base_packages: ['rsyslog', 'libselinux-python']
+  - List of required packages that are **not** the base rsyslog_base_packages: ['rsyslog']
   - List of modules to load  like `imfile`, `imtcp`, etc.
   - Defines the formatting and the rulebases for parsing the logs.
   - It is required to set for all logs the project identfier for pipelining:

--- a/roles/rsyslog/README.md
+++ b/roles/rsyslog/README.md
@@ -264,6 +264,7 @@ Common sub-variables
 - `rsyslog_config_dir`: Directory to store configuration files.  Default to '/etc/rsyslog.d'.
 - `rsyslog_custom_config_files`: List of custom configuration files are deployed to /etc/rsyslog.d.  The format is an array which element is the full path to each custom configuration file.  Default to none.
 - `rsyslog_group`: Owner group of rsyslogd.  Default to 'syslog' if `rsyslog_unprivileged` is true.  Otherwise, 'root'.
+- `rsyslog_in_image`: Specifies if the target host is a container and use rsyslog in the image. Default to false.
 - `rsyslog_purge_original_conf`: By default, the Rsyslog configuration files are applied on top of pre-existing configuration files. To purge local files prior to setting new ones, set `rsyslog_purge_original_conf` variable to 'true', it will move all Rsyslog configuration files to a backup directory before deploying the new configuration files. Defaults to 'false'.
 - `rsyslog_system_log_dir`: System log directory.  Default to '/var/log'.
 - `rsyslog_unprivileged`: If set to true, you could specify non-root `rsyslog_user` and `rsyslog_group`.  If ansible_distribution is one of "CentOS", "RedHat", and "Fedora", default to true.  Otherwise, 'false'.
@@ -340,9 +341,9 @@ Describing how the configuration files are defined to be deployed using the viaq
 
 Viaq configuration files are defined in {{ __rsyslog_viaq_rules }} in /roles/input_roles/viaq/defaults/main.yaml.  The set is made from the generic modules{__rsyslog_conf_global_options, __rsyslog_conf_local_modules, __rsyslog_conf_common_defaults} and viaq specific configurations.
 
-To make a new configuration file installed in addition to the current {{ rsyslog_viaq_rules }}, create an rsyslog config item based on the following skelton and add the title {{ rsyslog_conf_yourname }} to {{ rsyslog_viaq_rules }}.
+If you are a role developer and planning to add a new default configuration to the role depo, create an rsyslog config item based on the following skelton and add the title {{ __rsyslog_conf_yourname }} to {{ __rsyslog_viaq_rules }}.
 ```
-rsyslog_conf_yourname:
+__rsyslog_conf_yourname:
 
   - name: some_name
     type: choose one of 'global' 'module' 'modules' 'template' 'templates' 'output' 'service' 'rule' 'rules' 'ruleset' 'input'

--- a/roles/rsyslog/README.md
+++ b/roles/rsyslog/README.md
@@ -338,7 +338,7 @@ WARNING: Pre-existing rsyslog.conf and configuration files in /etc/rsyslog.d are
 
 Describing how the configuration files are defined to be deployed using the viaq case.
 
-Viaq configuration files are defined in {{ rsyslog_viaq_rules }} in /roles/input_rols/viaq/defaults/main.yaml.  The set is made from the generic modules{rsyslog_conf_global_options, rsyslog_conf_local_modules, rsyslog_conf_network_modules, rsyslog_conf_common} and viaq specific configurations.
+Viaq configuration files are defined in {{ __rsyslog_viaq_rules }} in /roles/input_roles/viaq/defaults/main.yaml.  The set is made from the generic modules{__rsyslog_conf_global_options, __rsyslog_conf_local_modules, __rsyslog_conf_common_defaults} and viaq specific configurations.
 
 To make a new configuration file installed in addition to the current {{ rsyslog_viaq_rules }}, create an rsyslog config item based on the following skelton and add the title {{ rsyslog_conf_yourname }} to {{ rsyslog_viaq_rules }}.
 ```

--- a/roles/rsyslog/defaults/main.yaml
+++ b/roles/rsyslog/defaults/main.yaml
@@ -7,6 +7,11 @@
 # Enable or disable ``rsyslog`` management.
 rsyslog_enabled: true
 
+# rsyslog_in_image
+#
+# true if the target host is a container and use rsyslog in the image.
+rsyslog_in_image: false
+
 # rsyslog_default
 #
 # Diploy default ``rsyslog`` configuration file /etc/rsyslog.conf if it is set to true.
@@ -54,23 +59,15 @@ rsyslog_message_reduction: false
 rsyslog_purge_original_conf: false
 
 # rpm packages
-# adding rsyslog_logging_packages
+# adding rsyslog packages
 # ------------------
 
-# rsyslog_base_packages
+# rsyslog_extra_packages
 #
-# List of default rpm packages to install.
-rsyslog_base_packages: ['rsyslog']
-
-# rsyslog_tls_packages
-#
-# List of rpm packages required for TLS support.
-rsyslog_tls_packages: ['rsyslog-gnutls', 'ca-certificates']
-
-# rsyslog_packages
-#
-# List of additional rpm packages to install.
-rsyslog_packages: []
+# List of extra rpm packages to install.
+# If custom configurations are to be installed, which requires additional rsyslog
+# packages, this variable can be used to install them.
+rsyslog_extra_packages: []
 
 # rsyslog_custom_config_files
 #
@@ -271,8 +268,6 @@ rsyslog_forwards_actions: []
 #
 # If you change the default weight map values, you will most likely need to
 # remove all files from `{{ rsyslog_config_dir }}` to reset the configuration.
-#
-# See :ref:`rsyslog_rules` for more details.
 rsyslog_weight_map:
   'global': '05'
   'globals': '05'
@@ -322,29 +317,28 @@ rsyslog_host_rules: []
 # details. This list should be used for configuration by other Ansible roles.
 rsyslog_dependent_rules: []
 
-# rsyslog_.*_rules
+# __rsyslog_.*_rules
 #
 # List of YAML dictionaries, each dictionary should contain ``rsyslogd``
-# configuration in a special format. See :ref:`rsyslog_rules` for more
-# details. This lis specifies default ``rsyslogd`` configuration enabled in the
-# role.
-rsyslog_common_rules:
+# configuration in a special format. This lis specifies default ``rsyslogd``
+# configuration enabled in the role.
+__rsyslog_common_rules:
 
-  - '{{ rsyslog_conf_global_options }}'
-  - '{{ rsyslog_conf_local_modules }}'
-  - '{{ rsyslog_conf_common_defaults }}'
-  - '{{ rsyslog_conf_send_targets_only }}'
+  - '{{ __rsyslog_conf_global_options }}'
+  - '{{ __rsyslog_conf_local_modules }}'
+  - '{{ __rsyslog_conf_common_defaults }}'
+  - '{{ __rsyslog_conf_send_targets_only }}'
 
 
 # Default configuration options
 # -----------------------------
 
-# rsyslog_conf_global_options
+# __rsyslog_conf_global_options
 #
 # Some of the global ``rsyslogd`` configuration options. See
 # http://www.rsyslog.com/doc/v8-stable/rainerscript/global.html for more
 # details.
-rsyslog_conf_global_options:
+__rsyslog_conf_global_options:
 
   - filename: '00-global.conf'
     comment: 'Global options'
@@ -366,11 +360,11 @@ rsyslog_conf_global_options:
       {% endif %}
       )
 
-# rsyslog_conf_local_modules
+# __rsyslog_conf_local_modules
 #
 # List of ``rsyslogd`` modules that enable logs from the local system to be
 # received and parsed by the ``rsyslogd`` daemon.
-rsyslog_conf_local_modules:
+__rsyslog_conf_local_modules:
 
   - name: 'local-modules'
     type: 'modules'
@@ -383,11 +377,11 @@ rsyslog_conf_local_modules:
                   if ("mark" in rsyslog_capabilities)
                   else "absent" }}'
 
-# rsyslog_conf_common_defaults
+# __rsyslog_conf_common_defaults
 #
 # List of common ``rsyslogd`` configuration, like new file owner/group and
 # permissions, work directory, configuration of message reduction.
-rsyslog_conf_common_defaults:
+__rsyslog_conf_common_defaults:
 
   - name: 'common-defaults'
     type: 'global'
@@ -409,7 +403,7 @@ rsyslog_conf_common_defaults:
         options: |-
           $RepeatedMsgReduction {{ "on" if rsyslog_message_reduction | bool else "off" }}
 
-rsyslog_conf_send_targets_only:
+__rsyslog_conf_send_targets_only:
 
   - name: 'send-targets-only'
     type: 'output'

--- a/roles/rsyslog/defaults/main.yaml
+++ b/roles/rsyslog/defaults/main.yaml
@@ -320,7 +320,7 @@ rsyslog_dependent_rules: []
 # __rsyslog_.*_rules
 #
 # List of YAML dictionaries, each dictionary should contain ``rsyslogd``
-# configuration in a special format. This lis specifies default ``rsyslogd``
+# configuration in a special format. This list specifies default ``rsyslogd``
 # configuration enabled in the role.
 __rsyslog_common_rules:
 

--- a/roles/rsyslog/roles/README.md
+++ b/roles/rsyslog/roles/README.md
@@ -21,7 +21,7 @@ The `defaults` directory includes:
 
 The `tasks` directory includes 2 tasks file:
   - `main.yaml` - tasks for deploying the config files
-    This file is sets `rsyslog_role_packages` and `rsyslog_role_rules` and includes the task that deploys the files.
+    This file is sets `__rsyslog_packages` and `__rsyslog_rules` and includes the task that deploys the files.
   - `cleanup.yml` - tasks that cleanup the files deployed for this project.
 
 Examples can be found in the existing projects.

--- a/roles/rsyslog/roles/README.md
+++ b/roles/rsyslog/roles/README.md
@@ -10,7 +10,7 @@ Each project adds a sub-role to ./logging/roles/rsyslog/roles/input_roles/.
 
 The sub-role usually includes `tasks` and `defaults` directories.
 The `defaults` directory includes:
-  - List of required packages that are **not** the base rsyslog_base_packages: ['rsyslog', 'libselinux-python']
+  - List of required packages that are **not** the base rsyslog_base_packages: ['rsyslog']
   - List of modules to load  like `imfile`, `imtcp`, etc.
   - Defines the formatting and the rulebases for parsing the logs.
   - It is required to set for all logs the project identfier for pipelining:
@@ -19,9 +19,9 @@ The `defaults` directory includes:
   - If `rsyslog_default` equals to "true", It is required to set for all logs you don't want to be processed by the default rules:
     set $.send_targets_only = "true";
 
-The `tasks` directory includes 2 tasks file:
+The `tasks` directory includes 2 task files:
   - `main.yaml` - tasks for deploying the config files
-    This file is sets `__rsyslog_packages` and `__rsyslog_rules` and includes the task that deploys the files.
+    This file sets `__rsyslog_packages` and `__rsyslog_rules` and includes the task that deploys the files.
   - `cleanup.yml` - tasks that cleanup the files deployed for this project.
 
 Examples can be found in the existing projects.

--- a/roles/rsyslog/roles/input_roles/basics/defaults/main.yaml
+++ b/roles/rsyslog/roles/input_roles/basics/defaults/main.yaml
@@ -12,7 +12,6 @@ rsyslog_unprivileged: false
 #       Note: unles rsyslog_send_over_tls_only is set to true, insecure network connection
 #       is also allowed.
 rsyslog_capabilities: []
-rsyslog_basics_packages: ['rsyslog-gnutls']
 
 rsyslog_use_imuxsock: false
 
@@ -22,25 +21,25 @@ rsyslog_use_imuxsock: false
 rsyslog_input_log_path: "/var/log/containers/*.log"
 rsyslog_input_log_tag: "container"
 
-# rsyslog_basics_rules
+# __rsyslog_basics_rules
 #
 # List of YAML dictionaries, each dictionary should contain ``rsyslogd``
 # configuration in a special format. See :ref:`rsyslog_rules` for more
 # details. This list specifies basics ``rsyslogd`` example configuration.
-rsyslog_basics_rules:
-  - '{{ rsyslog_conf_local_basics_modules }}'
-  - '{{ rsyslog_conf_default_rulesets }}'
-  - '{{ rsyslog_conf_system_input }}'
-  - '{{ rsyslog_conf_network_input }}'
+__rsyslog_basics_rules:
+  - '{{ __rsyslog_conf_local_basics_modules }}'
+  - '{{ __rsyslog_conf_default_rulesets }}'
+  - '{{ __rsyslog_conf_system_input }}'
+  - '{{ __rsyslog_conf_network_input }}'
 
 # Debops example configuration options
 # --------------------------------------------
 
-# rsyslog_conf_local_modules
+# __rsyslog_conf_local_modules
 #
 # List of ``rsyslogd`` modules that enable logs from the local system to be
 # received and parsed by the ``rsyslogd`` daemon.
-rsyslog_conf_local_basics_modules:
+__rsyslog_conf_local_basics_modules:
 
   - name: 'local-basics-modules'
     type: 'modules'
@@ -92,7 +91,7 @@ rsyslog_conf_local_basics_modules:
                   if ("network" in rsyslog_capabilities) and ("tls" in rsyslog_capabilities)
                   else "absent" }}'
 
-# rsyslog_conf_default_rulesets
+# __rsyslog_conf_default_rulesets
 #
 # The ``rsyslogd`` configuration can contain multiple rulesets, each one
 # connected to an input channel (see
@@ -104,7 +103,7 @@ rsyslog_conf_local_basics_modules:
 # network from remote hosts. The local log rules are stored in
 # `{{ rsyslog_config_dir }}/*.system` configuration files, and remote log
 # rules are stored in `{{ rsyslog_config_dir }}/*.remote` configuration files.
-rsyslog_conf_default_rulesets:
+__rsyslog_conf_default_rulesets:
 
   - name: 'default-rulesets'
     type: 'rules'
@@ -123,9 +122,9 @@ rsyslog_conf_default_rulesets:
                   if ("network" in rsyslog_capabilities)
                   else "absent" }}'
 
-# rsyslog_conf_system_input
+# __rsyslog_conf_system_input
 #
-rsyslog_conf_system_input:
+__rsyslog_conf_system_input:
 
   - name: 'system-input'
     type: 'input'
@@ -138,11 +137,11 @@ rsyslog_conf_system_input:
                   if rsyslog_use_imuxsock | d(false) | bool
                   else "absent" }}'
 
-# rsyslog_conf_network_input
+# __rsyslog_conf_network_input
 #
 # Configuration of UDP, TCP and TCP over TLS inputs to receive logs from remote
 # hosts, enabled by the ``network`` capability.
-rsyslog_conf_network_input:
+__rsyslog_conf_network_input:
 
   - name: 'network-input'
     type: 'input'

--- a/roles/rsyslog/roles/input_roles/basics/tasks/cleanup.yaml
+++ b/roles/rsyslog/roles/input_roles/basics/tasks/cleanup.yaml
@@ -1,9 +1,8 @@
 ---
-- name: Set basics facts
-  set_fact:
-    rsyslog_role_rules: "{{ rsyslog_basics_rules }}"
-
+# Deploy configuration files
 - name: Remove basics example config files from rsyslog.d
+  vars:
+    __rsyslog_rules: "{{ __rsyslog_basics_rules }}"
   include_role:
     name: "{{ role_path }}/../../../"
     tasks_from: cleanup.yaml

--- a/roles/rsyslog/roles/input_roles/basics/tasks/main.yaml
+++ b/roles/rsyslog/roles/input_roles/basics/tasks/main.yaml
@@ -1,10 +1,9 @@
 ---
-- name: Set basics facts
-  set_fact:
-    rsyslog_role_packages: "{{rsyslog_basics_packages | flatten | d([])}}"
-    rsyslog_role_rules: "{{ rsyslog_basics_rules }}"
-
+# Deploy configuration files
 - name: Install/Update basics role packages and generate example configuration files to role subdir
+  vars:
+    __rsyslog_packages: "{{ __rsyslog_basics_packages }}"
+    __rsyslog_rules: "{{ __rsyslog_basics_rules }}"
   include_role:
     name: "{{ role_path }}/../../../"
     tasks_from: deploy.yaml

--- a/roles/rsyslog/roles/input_roles/basics/vars/main.yaml
+++ b/roles/rsyslog/roles/input_roles/basics/vars/main.yaml
@@ -1,0 +1,4 @@
+# __rsyslog_basics_packages
+#
+# List of default rpm packages to install.
+__rsyslog_basics_packages: []

--- a/roles/rsyslog/roles/input_roles/files/defaults/main.yaml
+++ b/roles/rsyslog/roles/input_roles/files/defaults/main.yaml
@@ -2,7 +2,7 @@
 # Imfile configuration setting
 # ----------------------------
 
-rsyslog_unprivileged: False
+rsyslog_unprivileged: false
 
 # rsyslog_capabilities is an array which takes 'network', 'remote-files', 'tls'
 # 'network' enables input and output over network.
@@ -11,7 +11,7 @@ rsyslog_unprivileged: False
 #       Note: unles rsyslog_send_over_tls_only is set to true, insecure network connection
 #       is also allowed.
 rsyslog_capabilities: []
-rsyslog_files_input_packages: []
+__rsyslog_files_input_packages: []
 
 rsyslog_input_log_path: "/var/log/containers/*.log"
 rsyslog_input_log_tag: "container"
@@ -21,19 +21,19 @@ rsyslog_input_log_tag: "container"
 # List of YAML dictionaries, each dictionary should contain ``rsyslogd``
 # configuration in a special format. See :ref:`rsyslog_rules` for more
 # details. This list specifies imfile ``rsyslogd`` example configuration.
-rsyslog_files_input_rules:
-  - '{{ rsyslog_conf_imfile_modules }}'
-  - '{{ rsyslog_conf_imfile_rulesets }}'
-  - '{{ rsyslog_conf_imfile_inputs }}'
+__rsyslog_files_input_rules:
+  - '{{ __rsyslog_conf_imfile_modules }}'
+  - '{{ __rsyslog_conf_imfile_rulesets }}'
+  - '{{ __rsyslog_conf_imfile_inputs }}'
 
 # Debops example configuration options
 # --------------------------------------------
 
-# rsyslog_conf_local_modules
+# __rsyslog_conf_local_modules
 #
 # List of ``rsyslogd`` modules that enable logs from the local system to be
 # received and parsed by the ``rsyslogd`` daemon.
-rsyslog_conf_imfile_modules:
+__rsyslog_conf_imfile_modules:
 
   - name: 'imfile-modules'
     type: 'modules'
@@ -43,9 +43,9 @@ rsyslog_conf_imfile_modules:
         options: |-
           module(load="imfile" mode="inotify")
 
-# rsyslog_conf_imfile_rulesets
+# __rsyslog_conf_imfile_rulesets
 #
-rsyslog_conf_imfile_rulesets:
+__rsyslog_conf_imfile_rulesets:
 
   - name: 'imfile-rulesets'
     type: 'rules'
@@ -57,9 +57,9 @@ rsyslog_conf_imfile_rulesets:
             $IncludeConfig {{rsyslog_config_dir}}/*.files
           }
 
-# rsyslog_conf_system_inputs
+# __rsyslog_conf_system_inputs
 #
-rsyslog_conf_imfile_inputs:
+__rsyslog_conf_imfile_inputs:
 
   - name: 'imfile-input'
     type: 'input'
@@ -68,7 +68,7 @@ rsyslog_conf_imfile_inputs:
       - comment: 'Log messages from log files'
         options: |-
           # FIXME: Need to normalize a log before passing it to elasticsearch output
-          {% if rsyslog_elasticsearch is defined and rsyslog_elasticsearch|length > 0 %}
+          {% if rsyslog_elasticsearch is defined and rsyslog_elasticsearch | length > 0 %}
 
           {% for element in rsyslog_logs_collections %}
           {% if element.name is defined and element.type == "files" %}

--- a/roles/rsyslog/roles/input_roles/files/defaults/main.yaml
+++ b/roles/rsyslog/roles/input_roles/files/defaults/main.yaml
@@ -16,7 +16,7 @@ __rsyslog_files_input_packages: []
 rsyslog_input_log_path: "/var/log/containers/*.log"
 rsyslog_input_log_tag: "container"
 
-# rsyslog_files_input_rules
+# __rsyslog_files_input_rules
 #
 # List of YAML dictionaries, each dictionary should contain ``rsyslogd``
 # configuration in a special format. See :ref:`rsyslog_rules` for more
@@ -68,7 +68,7 @@ __rsyslog_conf_imfile_inputs:
       - comment: 'Log messages from log files'
         options: |-
           # FIXME: Need to normalize a log before passing it to elasticsearch output
-          {% if rsyslog_elasticsearch is defined and rsyslog_elasticsearch | length > 0 %}
+          {% if rsyslog_elasticsearch is defined and rsyslog_elasticsearch %}
 
           {% for element in rsyslog_logs_collections %}
           {% if element.name is defined and element.type == "files" %}

--- a/roles/rsyslog/roles/input_roles/files/tasks/cleanup.yaml
+++ b/roles/rsyslog/roles/input_roles/files/tasks/cleanup.yaml
@@ -1,10 +1,8 @@
 ---
-- name: Set input files facts
-  set_fact:
-    rsyslog_role_packages: "{{ rsyslog_files_input_packages|flatten }}"
-    rsyslog_role_rules: "{{ rsyslog_files_input_rules }}"
-
+# Deploy configuration files
 - name: Remove input files example config files from rsyslog.d
+  vars:
+    __rsyslog_rules: "{{ rsyslog_files_input_rules }}"
   include_role:
     name: "{{ role_path }}/../../../"
     tasks_from: cleanup.yaml

--- a/roles/rsyslog/roles/input_roles/files/tasks/cleanup.yaml
+++ b/roles/rsyslog/roles/input_roles/files/tasks/cleanup.yaml
@@ -2,7 +2,7 @@
 # Deploy configuration files
 - name: Remove input files example config files from rsyslog.d
   vars:
-    __rsyslog_rules: "{{ rsyslog_files_input_rules }}"
+    __rsyslog_rules: "{{ __rsyslog_files_input_rules }}"
   include_role:
     name: "{{ role_path }}/../../../"
     tasks_from: cleanup.yaml

--- a/roles/rsyslog/roles/input_roles/files/tasks/main.yaml
+++ b/roles/rsyslog/roles/input_roles/files/tasks/main.yaml
@@ -2,7 +2,7 @@
 # Deploy configuration files
 - name: Install/Update input files role packages and generate example configuration files to role subdir
   vars:
-    __rsyslog_packages: "{{ __rsyslog_files_input_packages | flatten }}"
+    __rsyslog_packages: "{{ __rsyslog_files_input_packages }}"
     __rsyslog_rules: "{{ __rsyslog_files_input_rules }}"
   include_role:
     name: "{{ role_path }}/../../../"

--- a/roles/rsyslog/roles/input_roles/files/tasks/main.yaml
+++ b/roles/rsyslog/roles/input_roles/files/tasks/main.yaml
@@ -1,10 +1,9 @@
 ---
-- name: Set input files facts
-  set_fact:
-    rsyslog_role_packages: "{{ rsyslog_files_input_packages|flatten }}"
-    rsyslog_role_rules: "{{ rsyslog_files_input_rules }}"
-
+# Deploy configuration files
 - name: Install/Update input files role packages and generate example configuration files to role subdir
+  vars:
+    __rsyslog_packages: "{{ __rsyslog_files_input_packages | flatten }}"
+    __rsyslog_rules: "{{ __rsyslog_files_input_rules }}"
   include_role:
     name: "{{ role_path }}/../../../"
     tasks_from: deploy.yaml

--- a/roles/rsyslog/roles/input_roles/ovirt/defaults/main.yaml
+++ b/roles/rsyslog/roles/input_roles/ovirt/defaults/main.yaml
@@ -6,16 +6,10 @@
 # adding rsyslog_logging_packages
 # ------------------
 
-# .. envvar:: rsyslog_logging_packages
-#
-# List of rpm packages for Common Logging.
-rsyslog_ovirt_packages: ['rsyslog-mmnormalize', 'rsyslog-mmjsonparse', 'libfastjson', 'liblognorm', 'libestr']
-rsyslog_ovirt_prereq_packages: []
-
 # Available configuration set
 # ----------------------------
 
-rsyslog_unprivileged: 'False'
+rsyslog_unprivileged: false
 
 rsyslog_elasticsearch: []
 
@@ -23,7 +17,7 @@ rsyslog_elasticsearch: []
 # oVirt Rsyslog configuration rules
 # ---------------------------
 
-rsyslog_ovirt_rules:
+__rsyslog_ovirt_rules:
   - '{{ rsyslog_conf_local_ovirt_modules }}'
   - '{{ rsyslog_conf_ovirt_main_modules }}'
   - '{{ rsyslog_conf_ovirt_formatting }}'

--- a/roles/rsyslog/roles/input_roles/ovirt/tasks/cleanup.yaml
+++ b/roles/rsyslog/roles/input_roles/ovirt/tasks/cleanup.yaml
@@ -1,9 +1,8 @@
 ---
-- name: Set oVirt facts
-  set_fact:
-    rsyslog_role_rules: "{{ rsyslog_ovirt_rules }}"
-
+# Deploy configuration files
 - name: Remove oVirt configs
+  vars:
+    __rsyslog_rules: "{{ __rsyslog_ovirt_rules }}"
   include_role:
     name: "{{ role_path }}/../../../"
     tasks_from: cleanup.yaml

--- a/roles/rsyslog/roles/input_roles/ovirt/tasks/main.yaml
+++ b/roles/rsyslog/roles/input_roles/ovirt/tasks/main.yaml
@@ -1,17 +1,16 @@
 ---
-- name: Set oVirt facts
-  set_fact:
-    rsyslog_role_packages: "{{ rsyslog_ovirt_prereq_packages|flatten|d([]) }}+{{ rsyslog_ovirt_packages|flatten|d([]) }}"
-    rsyslog_role_rules: "{{ rsyslog_ovirt_rules }}"
-
+# Deploy configuration files
 - name: Install/Update role packages and generate role configuration files to role subdir
+  vars:
+    __rsyslog_packages: "{{ __rsyslog_ovirt_prereq_packages | d([]) + __rsyslog_ovirt_packages | d([]) }}"
+    __rsyslog_rules: "{{ __rsyslog_ovirt_rules }}"
   include_role:
     name: "{{ role_path }}/../../../"
     tasks_from: deploy.yaml
 
 - name: Allow rsyslog to listen on collectd port
   seport:
-    ports: "{{ rsyslog_read_collectd_port|d(44514) }}"
+    ports: "{{ rsyslog_read_collectd_port | d(44514) }}"
     proto: tcp
     setype: syslogd_port_t
     state: present

--- a/roles/rsyslog/roles/input_roles/ovirt/vars/main.yaml
+++ b/roles/rsyslog/roles/input_roles/ovirt/vars/main.yaml
@@ -1,0 +1,5 @@
+# __rsyslog_ovirt_packages
+#
+# List of rpm packages for Common Logging.
+__rsyslog_ovirt_packages: ['rsyslog-mmnormalize', 'rsyslog-mmjsonparse', 'libfastjson', 'liblognorm', 'libestr']
+__rsyslog_ovirt_prereq_packages: []

--- a/roles/rsyslog/roles/input_roles/viaq-k8s/defaults/main.yaml
+++ b/roles/rsyslog/roles/input_roles/viaq-k8s/defaults/main.yaml
@@ -2,7 +2,7 @@
 # Viaq configuration
 # ---------------------
 
-# .. envvar:: rsyslog_viaq_log_dir
+# rsyslog_viaq_log_dir
 #
 # Viaq log directory
 rsyslog_viaq_log_dir: '{{ rsyslog_system_log_dir }}/containers'
@@ -11,24 +11,19 @@ rsyslog_viaq_log_dir: '{{ rsyslog_system_log_dir }}/containers'
 # adding rsyslog_logging_packages
 # ------------------
 
-# .. envvar:: rsyslog_viaq_k8s_packages
-#
-# List of rpm packages for Common Logging.
-rsyslog_viaq_k8s_packages: ['rsyslog-mmjsonparse', 'rsyslog-mmkubernetes']
-
 # Available configuration set
 # ----------------------------
 
 # Viaq Rsyslog configuration rules
 # ---------------------------
 
-rsyslog_viaq_k8s_rules:
+__rsyslog_viaq_k8s_rules:
 
-  - '{{ rsyslog_conf_viaq_mmk8s_module }}'
-  - '{{ rsyslog_conf_viaq_mmk8s_input }}'
-  - '{{ rsyslog_rulebase_viaq_k8s_filename }}'
-  - '{{ rsyslog_rulebase_viaq_k8s_container_name }}'
-  - '{{ rsyslog_rulebase_viaq_crio }}'
+  - '{{ __rsyslog_conf_viaq_mmk8s_module }}'
+  - '{{ __rsyslog_conf_viaq_mmk8s_input }}'
+  - '{{ __rsyslog_rulebase_viaq_k8s_filename }}'
+  - '{{ __rsyslog_rulebase_viaq_k8s_container_name }}'
+  - '{{ __rsyslog_rulebase_viaq_crio }}'
 
 # Default Viaq-k8s configuration options
 # ---------------------------------
@@ -36,7 +31,7 @@ rsyslog_viaq_k8s_rules:
 logging_mmk8s_ca_cert: ''
 logging_mmk8s_token: ''
 
-rsyslog_conf_viaq_mmk8s_module:
+__rsyslog_conf_viaq_mmk8s_module:
 
   - name: 'mmk8s'
     type: 'modules'
@@ -50,7 +45,7 @@ rsyslog_conf_viaq_mmk8s_module:
           # Parse logs to JSON
           module(load="mmjsonparse")
 
-rsyslog_conf_viaq_mmk8s_input:
+__rsyslog_conf_viaq_mmk8s_input:
 
   - name: 'mmk8s'
     type: 'templates'
@@ -76,7 +71,7 @@ rsyslog_conf_viaq_mmk8s_input:
                  tokenfile="{{ logging_mmk8s_token }}" annotation_match=["."])
           }
 
-rsyslog_rulebase_viaq_k8s_filename:
+__rsyslog_rulebase_viaq_k8s_filename:
 
   - name: 'k8s_filename'
     filename: 'k8s_filename.rulebase'
@@ -88,7 +83,7 @@ rsyslog_rulebase_viaq_k8s_filename:
           version=2
           rule=:{{ rsyslog_viaq_log_dir }}/%pod_name:char-to:_%_%namespace_name:char-to:_%_%container_name_and_id:char-to:.%.log
 
-rsyslog_rulebase_viaq_k8s_container_name:
+__rsyslog_rulebase_viaq_k8s_container_name:
 
   - name: 'k8s_container_name'
     filename: 'k8s_container_name.rulebase'
@@ -103,7 +98,7 @@ rsyslog_rulebase_viaq_k8s_container_name:
           # not a kubernetes container
           rule=:%container_name:rest%
 
-rsyslog_rulebase_viaq_crio:
+__rsyslog_rulebase_viaq_crio:
 
   - name: 'crio'
     filename: 'crio.rulebase'

--- a/roles/rsyslog/roles/input_roles/viaq-k8s/tasks/cleanup.yaml
+++ b/roles/rsyslog/roles/input_roles/viaq-k8s/tasks/cleanup.yaml
@@ -1,9 +1,8 @@
 ---
-- name: Set Viaq-k8s facts
-  set_fact:
-    rsyslog_role_rules: "{{ rsyslog_viaq_k8s_rules }}"
-
+# Deploy configuration files
 - name: Remove Viaq-k8s role config files from subdir
+  vars:
+    __rsyslog_rules: "{{ __rsyslog_viaq_k8s_rules }}"
   include_role:
     name: "{{ role_path }}/../../../"
     tasks_from: cleanup.yaml

--- a/roles/rsyslog/roles/input_roles/viaq-k8s/tasks/main.yaml
+++ b/roles/rsyslog/roles/input_roles/viaq-k8s/tasks/main.yaml
@@ -1,10 +1,9 @@
 ---
-- name: Set Viaq-k8s facts
-  set_fact:
-    rsyslog_role_packages: "{{ rsyslog_viaq_k8s_packages|flatten }}"
-    rsyslog_role_rules: "{{ rsyslog_viaq_k8s_rules }}"
-
+# Deploy configuration files
 - name: Install/Update role packages and generate role configuration files to role subdir
+  vars:
+    __rsyslog_packages: "{{ __rsyslog_viaq_k8s_packages }}"
+    __rsyslog_rules: "{{ __rsyslog_viaq_k8s_rules }}"
   include_role:
     name: "{{ role_path }}/../../../"
     tasks_from: deploy.yaml

--- a/roles/rsyslog/roles/input_roles/viaq-k8s/vars/main.yaml
+++ b/roles/rsyslog/roles/input_roles/viaq-k8s/vars/main.yaml
@@ -1,0 +1,4 @@
+# __rsyslog_viaq_k8s_packages
+#
+# List of rpm packages for Common Logging.
+__rsyslog_viaq_k8s_packages: ['rsyslog-mmjsonparse', 'rsyslog-mmkubernetes']

--- a/roles/rsyslog/roles/input_roles/viaq/defaults/main.yaml
+++ b/roles/rsyslog/roles/input_roles/viaq/defaults/main.yaml
@@ -6,37 +6,31 @@
 # adding rsyslog_logging_packages
 # ------------------
 
-# .. envvar:: rsyslog_viaq_packages
-#
-# List of rpm packages for Common Logging.
-rsyslog_viaq_prereq_packages: ['nmap-ncat', 'systemd-python', 'policycoreutils', 'checkpolicy', 'policycoreutils-python']
-rsyslog_viaq_packages: ['rsyslog-mmnormalize']
-
 # Available configuration set
 # ----------------------------
 
-rsyslog_unprivileged: 'False'
+rsyslog_unprivileged: false
 
 # Viaq Rsyslog configuration rules
 # ---------------------------
 
-rsyslog_viaq_rules:
+__rsyslog_viaq_rules:
 
-  - '{{ rsyslog_conf_local_viaq_modules }}'
-  - '{{ rsyslog_conf_viaq_main_modules }}'
-  - '{{ rsyslog_conf_viaq_formatting }}'
-  - '{{ rsyslog_rulebase_viaq_parse_json }}'
-  - '{{ rsyslog_json_viaq_normalize_level }}'
-  - '{{ rsyslog_json_viaq_prio_to_level }}'
+  - '{{ __rsyslog_conf_local_viaq_modules }}'
+  - '{{ __rsyslog_conf_viaq_main_modules }}'
+  - '{{ __rsyslog_conf_viaq_formatting }}'
+  - '{{ __rsyslog_rulebase_viaq_parse_json }}'
+  - '{{ __rsyslog_json_viaq_normalize_level }}'
+  - '{{ __rsyslog_json_viaq_prio_to_level }}'
 
 # Default Viaq configuration options
 # ---------------------------------
 
-# .. envvar:: rsyslog_conf_local_viaq_modules
+# __rsyslog_conf_local_viaq_modules
 #
 # List of ``rsyslogd`` modules that enable logs from the local system to be
 # received and parsed by the ``rsyslogd`` daemon.
-rsyslog_conf_local_viaq_modules:
+__rsyslog_conf_local_viaq_modules:
 
   - name: 'local-viaq-modules'
     type: 'modules'
@@ -46,7 +40,7 @@ rsyslog_conf_local_viaq_modules:
         options: |-
           module(load="imuxsock" SysSock.use="off")
 
-rsyslog_conf_viaq_main_modules:
+__rsyslog_conf_viaq_main_modules:
 
   - name: 'viaq_main'
     type: 'modules'
@@ -58,13 +52,13 @@ rsyslog_conf_viaq_main_modules:
 
       - options: |-
           # Read from journal
-          module(load="imjournal" StateFile="{{ rsyslog_work_dir }}/imjournal.state" UsePid="both" RateLimit.Burst="{{ imjournal_ratelimit_burst|default(1000000) }}" RateLimit.Interval="{{ imjournal_ratelimit_interval|default(10) }}" PersistStateInterval="1000" WorkAroundJournalBug="on")
+          module(load="imjournal" StateFile="{{ rsyslog_work_dir }}/imjournal.state" UsePid="both" RateLimit.Burst="{{ imjournal_ratelimit_burst | default(1000000) }}" RateLimit.Interval="{{ imjournal_ratelimit_interval | default(10) }}" PersistStateInterval="1000" WorkAroundJournalBug="on")
 
       - options: |-
           # Normalize logs
           module(load="mmnormalize")
 
-rsyslog_conf_viaq_formatting:
+__rsyslog_conf_viaq_formatting:
 
   - name: 'viaq_formatting'
     type: 'template'
@@ -366,7 +360,7 @@ rsyslog_conf_viaq_formatting:
           # add viaq logs identifier
           set $.logs_collection = "viaq";
 
-rsyslog_rulebase_viaq_parse_json:
+__rsyslog_rulebase_viaq_parse_json:
 
   - name: 'parse_json'
     filename: 'parse_json.rulebase'
@@ -378,7 +372,7 @@ rsyslog_rulebase_viaq_parse_json:
           version=2
           rule=:%.:json%
 
-rsyslog_json_viaq_normalize_level:
+__rsyslog_json_viaq_normalize_level:
 
   - name: 'normalize_level'
     filename: 'normalize_level.json'
@@ -408,7 +402,7 @@ rsyslog_json_viaq_normalize_level:
             ]
           }
 
-rsyslog_json_viaq_prio_to_level:
+__rsyslog_json_viaq_prio_to_level:
 
   - name: 'prio_to_level'
     filename: 'prio_to_level.json'

--- a/roles/rsyslog/roles/input_roles/viaq/tasks/cleanup.yaml
+++ b/roles/rsyslog/roles/input_roles/viaq/tasks/cleanup.yaml
@@ -1,9 +1,8 @@
 ---
-- name: Set Viaq facts
-  set_fact:
-    rsyslog_role_rules: "{{ rsyslog_viaq_rules }}"
-
+# Deploy configuration files
 - name: Remove viaq configs
+  vars:
+    __rsyslog_rules: "{{ __rsyslog_viaq_rules }}"
   include_role:
     name: "{{ role_path }}/../../../"
     tasks_from: cleanup.yaml

--- a/roles/rsyslog/roles/input_roles/viaq/tasks/main.yaml
+++ b/roles/rsyslog/roles/input_roles/viaq/tasks/main.yaml
@@ -1,10 +1,9 @@
 ---
-- name: Set Viaq facts
-  set_fact:
-    rsyslog_role_packages: "{{ rsyslog_viaq_prereq_packages|flatten|d([]) }}+{{ rsyslog_viaq_packages|flatten|d([]) }}"
-    rsyslog_role_rules: "{{ rsyslog_viaq_rules }}"
-
+# Deploy configuration files
 - name: Install/Update role packages and generate role configuration files to role subdir
+  vars:
+    __rsyslog_packages: "{{ __rsyslog_viaq_prereq_packages + __rsyslog_viaq_packages }}"
+    __rsyslog_rules: "{{ __rsyslog_viaq_rules }}"
   include_role:
     name: "{{ role_path }}/../../../"
     tasks_from: deploy.yaml

--- a/roles/rsyslog/roles/input_roles/viaq/vars/main.yaml
+++ b/roles/rsyslog/roles/input_roles/viaq/vars/main.yaml
@@ -1,0 +1,5 @@
+# __rsyslog_viaq_packages
+#
+# List of rpm packages for Common Logging.
+__rsyslog_viaq_prereq_packages: ['nmap-ncat', 'systemd-python', 'policycoreutils', 'checkpolicy', 'policycoreutils-python']
+__rsyslog_viaq_packages: ['rsyslog-mmnormalize']

--- a/roles/rsyslog/roles/output_roles/elasticsearch/defaults/main.yaml
+++ b/roles/rsyslog/roles/output_roles/elasticsearch/defaults/main.yaml
@@ -2,12 +2,6 @@
 # Elasticsearch configuration
 # ---------------------
 
-# .. envvar:: rsyslog_elasticsearch_package
-#
-# List of rpm packages for Elasticsearch output.
-rsyslog_elasticsearch_packages: ['rsyslog-elasticsearch']
-
-
 # Available configuration set
 # ----------------------------
 
@@ -21,15 +15,15 @@ rsyslog_elasticsearch:
 # Elasticsearch Rsyslog configuration rules
 # ---------------------------
 
-rsyslog_elasticsearch_rules:
+__rsyslog_elasticsearch_rules:
 
-  - '{{ rsyslog_conf_es_main_modules }}'
-  - '{{ rsyslog_conf_es_elasticsearch }}'
+  - '{{ __rsyslog_conf_es_main_modules }}'
+  - '{{ __rsyslog_conf_es_elasticsearch }}'
 
 # Default elasticsearch configuration options [[[
 # ---------------------------------
 
-rsyslog_conf_es_main_modules:
+__rsyslog_conf_es_main_modules:
 
   - name: 'elasticsearch_main'
     type: 'modules'
@@ -40,7 +34,7 @@ rsyslog_conf_es_main_modules:
           # Send to ElasticSearch
           module(load="omelasticsearch")
 
-rsyslog_conf_es_elasticsearch:
+__rsyslog_conf_es_elasticsearch:
 
   - name: 'elasticsearch'
     type: 'output'

--- a/roles/rsyslog/roles/output_roles/elasticsearch/tasks/main.yaml
+++ b/roles/rsyslog/roles/output_roles/elasticsearch/tasks/main.yaml
@@ -9,7 +9,7 @@
         - '{{ rsyslog_elasticsearch }}'
       when:
         - item.ca_cert_src is defined
-        - item.ca_cert_src != ""
+        - item.ca_cert_src
 
     - name: Copy local Elasticsearch certs to /etc/rsyslog.d directory in Rsyslog
       copy:
@@ -19,7 +19,7 @@
         - '{{ rsyslog_elasticsearch }}'
       when:
         - item.cert_src is defined
-        - item.cert_src != ""
+        - item.cert_src
 
     - name: Copy local Elasticsearch keys to /etc/rsyslog.d directory in Rsyslog
       copy:
@@ -29,21 +29,24 @@
         - '{{ rsyslog_elasticsearch }}'
       when:
         - item.key_src is defined
-        - item.key_src != ""
+        - item.key_src
 
     - name: Update ca_cert path to /etc/rsyslog.d directory in Rsyslog
       set_fact:
-        rsyslog_elasticsearch_temp: "{{ rsyslog_elasticsearch_temp | d([]) }} + {{ [ item | combine( { 'ca_cert': item.ca_cert_src | basename , 'cert': item.cert_src | basename, 'key': item.key_src | basename } ) ] }}"
+        __rsyslog_elasticsearch_temp: >-
+          {{ __rsyslog_elasticsearch_temp | d([]) }} +
+          {{ [ item | combine( { 'ca_cert': item.ca_cert_src | basename ,
+          'cert': item.cert_src | basename, 'key': item.key_src | basename } ) ] }}
       with_items:
         - '{{ rsyslog_elasticsearch }}'
       when:
         - item.ca_cert_src is defined
-        - item.ca_cert_src != ""
+        - item.ca_cert_src
       register: result
 
     - name: Set updated rsyslog_elasticsearch
       set_fact:
-        rsyslog_elasticsearch: "{{ rsyslog_elasticsearch_temp }}"
+        rsyslog_elasticsearch: "{{ __rsyslog_elasticsearch_temp }}"
 
   when:
     - rsyslog_elasticsearch is defined
@@ -51,12 +54,10 @@
     - use_local_omelasticsearch_cert | default(false) | bool
 
 # Deploy configuration files
-- name: Set Elasticsearch facts
-  set_fact:
-    rsyslog_role_packages: "{{ rsyslog_elasticsearch_packages | flatten([]) }}"
-    rsyslog_role_rules: "{{ rsyslog_elasticsearch_rules }}"
-
 - name: Install/Update role packages and generate role configuration files (elasticsearch)
+  vars:
+    __rsyslog_packages: "{{ __rsyslog_elasticsearch_packages }}"
+    __rsyslog_rules: "{{ __rsyslog_elasticsearch_rules }}"
   include_role:
     name: "{{ role_path }}/../../../"
     tasks_from: deploy.yaml

--- a/roles/rsyslog/roles/output_roles/elasticsearch/tasks/main.yaml
+++ b/roles/rsyslog/roles/output_roles/elasticsearch/tasks/main.yaml
@@ -9,7 +9,7 @@
         - '{{ rsyslog_elasticsearch }}'
       when:
         - item.ca_cert_src is defined
-        - item.ca_cert_src
+        - item.ca_cert_src | length > 0
 
     - name: Copy local Elasticsearch certs to /etc/rsyslog.d directory in Rsyslog
       copy:
@@ -19,7 +19,7 @@
         - '{{ rsyslog_elasticsearch }}'
       when:
         - item.cert_src is defined
-        - item.cert_src
+        - item.cert_src | length > 0
 
     - name: Copy local Elasticsearch keys to /etc/rsyslog.d directory in Rsyslog
       copy:
@@ -29,7 +29,7 @@
         - '{{ rsyslog_elasticsearch }}'
       when:
         - item.key_src is defined
-        - item.key_src
+        - item.key_src | length > 0
 
     - name: Update ca_cert path to /etc/rsyslog.d directory in Rsyslog
       set_fact:
@@ -41,7 +41,7 @@
         - '{{ rsyslog_elasticsearch }}'
       when:
         - item.ca_cert_src is defined
-        - item.ca_cert_src
+        - item.ca_cert_src | length > 0
       register: result
 
     - name: Set updated rsyslog_elasticsearch

--- a/roles/rsyslog/roles/output_roles/elasticsearch/vars/main.yaml
+++ b/roles/rsyslog/roles/output_roles/elasticsearch/vars/main.yaml
@@ -1,0 +1,4 @@
+# __rsyslog_elasticsearch_package
+#
+# List of rpm packages for Elasticsearch output.
+__rsyslog_elasticsearch_packages: ['rsyslog-elasticsearch']

--- a/roles/rsyslog/roles/output_roles/files/defaults/main.yaml
+++ b/roles/rsyslog/roles/output_roles/files/defaults/main.yaml
@@ -4,14 +4,14 @@
 
 # Files Rsyslog output configuration rules
 # ---------------------------------
-rsyslog_files_output_rules:
-  - '{{ rsyslog_conf_files_output_modules }}'
-  - '{{ rsyslog_conf_files_output_rules }}'
-  - '{{ rsyslog_conf_remote_templates }}'
-  - '{{ rsyslog_conf_remote_output }}'
+__rsyslog_files_output_rules:
+  - '{{ __rsyslog_conf_files_output_modules }}'
+  - '{{ __rsyslog_conf_files_output_rules }}'
+  - '{{ __rsyslog_conf_remote_templates }}'
+  - '{{ __rsyslog_conf_remote_output }}'
 
-# rsyslog_conf_files_output_modules:
-rsyslog_conf_files_output_modules:
+# __rsyslog_conf_files_output_modules:
+__rsyslog_conf_files_output_modules:
 
   - name: 'output-modules'
     type: 'modules'
@@ -25,12 +25,12 @@ rsyslog_conf_files_output_modules:
           module(load="builtin:omfile")
           {% endif %}
 
-# rsyslog_conf_files_output_rules:
+# __rsyslog_conf_files_output_rules:
 #
 # A set of default ``rsyslog`` options which store local system logs in files
 # located in `{{ rsyslog_system_log_dir }}/` directory. This is mostly the
 # same as the default ``rsyslogd`` configuration provided in the installations.
-rsyslog_conf_files_output_rules:
+__rsyslog_conf_files_output_rules:
 
   - name: 'output-files'
     type: 'output'
@@ -39,7 +39,7 @@ rsyslog_conf_files_output_rules:
     sections:
 
       - options: |-
-          {% if rsyslog_files_actions is defined and rsyslog_files_actions|length > 0 %}
+          {% if rsyslog_files_actions is defined and rsyslog_files_actions | length > 0 %}
           {% for element in rsyslog_files_actions %}
           {% if element.name is defined and element.path is defined %}
           {% if element.severity is defined %}
@@ -102,14 +102,14 @@ rsyslog_conf_files_output_rules:
           local7.*                                                {{ rsyslog_system_log_dir }}/boot.log
           {% endif %}
 
-# rsyslog_conf_remote_templates
+# __rsyslog_conf_remote_templates
 #
 # List of ``rsyslogd`` templates which are used to generate dynamic filenames for remote logs,
 # based on hostnames. You can add additional template configuration by writing it in the
 # `{{ rsyslog_config_dir }}/*.template` files, they will be included by the main configuration.
 #
 # This section will create 20-remote-templates.conf
-rsyslog_conf_remote_templates:
+__rsyslog_conf_remote_templates:
 
   - name: 'remote-templates'
     type: 'template'
@@ -166,9 +166,9 @@ rsyslog_conf_remote_templates:
           # Include custom templates
           $IncludeConfig {{ rsyslog_config_dir }}/*.template
 
-# rsyslog_conf_remote_output
+# __rsyslog_conf_remote_output
 #
-rsyslog_conf_remote_output:
+__rsyslog_conf_remote_output:
 
   - name: 'remote-dynamic-logs'
     comment: 'Store remote logs in separate logfiles'

--- a/roles/rsyslog/roles/output_roles/files/tasks/main.yaml
+++ b/roles/rsyslog/roles/output_roles/files/tasks/main.yaml
@@ -1,10 +1,9 @@
 ---
 # Deploy configuration files
-- name: Set files facts
-  set_fact:
-    rsyslog_role_rules: "{{ rsyslog_files_output_rules }}"
-
 - name: Install/Update role packages and generate role configuration files for output to local files
+  vars:
+    __rsyslog_packages: "{{ __rsyslog_files_output_packages }}"
+    __rsyslog_rules: "{{ __rsyslog_files_output_rules }}"
   include_role:
     name: "{{ role_path }}/../../../"
     tasks_from: deploy.yaml

--- a/roles/rsyslog/roles/output_roles/files/vars/main.yaml
+++ b/roles/rsyslog/roles/output_roles/files/vars/main.yaml
@@ -1,0 +1,4 @@
+# __rsyslog_files_output_package
+#
+# List of rpm packages for Files output.
+__rsyslog_files_output_packages: []

--- a/roles/rsyslog/roles/output_roles/forwards/defaults/main.yaml
+++ b/roles/rsyslog/roles/output_roles/forwards/defaults/main.yaml
@@ -4,13 +4,13 @@
 
 # Forwards Rsyslog output configuration rules
 # ---------------------------------
-rsyslog_forwards_output_rules:
-  - '{{ rsyslog_conf_forwards_output_rules }}'
+__rsyslog_forwards_output_rules:
+  - '{{ __rsyslog_conf_forwards_output_rules }}'
 
-# rsyslog_conf_forwards_output_rules:
+# __rsyslog_conf_forwards_output_rules:
 #
 # Enable log forwarding to another ``rsyslogd`` instance if `rsyslog_forwards_actions` variables are defined.
-rsyslog_conf_forwards_output_rules:
+__rsyslog_conf_forwards_output_rules:
 
   - name: 'output-forwards'
     type: 'output'
@@ -32,29 +32,29 @@ rsyslog_conf_forwards_output_rules:
           {% if element.severity is defined %}
           {% if element.facility is defined %}
           {% if element.exclude is defined %}
-          {{ element.facility }}.{{ element.severity }};{{ element.exclude }} action(name="{{ element.name }}" type="omfwd" Target="{{ element.target }}" Port="{{ element.port|d(514) }}" Protocol="{{ element.protocol|d('tcp') }}")
+          {{ element.facility }}.{{ element.severity }};{{ element.exclude }} action(name="{{ element.name }}" type="omfwd" Target="{{ element.target }}" Port="{{ element.port | d(514) }}" Protocol="{{ element.protocol | d('tcp') }}")
           {% else %}
-          {{ element.facility }}.{{ element.severity }} action(name="{{ element.name }}" type="omfwd" Target="{{ element.target }}" Port="{{ element.port|d(514) }}" Protocol="{{ element.protocol|d('tcp') }}")
+          {{ element.facility }}.{{ element.severity }} action(name="{{ element.name }}" type="omfwd" Target="{{ element.target }}" Port="{{ element.port | d(514) }}" Protocol="{{ element.protocol | d('tcp') }}")
           {% endif %}
           {% else %}
           {% if element.exclude is defined %}
-          *.{{ element.severity }};{{ element.exclude }} action(name="{{ element.name }}" type="omfwd" Target="{{ element.target }}" Port="{{ element.port|d(514) }}" Protocol="{{ element.protocol|d('tcp') }}")
+          *.{{ element.severity }};{{ element.exclude }} action(name="{{ element.name }}" type="omfwd" Target="{{ element.target }}" Port="{{ element.port | d(514) }}" Protocol="{{ element.protocol | d('tcp') }}")
           {% else %}
-          *.{{ element.severity }} action(name="{{ element.name }}" type="omfwd" Target="{{ element.target }}" Port="{{ element.port|d(514) }}" Protocol="{{ element.protocol|d('tcp') }}")
+          *.{{ element.severity }} action(name="{{ element.name }}" type="omfwd" Target="{{ element.target }}" Port="{{ element.port | d(514) }}" Protocol="{{ element.protocol | d('tcp') }}")
           {% endif %}
           {% endif %}
           {% else %}
           {% if element.facility is defined %}
           {% if element.exclude is defined %}
-          {{ element.facility }}.*;{{ element.exclude }} action(name="{{ element.name }}" type="omfwd" Target="{{ element.target }}" Port="{{ element.port|d(514) }}" Protocol="{{ element.protocol|d('tcp') }}")
+          {{ element.facility }}.*;{{ element.exclude }} action(name="{{ element.name }}" type="omfwd" Target="{{ element.target }}" Port="{{ element.port | d(514) }}" Protocol="{{ element.protocol | d('tcp') }}")
           {% else %}
-          {{ element.facility }}.* action(name="{{ element.name }}" type="omfwd" Target="{{ element.target }}" Port="{{ element.port|d(514) }}" Protocol="{{ element.protocol|d('tcp') }}")
+          {{ element.facility }}.* action(name="{{ element.name }}" type="omfwd" Target="{{ element.target }}" Port="{{ element.port | d(514) }}" Protocol="{{ element.protocol | d('tcp') }}")
           {% endif %}
           {% else %}
           {% if element.exclude is defined %}
-          *.*;{{ element.exclude }} action(name="{{ element.name }}" type="omfwd" Target="{{ element.target }}" Port="{{ element.port|d(514) }}" Protocol="{{ element.protocol|d('tcp') }}")
+          *.*;{{ element.exclude }} action(name="{{ element.name }}" type="omfwd" Target="{{ element.target }}" Port="{{ element.port | d(514) }}" Protocol="{{ element.protocol | d('tcp') }}")
           {% else %}
-          *.* action(name="{{ element.name }}" type="omfwd" Target="{{ element.target }}" Port="{{ element.port|d(514) }}" Protocol="{{ element.protocol|d('tcp') }}")
+          *.* action(name="{{ element.name }}" type="omfwd" Target="{{ element.target }}" Port="{{ element.port | d(514) }}" Protocol="{{ element.protocol | d('tcp') }}")
           {% endif %}
           {% endif %}
           {% endif %}

--- a/roles/rsyslog/roles/output_roles/forwards/tasks/main.yaml
+++ b/roles/rsyslog/roles/output_roles/forwards/tasks/main.yaml
@@ -1,10 +1,9 @@
 ---
 # Deploy configuration files
-- name: Set forwards facts
-  set_fact:
-    rsyslog_role_rules: "{{ rsyslog_forwards_output_rules }}"
-
 - name: Install/Update role packages and generate role configuration files for forwarding outputs
+  vars:
+    __rsyslog_packages: "{{ __rsyslog_forwards_output_packages }}"
+    __rsyslog_rules: "{{ __rsyslog_forwards_output_rules }}"
   include_role:
     name: "{{ role_path }}/../../../"
     tasks_from: deploy.yaml

--- a/roles/rsyslog/roles/output_roles/forwards/vars/main.yaml
+++ b/roles/rsyslog/roles/output_roles/forwards/vars/main.yaml
@@ -1,0 +1,4 @@
+# __rsyslog_forwards_output_package
+#
+# List of rpm packages for Forwards output.
+__rsyslog_forwards_output_packages: []

--- a/roles/rsyslog/tasks/cleanup.yaml
+++ b/roles/rsyslog/tasks/cleanup.yaml
@@ -1,10 +1,13 @@
 ---
 - name: Remove role config files from subdir
   file:
-    path: '{{ item.path | d(rsyslog_config_dir) }}/{{ item.filename | d((item.weight if item.weight | d() else rsyslog_weight_map[item.type | d("rules")]) + "-" + (item.name | d("rules")) + "." + (item.suffix | d("conf"))) }}'
+    path: >-
+      {{ item.path | d(rsyslog_config_dir) }}/{{ item.filename | d((item.weight
+      if item.weight | d() else rsyslog_weight_map[item.type | d("rules")]) +
+      "-" + (item.name | d("rules")) + "." + (item.suffix | d("conf"))) }}
     state: absent
   with_flattened:
-    - '{{ rsyslog_role_rules }}'
+    - '{{ __rsyslog_rules }}'
   when:
     - item.filename | d() or item.name | d()
     - item.options | d() or item.sections | d()

--- a/roles/rsyslog/tasks/deploy.yaml
+++ b/roles/rsyslog/tasks/deploy.yaml
@@ -1,20 +1,23 @@
 ---
 - name: Install/Update required packages
   package:
-    name: "{{ rsyslog_role_packages }}"
+    name: "{{ __rsyslog_packages }}"
     state: latest
   when:
-    - not use_rsyslog_image | default(false) |bool
+    - not rsyslog_in_image | default(false) | bool
   notify: restart rsyslogd
 
 - name: Generate role configuration files in rsyslog.d and subdir
   template:
     src: 'etc/rsyslog.d/rules.conf.j2'
-    dest: '{{ item.path | d(rsyslog_config_dir) }}/{{ item.filename | d((item.weight if item.weight | d() else rsyslog_weight_map[item.type | d("rules")]) + "-" + (item.name | d("rules")) + "." + (item.suffix | d("conf"))) }}'
+    dest: >-
+      {{ item.path | d(rsyslog_config_dir) }}/{{ item.filename | d((item.weight
+      if item.weight | d() else rsyslog_weight_map[item.type | d("rules")]) +
+      "-" + (item.name | d("rules")) + "." + (item.suffix | d("conf"))) }}
     owner: '{{ item.owner | d("root") }}'
     group: '{{ item.group | d("root") }}'
     mode: '{{ item.mode  | d("0400") }}'
-  loop: '{{ rsyslog_role_rules | flatten }}'
+  loop: '{{ __rsyslog_rules | flatten }}'
   when:
     - item.filename | d() or item.name | d()
     - item.options | d() or item.sections | d()

--- a/roles/rsyslog/tasks/deploy.yaml
+++ b/roles/rsyslog/tasks/deploy.yaml
@@ -4,7 +4,7 @@
     name: "{{ __rsyslog_packages }}"
     state: latest
   when:
-    - not rsyslog_in_image | default(false) | bool
+    - not rsyslog_in_image | bool
   notify: restart rsyslogd
 
 - name: Generate role configuration files in rsyslog.d and subdir

--- a/roles/rsyslog/tasks/main.yaml
+++ b/roles/rsyslog/tasks/main.yaml
@@ -1,6 +1,6 @@
 - name: Install/Update required packages
   package:
-    name: "{{ (__rsyslog_base_packages) + (__rsyslog_tls_packages if rsyslog_pki else []) + (rsyslog_extra_packages) }}"
+    name: "{{ (__rsyslog_base_packages) + (__rsyslog_tls_packages if rsyslog_pki else []) + (rsyslog_extra_packages | flatten) }}"
     state: latest
   when:
     - rsyslog_enabled | bool
@@ -29,7 +29,7 @@
       set_fact:
         __rsyslog_failed_validation: true
       when: __rsyslog_version is version('8.37.0-7.2', '<')
-  when: use_rsyslog_image | default(false) | bool
+  when: rsyslog_in_image | bool
 
 - block:
     - name: Create required system group
@@ -87,15 +87,22 @@
         remove: '{{ true if rsyslog_purge_original_conf | bool else false }}'
       changed_when: false
 
+    - name: Get directory stat
+      stat:
+        path: "{{ rsyslog_system_log_dir }}"
+      register: stat_rsyslog_system_log_dir
+
     - name: Update directory and file permissions
       shell: |
         [ ! -d {{ rsyslog_system_log_dir }} ] ||
         ( [ "$(stat -c '%G' {{ rsyslog_system_log_dir }})" = "{{ rsyslog_group }}" ] ||
         ( chown -v root:{{ rsyslog_group }} {{ rsyslog_system_log_dir }} ;
-        chmod -v 775 {{ rsyslog_system_log_dir }} ) )
+        chmod -v 0775 {{ rsyslog_system_log_dir }} ) )
       register: rsyslog_register_file_permissions
       when: rsyslog_unprivileged | bool
-      changed_when: rsyslog_register_file_permissions.stdout
+      changed_when:
+        - rsyslog_register_file_permissions.rc == 0
+        - stat_rsyslog_system_log_dir.stat.mode != "0755"
 
     - name: Generate main rsyslog configuration
       template:
@@ -210,11 +217,11 @@
         - not rsyslog_enabled | bool
         - not rsyslog_in_image | default(false) | bool
 
-  when: __rsyslog_failed_validation | d(false) == false
+  when: not __rsyslog_failed_validation | d(false)
 
 - name: Check rsyslog version
   debug:
     msg: "Rsyslog version must be >= 8.37.0-7.2"
   when:
-    - __rsyslog_failed_validation | d(false) == true
-    - use_rsyslog_image | default(false) | bool
+    - __rsyslog_failed_validation | d(false)
+    - rsyslog_in_image | default(false) | bool

--- a/roles/rsyslog/tasks/main.yaml
+++ b/roles/rsyslog/tasks/main.yaml
@@ -1,43 +1,34 @@
----
 - name: Install/Update required packages
   package:
-    name: "{{ lookup('flattened', rsyslog_base_packages, rsyslog_tls_packages if rsyslog_pki else [], rsyslog_packages) }}"
+    name: "{{ (__rsyslog_base_packages) + (__rsyslog_tls_packages if rsyslog_pki else []) + (rsyslog_extra_packages) }}"
     state: latest
   when:
     - rsyslog_enabled | bool
-    - not use_rsyslog_image | default(false) | bool
-  ignore_errors: yes
-  tags:
-    - skip_ansible_lint
+
+- name: Gather package facts
+  package_facts:
+    manager: auto
 
 - name: Get rsyslog version
-  package:
-    list: rsyslog
-  register: rsyslog_version
+  set_fact:
+    __rsyslog_version: >-
+      {{ ansible_facts.packages['rsyslog'][0].version
+      if ansible_facts.packages | selectattr('rsyslog', 'defined') | list | length > 0
+      else '0.0.0' }}
 
 - debug:
-    msg: "Rsyslog_version is {{ rsyslog_version }}"
+    msg: "Rsyslog_version is {{ __rsyslog_version }}, which is older than \"8.37.0-7.2\"."
+  when: __rsyslog_version is version('8.37.0-7.2', '<')
+
+- debug:
+    msg: "Rsyslog_version is {{ __rsyslog_version }}, which is newer than \"8.37.0-7.2\"."
+  when: __rsyslog_version is version('8.37.0-7.2', '>')
 
 - block:
-    - name: Set rsyslog version
+    - name: Set __rsyslog_failed_validation
       set_fact:
-        rsyslog_version: "{{ rsyslog_version.results | selectattr('yumstate','match','installed') | map(attribute='version') | list | first }}-{{ rsyslog_version.results | selectattr('yumstate','match','installed') | map(attribute='release') | list | first }}"
-      when: rsyslog_version.results | selectattr('yumstate','match','installed') | list | first is defined
-      ignore_errors: true
-
-    - name: Set rsyslog version
-      set_fact:
-        rsyslog_version: "{{ rsyslog_version.results | selectattr('yumstate','match','available') | map(attribute='version') | list | first }}-{{ rsyslog_version.results | selectattr('yumstate','match','available') | map(attribute='release') | list | first }}"
-      when: rsyslog_version.results | selectattr('yumstate','match','available') | list | first is defined
-      ignore_errors: true
-
-    - debug:
-        msg: "Rsyslog_version is {{ rsyslog_version }}"
-
-    - name: Set rsyslog_failed_validation
-      set_fact:
-        rsyslog_failed_validation: true
-      when: rsyslog_version is version('8.37.0-7.2.el7', '<')
+        __rsyslog_failed_validation: true
+      when: __rsyslog_version is version('8.37.0-7.2', '<')
   when: use_rsyslog_image | default(false) | bool
 
 - block:
@@ -76,12 +67,12 @@
     # Creating a backup dir for rsyslog.d
     - name: Set backup dir name
       set_fact:
-        backupdir: '{{ rsyslog_backup_dir | default("/tmp") }}/rsyslog.d-{{ ansible_date_time.iso8601_basic_short }}'
+        rsyslog_backup_dir: '{{ rsyslog_backup_dir | default("/tmp") }}/rsyslog.d-{{ ansible_date_time.iso8601_basic_short }}'
 
     - name: Create a backup dir
       file:
         state: directory
-        path: '{{ backupdir }}'
+        path: '{{ rsyslog_backup_dir }}'
         owner: '{{ rsyslog_user }}'
         group: '{{ rsyslog_file_group }}'
         mode: 0755
@@ -92,16 +83,19 @@
     - name: Archive the contents of {{ rsyslog_config_dir }} to the backup dir
       archive:
         path: ["{{ rsyslog_config_dir }}", /etc/rsyslog.conf]
-        dest: "{{ backupdir }}/backup.tgz"
+        dest: "{{ rsyslog_backup_dir }}/backup.tgz"
         remove: '{{ true if rsyslog_purge_original_conf | bool else false }}'
       changed_when: false
 
     - name: Update directory and file permissions
       shell: |
-        [ ! -d {{ rsyslog_system_log_dir }} ] || ( [ "$(stat -c '%G' {{ rsyslog_system_log_dir }})" = "{{ rsyslog_group }}" ] || ( chown -v root:{{ rsyslog_group }} {{ rsyslog_system_log_dir }} ; chmod -v 775 {{ rsyslog_system_log_dir }} ) )
+        [ ! -d {{ rsyslog_system_log_dir }} ] ||
+        ( [ "$(stat -c '%G' {{ rsyslog_system_log_dir }})" = "{{ rsyslog_group }}" ] ||
+        ( chown -v root:{{ rsyslog_group }} {{ rsyslog_system_log_dir }} ;
+        chmod -v 775 {{ rsyslog_system_log_dir }} ) )
       register: rsyslog_register_file_permissions
       when: rsyslog_unprivileged | bool
-      changed_when: rsyslog_register_file_permissions.stdout != ''
+      changed_when: rsyslog_register_file_permissions.stdout
 
     - name: Generate main rsyslog configuration
       template:
@@ -117,11 +111,14 @@
     - name: Generate common rsyslog configuration files in rsyslog.d
       template:
         src: 'etc/rsyslog.d/rules.conf.j2'
-        dest: '{{ rsyslog_config_dir }}/{{ item.filename | d((item.weight if item.weight | d() else rsyslog_weight_map[item.type | d("rules")]) + "-" + (item.name | d("rules")) + "." + (item.suffix | d("conf"))) }}'
+        dest: |-
+          {{ rsyslog_config_dir }}/{{ item.filename | d((item.weight if item.weight | d()
+          else rsyslog_weight_map[item.type | d("rules")]) + "-" + (item.name | d("rules")) +
+          "." + (item.suffix | d("conf"))) }}
         owner: '{{ item.owner | d("root") }}'
         group: '{{ item.group | d("root") }}'
         mode: '{{ item.mode | d("0400") }}'
-      loop: '{{ rsyslog_common_rules | flatten }}'
+      loop: '{{ __rsyslog_common_rules | flatten }}'
       when:
         - rsyslog_enabled | bool
         - rsyslog_logs_collections is defined and rsyslog_logs_collections != []
@@ -132,9 +129,12 @@
 
     - name: Remove common config files in rsyslog.d
       file:
-        path: '{{ rsyslog_config_dir }}/{{ item.filename | d((item.weight if item.weight | d() else rsyslog_weight_map[item.type | d("rules")]) + "-" + (item.name | d("rules")) + "." + (item.suffix | d("conf"))) }}'
+        path: |-
+          {{ rsyslog_config_dir }}/{{ item.filename | d((item.weight if item.weight | d() else
+          rsyslog_weight_map[item.type | d("rules")]) + "-" + (item.name | d("rules")) + "." +
+          (item.suffix | d("conf"))) }}
         state: absent
-      loop: '{{ rsyslog_common_rules | flatten }}'
+      loop: '{{ __rsyslog_common_rules | flatten }}'
       when:
         - not rsyslog_enabled | bool
         - rsyslog_logs_collections is not defined or rsyslog_logs_collections == []
@@ -199,7 +199,7 @@
         state: started
       when:
         - rsyslog_enabled | bool
-        - not use_rsyslog_image | default(false) | bool
+        - not rsyslog_in_image | default(false) | bool
 
     - name: Disable rsyslog service
       systemd:
@@ -208,13 +208,13 @@
         state: stopped
       when:
         - not rsyslog_enabled | bool
-        - not use_rsyslog_image | default(false) | bool
+        - not rsyslog_in_image | default(false) | bool
 
-  when: rsyslog_failed_validation | d(false) == false
+  when: __rsyslog_failed_validation | d(false) == false
 
 - name: Check rsyslog version
   debug:
-    msg: "Rsyslog version must be >= 8.37.0-7.2.el7"
+    msg: "Rsyslog version must be >= 8.37.0-7.2"
   when:
-    - rsyslog_failed_validation | d(false) == true
+    - __rsyslog_failed_validation | d(false) == true
     - use_rsyslog_image | default(false) | bool

--- a/roles/rsyslog/vars/main.yaml
+++ b/roles/rsyslog/vars/main.yaml
@@ -1,0 +1,9 @@
+# __rsyslog_base_packages
+#
+# List of default rpm packages to install.
+__rsyslog_base_packages: ['rsyslog']
+
+# __rsyslog_tls_packages
+#
+# List of rpm packages required for TLS support.
+__rsyslog_tls_packages: ['rsyslog-gnutls', 'ca-certificates']

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -108,7 +108,7 @@
       lineinfile:
         path: "{{ role_path }}/debug/main.yaml"
         create: yes
-        line: "{{ item.key }}: {{ item.value| to_nice_json(indent=2) }}"
+        line: "{{ item.key }}: {{ item.value | to_nice_json(indent=2) }}"
       with_dict: "{{ hostvars[inventory_hostname] }}"
       when:
         - item.key is match("rsyslog*")

--- a/tests/set_rsyslog_variables.yml
+++ b/tests/set_rsyslog_variables.yml
@@ -1,10 +1,10 @@
----
 - name: Get info of /etc/rsyslog.conf
   command: /usr/bin/wc -l /etc/rsyslog.conf
   register: rsyslog_conf_line_count
+  changed_when: not rsyslog_conf_line_count.stdout
+
 - name: Get file counts in /etc/rsyslog.d
   find:
     paths: /etc/rsyslog.d
     patterns: '*.conf,*.template,*.system,*.remote'
   register: rsyslog_d_file_count
-

--- a/tests/set_rsyslog_variables.yml
+++ b/tests/set_rsyslog_variables.yml
@@ -1,7 +1,7 @@
 - name: Get info of /etc/rsyslog.conf
   command: /usr/bin/wc -l /etc/rsyslog.conf
   register: rsyslog_conf_line_count
-  changed_when: not rsyslog_conf_line_count.stdout
+  changed_when: false
 
 - name: Get file counts in /etc/rsyslog.d
   find:

--- a/tests/tests_default.yml
+++ b/tests/tests_default.yml
@@ -1,4 +1,3 @@
-
 - name: Ensure that the role runs with default parameters
   hosts: all
   become: true

--- a/tests/tests_default_files.yml
+++ b/tests/tests_default_files.yml
@@ -1,13 +1,14 @@
-
 - name: Ensure that the role runs with parameters to output into local files
   hosts: all
   become: true
+  vars:
+    __test_files_conf: /etc/rsyslog.d/30-output-files.system
 
   tasks:
     - name: deploy config to output into local files
       vars:
-        logging_enabled: True
-        rsyslog_default: False
+        logging_enabled: true
+        rsyslog_default: false
         logging_outputs:
           - name: files-output
             type: files
@@ -26,33 +27,30 @@
 
     - name: Check rsyslog.conf size
       assert:
-        that: rsyslog_conf_line_count.stdout.0|int <= 7
+        that: rsyslog_conf_line_count.stdout.0 | int <= 7
 
     - name: Check file counts in rsyslog.d
       assert:
         that: rsyslog_d_file_count.matched >= 9
 
-    - name: Set files config path
-      set_fact:
-        test_files_conf: "/etc/rsyslog.d/30-output-files.system"
-
     - name: Get the files config stat
       stat:
-        path: "{{ test_files_conf }}"
+        path: "{{ __test_files_conf }}"
       register: stat_output_files_system
 
     - name: Get the forwarding config stat
       stat:
-        path: "{{ test_files_conf }}"
+        path: "{{ __test_files_conf }}"
       register: stat_output_files_system
 
     - name: Check if the files config exists
       assert:
-        that: stat_output_files_system.stat.exists == True
+        that: stat_output_files_system.stat.exists
 
     - name: Grep output to messages line
-      command: /bin/grep "\/var\/log\/messages" {{ test_files_conf }}
+      command: /bin/grep "\/var\/log\/messages" {{ __test_files_conf }}
       register: files_conf_messages
+      changed_when: not files_conf_messages.stdout
 
     - name: Check the filter
       assert:
@@ -60,12 +58,14 @@
 
     - name: Run logger to generate a test log message
       command: /bin/logger -i -p local6.info -t testTag0 testMessage0000
+      register: logger_rc
+      changed_when: not logger_rc.stdout
 
     - name: Check the test log message in /var/log/messages
       command: /bin/grep testMessage0000 /var/log/messages
       register: testMessage0000
+      changed_when: not testMessage0000.stdout
 
     - name: Check if the test message is in /var/log/messages
       assert:
-        that: testMessage0000.stdout != ""
-
+        that: testMessage0000.stdout

--- a/tests/tests_default_files.yml
+++ b/tests/tests_default_files.yml
@@ -50,7 +50,7 @@
     - name: Grep output to messages line
       command: /bin/grep "\/var\/log\/messages" {{ __test_files_conf }}
       register: files_conf_messages
-      changed_when: not files_conf_messages.stdout
+      changed_when: false
 
     - name: Check the filter
       assert:
@@ -58,14 +58,13 @@
 
     - name: Run logger to generate a test log message
       command: /bin/logger -i -p local6.info -t testTag0 testMessage0000
-      register: logger_rc
-      changed_when: not logger_rc.stdout
+      changed_when: false
 
     - name: Check the test log message in /var/log/messages
       command: /bin/grep testMessage0000 /var/log/messages
       register: testMessage0000
-      changed_when: not testMessage0000.stdout
+      changed_when: false
 
     - name: Check if the test message is in /var/log/messages
       assert:
-        that: testMessage0000.stdout
+        that: testMessage0000.stdout | length > 0

--- a/tests/tests_enabled.yml
+++ b/tests/tests_enabled.yml
@@ -1,9 +1,8 @@
-
 - name: Ensure that the role runs with rsyslog_enabled=true
   hosts: all
   become: true
   vars:
-    rsyslog_default: True
+    rsyslog_default: true
 
   tasks:
     - name: default run (deploy rsyslog.conf)
@@ -16,7 +15,7 @@
 
     - name: Check rsyslog.conf size
       assert:
-        that: rsyslog_conf_line_count.stdout.0|int > 7
+        that: rsyslog_conf_line_count.stdout.0 | int > 7
 
     - name: Check file counts in rsyslog.d
       assert:

--- a/tests/tests_files.yml
+++ b/tests/tests_files.yml
@@ -59,7 +59,7 @@
     - name: Grep output to messages line
       command: /bin/grep ".var.log.messages" {{ __test_files_conf }}
       register: files_conf_messages
-      changed_when: not files_conf_messages.stdout
+      changed_when: false
 
     - name: Check the filter
       assert:
@@ -67,14 +67,13 @@
 
     - name: Run logger to generate a test log message
       command: /bin/logger -i -p local6.info -t testTag0 testMessage0000
-      register: logger_rc
-      changed_when: not logger_rc.stdout
+      changed_when: false
 
     - name: Check the test log message in /var/log/messages
       command: /bin/grep testMessage0000 /var/log/messages
       register: testMessage0000
-      changed_when: not testMessage0000.stdout
+      changed_when: false
 
     - name: Check if the test message is in /var/log/messages
       assert:
-        that: testMessage0000.stdout
+        that: testMessage0000.stdout | length > 0

--- a/tests/tests_files.yml
+++ b/tests/tests_files.yml
@@ -1,7 +1,9 @@
-
 - name: Ensure that the role runs with parameters to output into local files
   hosts: all
   become: true
+  vars:
+    __test_files_conf: /etc/rsyslog.d/30-output-files.system
+
 
   tasks:
     - name: deploy config to output into local files
@@ -39,28 +41,25 @@
 
     - name: Check rsyslog.conf size
       assert:
-        that: rsyslog_conf_line_count.stdout.0|int <= 7
+        that: rsyslog_conf_line_count.stdout.0 | int <= 7
 
     - name: Check file counts in rsyslog.d
       assert:
         that: rsyslog_d_file_count.matched >= 9
 
-    - name: Set files config path
-      set_fact:
-        test_files_conf: "/etc/rsyslog.d/30-output-files.system"
-
     - name: Get the files config stat
       stat:
-        path: "{{ test_files_conf }}"
+        path: "{{ __test_files_conf }}"
       register: stat_output_files_system
 
     - name: Check if the files config exists
       assert:
-        that: stat_output_files_system.stat.exists == True
+        that: stat_output_files_system.stat.exists
 
     - name: Grep output to messages line
-      command: /bin/grep ".var.log.messages" {{ test_files_conf }}
+      command: /bin/grep ".var.log.messages" {{ __test_files_conf }}
       register: files_conf_messages
+      changed_when: not files_conf_messages.stdout
 
     - name: Check the filter
       assert:
@@ -68,12 +67,14 @@
 
     - name: Run logger to generate a test log message
       command: /bin/logger -i -p local6.info -t testTag0 testMessage0000
+      register: logger_rc
+      changed_when: not logger_rc.stdout
 
     - name: Check the test log message in /var/log/messages
       command: /bin/grep testMessage0000 /var/log/messages
       register: testMessage0000
+      changed_when: not testMessage0000.stdout
 
     - name: Check if the test message is in /var/log/messages
       assert:
-        that: testMessage0000.stdout != ""
-
+        that: testMessage0000.stdout

--- a/tests/tests_files_files.yml
+++ b/tests/tests_files_files.yml
@@ -59,7 +59,7 @@
     - name: Grep output to messages line
       command: /bin/grep ".var.log.messages" {{ test_outputfiles_conf }}
       register: files_conf_messages
-      changed_when: files_conf_messages.stdout
+      changed_when: false
 
     - name: Set input files config path
       set_fact:
@@ -77,12 +77,12 @@
     - name: Cat input file
       command: /bin/cat {{ test_inputfiles_conf }}
       register: cat_file
-      changed_when: cat_file.stdout
+      changed_when: false
 
     - name: Grep input file
       command: /bin/grep 'inputdirectory' {{ test_inputfiles_conf }}
       register: files_conf_input_file
-      changed_when: files_conf_input_file.stdout
+      changed_when: false
 
     - name: Check the filter
       assert:

--- a/tests/tests_files_files.yml
+++ b/tests/tests_files_files.yml
@@ -1,17 +1,14 @@
-
 - name: Ensure that the role runs with parameters to output into local files
   hosts: all
   become: true
+  vars:
+    __test_inputfiles_dir: /var/log/inputdirectory
 
   tasks:
-    - name: Set input file dir
-      set_fact:
-        test_inputfiles_dir: "/var/log/inputdirectory"
-
     - name: deploy config to output into local files
       vars:
-        logging_enabled: True
-        rsyslog_default: False
+        logging_enabled: true
+        rsyslog_default: false
         logging_outputs:
           - name: files-output
             type: files
@@ -26,7 +23,7 @@
             logs_collections:
               - name: files_input
                 type: files
-                rsyslog_input_log_path: "{{ test_inputfiles_dir }}/*.log"
+                rsyslog_input_log_path: "{{ __test_inputfiles_dir }}/*.log"
                 rsyslog_input_log_tag: "newtag"
       include_role:
         name: linux-system-roles.logging
@@ -40,7 +37,7 @@
 
     - name: Check rsyslog.conf size
       assert:
-        that: rsyslog_conf_line_count.stdout.0|int <= 7
+        that: rsyslog_conf_line_count.stdout.0 | int <= 7
 
     - name: Check file counts in rsyslog.d
       assert:
@@ -57,11 +54,12 @@
 
     - name: Check if the output files config exists
       assert:
-        that: stat_output_files_system.stat.exists == True
+        that: stat_output_files_system.stat.exists
 
     - name: Grep output to messages line
       command: /bin/grep ".var.log.messages" {{ test_outputfiles_conf }}
       register: files_conf_messages
+      changed_when: files_conf_messages.stdout
 
     - name: Set input files config path
       set_fact:
@@ -74,21 +72,18 @@
 
     - name: Check if the input files config exists
       assert:
-        that: stat_input_files_conf.stat.exists == True
+        that: stat_input_files_conf.stat.exists
 
-    - name: CAt input file
+    - name: Cat input file
       command: /bin/cat {{ test_inputfiles_conf }}
       register: cat_file
-
-    - name: CAt input file 2
-      debug:
-        msg: cat_file.stdout
+      changed_when: cat_file.stdout
 
     - name: Grep input file
       command: /bin/grep 'inputdirectory' {{ test_inputfiles_conf }}
       register: files_conf_input_file
+      changed_when: files_conf_input_file.stdout
 
     - name: Check the filter
       assert:
         that: files_conf_input_file.stdout is match("input\(type=\"imfile\" file=\"\/var\/log\/inputdirectory\/\*\.log\" tag=\"newtag\"\)")
-

--- a/tests/tests_files_forwards.yml
+++ b/tests/tests_files_forwards.yml
@@ -1,13 +1,14 @@
-
 - name: Ensure that the role runs with parameters to output into local files
   hosts: all
   become: true
+  vars:
+    __test_files_conf: /etc/rsyslog.d/30-output-files.system
 
   tasks:
     - name: deploy config to output into local files
       vars:
-        logging_enabled: True
-        rsyslog_default: False
+        logging_enabled: true
+        rsyslog_default: false
         logging_outputs:
           - name: output-files
             type: files
@@ -51,28 +52,25 @@
 
     - name: Check rsyslog.conf size
       assert:
-        that: rsyslog_conf_line_count.stdout.0|int <= 7
+        that: rsyslog_conf_line_count.stdout.0 | int <= 7
 
     - name: Check file counts in rsyslog.d
       assert:
         that: rsyslog_d_file_count.matched >= 9
 
-    - name: Set files config path
-      set_fact:
-        test_files_conf: "/etc/rsyslog.d/30-output-files.system"
-
     - name: Get the files config stat
       stat:
-        path: "{{ test_files_conf }}"
+        path: "{{ __test_files_conf }}"
       register: stat_output_files_system
 
     - name: Check if the files config exists
       assert:
-        that: stat_output_files_system.stat.exists == True
+        that: stat_output_files_system.stat.exists
 
     - name: Grep output to messages line
-      command: /bin/grep ".var.log.messages" {{ test_files_conf }}
+      command: /bin/grep ".var.log.messages" {{ __test_files_conf }}
       register: files_conf_messages
+      changed_when: not files_conf_messages.stdout
 
     - name: Check the filter
       assert:
@@ -80,14 +78,17 @@
 
     - name: Run logger to generate a test log message
       command: /bin/logger -i -p local6.info -t testTag0 testMessage0000
+      register: logger_rc
+      changed_when: not logger_rc.stdout
 
     - name: Check the test log message in /var/log/messages
       command: /bin/grep testMessage0000 /var/log/messages
       register: testMessage0000
+      changed_when: not testMessage0000.stdout
 
     - name: Check if the test message is in /var/log/messages
       assert:
-        that: testMessage0000.stdout != ""
+        that: testMessage0000.stdout
 
     - name: Set forwarding config path
       set_fact:
@@ -100,13 +101,13 @@
 
     - name: Check if the forwarding config exists
       assert:
-        that: stat_output_forwards_system.stat.exists == True
+        that: stat_output_forwards_system.stat.exists
 
     - name: Grep severity_and_facility
       command: /bin/grep "\<severity_and_facility\>" {{ test_forward_conf }}
       register: severity_and_facility
+      changed_when: not severity_and_facility.stdout
 
     - name: Check severity_and_facility
       assert:
         that: severity_and_facility.stdout is match("local1\.info action.name=.severity_and_facility.* Target=.host.domain. Port=.1514. Protocol=.tcp.*")
-

--- a/tests/tests_files_forwards.yml
+++ b/tests/tests_files_forwards.yml
@@ -70,7 +70,7 @@
     - name: Grep output to messages line
       command: /bin/grep ".var.log.messages" {{ __test_files_conf }}
       register: files_conf_messages
-      changed_when: not files_conf_messages.stdout
+      changed_when: false
 
     - name: Check the filter
       assert:
@@ -78,17 +78,16 @@
 
     - name: Run logger to generate a test log message
       command: /bin/logger -i -p local6.info -t testTag0 testMessage0000
-      register: logger_rc
-      changed_when: not logger_rc.stdout
+      changed_when: false
 
     - name: Check the test log message in /var/log/messages
       command: /bin/grep testMessage0000 /var/log/messages
       register: testMessage0000
-      changed_when: not testMessage0000.stdout
+      changed_when: false
 
     - name: Check if the test message is in /var/log/messages
       assert:
-        that: testMessage0000.stdout
+        that: testMessage0000.stdout | length > 0
 
     - name: Set forwarding config path
       set_fact:
@@ -106,7 +105,7 @@
     - name: Grep severity_and_facility
       command: /bin/grep "\<severity_and_facility\>" {{ test_forward_conf }}
       register: severity_and_facility
-      changed_when: not severity_and_facility.stdout
+      changed_when: false
 
     - name: Check severity_and_facility
       assert:

--- a/tests/tests_forwards.yml
+++ b/tests/tests_forwards.yml
@@ -1,14 +1,15 @@
-
 - name: Deploy rsyslog conf on the target host as a client
   hosts: all
   become: true
+  vars:
+    __test_forward_conf: /etc/rsyslog.d/30-output-forwards.system
 
   tasks:
     - name: Deploy rsyslog config on the target host
       vars:
-        logging_enabled: True
-        logging_purge_confs: True
-        rsyslog_default: False
+        logging_enabled: true
+        logging_purge_confs: true
+        rsyslog_default: false
         logging_outputs:
           - name: output-forwards
             type: forwards
@@ -47,88 +48,89 @@
             logs_collections:
               - name: basic_input
                 type: basics
-
       include_role:
         name: linux-system-roles.logging
 
-    - name: Set forwarding config path
-      set_fact:
-        test_forward_conf: "/etc/rsyslog.d/30-output-forwards.system"
-
     - name: Get the forwarding config stat
       stat:
-        path: "{{ test_forward_conf }}"
+        path: "{{ __test_forward_conf }}"
       register: stat_output_forwards_system
 
     - name: Check if the forwarding config exists
       assert:
-        that: stat_output_forwards_system.stat.exists == True
+        that: stat_output_forwards_system.stat.exists
 
     - name: Grep severity_and_facility
-      command: /bin/grep "\<severity_and_facility\>" {{ test_forward_conf }}
+      command: /bin/grep "\<severity_and_facility\>" {{ __test_forward_conf }}
       register: severity_and_facility
+      changed_when: not severity_and_facility.stdout
 
     - name: Check severity_and_facility
       assert:
         that: severity_and_facility.stdout is match("local1\.info action.name=.severity_and_facility.* Target=.host.domain. Port=.1514. Protocol=.tcp.*")
 
     - name: Grep facility_only
-      command: /bin/grep "\<facility_only\>" {{ test_forward_conf }}
+      command: /bin/grep "\<facility_only\>" {{ __test_forward_conf }}
       register: facility_only
+      changed_when: not facility_only.stdout
 
     - name: Check facility_only
       assert:
         that: facility_only.stdout is match("local2\.\* action.name=.facility_only.* Target=.host.domain. Port=.2514. Protocol=.tcp.")
 
     - name: Grep severity_only
-      command: /bin/grep "\<severity_only\>" {{ test_forward_conf }}
+      command: /bin/grep "\<severity_only\>" {{ __test_forward_conf }}
       register: severity_only
+      changed_when: not severity_only.stdout
 
     - name: Check severity_only
       assert:
         that: severity_only.stdout is match("\*\.err action.name=.severity_only.* Target=.host.domain. Port=.3514. Protocol=.tcp.*")
 
     - name: Grep no_severity_and_facility
-      command: /bin/grep "\<no_severity_and_facility\>" {{ test_forward_conf }}
+      command: /bin/grep "\<no_severity_and_facility\>" {{ __test_forward_conf }}
       register: no_severity_and_facility
+      changed_when: not no_severity_and_facility.stdout
 
     - name: Check no_severity_and_facility
       assert:
         that: no_severity_and_facility.stdout is match("\*\.\* action.name=.no_severity_and_facility.* Target=.host.domain. Port=.4514. Protocol=.tcp.")
 
     - name: Grep no_severity_and_facility_protocol
-      command: /bin/grep "\<no_severity_and_facility_protocol\>" {{ test_forward_conf }}
+      command: /bin/grep "\<no_severity_and_facility_protocol\>" {{ __test_forward_conf }}
       register: no_severity_and_facility_protocol
+      changed_when: not no_severity_and_facility_protocol.stdout
 
     - name: Check no_severity_and_facility_protocol
       assert:
         that: no_severity_and_facility_protocol.stdout is match("\*\.\* action.name=.no_severity_and_facility_protocol.* Target=.host.domain. Port=.5514. Protocol=.tcp.")
 
     - name: Grep no_severity_and_facility_udp
-      command: /bin/grep "\<no_severity_and_facility_udp\>" {{ test_forward_conf }}
+      command: /bin/grep "\<no_severity_and_facility_udp\>" {{ __test_forward_conf }}
       register: no_severity_and_facility_udp
+      changed_when: not no_severity_and_facility_udp.stdout
 
     - name: Check no_severity_and_facility_udp
       assert:
         that: no_severity_and_facility_udp.stdout is match("\*\.\* action.name=.no_severity_and_facility_udp.* Target=.host.domain. Port=.6514. Protocol=.udp.")
 
     - name: Grep no_severity_and_facility_protocol_port
-      command: /bin/grep "\<no_severity_and_facility_protocol_port\>" {{ test_forward_conf }}
+      command: /bin/grep "\<no_severity_and_facility_protocol_port\>" {{ __test_forward_conf }}
       register: no_severity_and_facility_protocol_port
+      changed_when: not no_severity_and_facility_protocol_port.stdout
 
     - name: Check no_severity_and_facility_protocol_port
       assert:
         that: no_severity_and_facility_protocol_port.stdout is match("\*\.\* action.name=.no_severity_and_facility_protocol_port.* Target=.host.domain. Port=.514. Protocol=.tcp.")
 
     - name: Grep no_severity_and_facility_protocol_port_target
-      command: /bin/grep "\<no_severity_and_facility_protocol_port_target\>" {{ test_forward_conf }}
+      command: /bin/grep "\<no_severity_and_facility_protocol_port_target\>" {{ __test_forward_conf }}
       register: result
+      changed_when: result.stdout
       failed_when: result.rc != 1
 
     - name: Grep no_name
-      command: /bin/grep "\<no_name\.localdomain\>" {{ test_forward_conf }}
+      command: /bin/grep "\<no_name\.localdomain\>" {{ __test_forward_conf }}
       register: result
+      changed_when: result.stdout
       failed_when: result.rc != 1
-
-# - name: no_severity_and_facility_protocol_port_target
-# - target: no_name.localdomain

--- a/tests/tests_forwards.yml
+++ b/tests/tests_forwards.yml
@@ -63,7 +63,7 @@
     - name: Grep severity_and_facility
       command: /bin/grep "\<severity_and_facility\>" {{ __test_forward_conf }}
       register: severity_and_facility
-      changed_when: not severity_and_facility.stdout
+      changed_when: false
 
     - name: Check severity_and_facility
       assert:
@@ -72,7 +72,7 @@
     - name: Grep facility_only
       command: /bin/grep "\<facility_only\>" {{ __test_forward_conf }}
       register: facility_only
-      changed_when: not facility_only.stdout
+      changed_when: false
 
     - name: Check facility_only
       assert:
@@ -81,7 +81,7 @@
     - name: Grep severity_only
       command: /bin/grep "\<severity_only\>" {{ __test_forward_conf }}
       register: severity_only
-      changed_when: not severity_only.stdout
+      changed_when: false
 
     - name: Check severity_only
       assert:
@@ -90,7 +90,7 @@
     - name: Grep no_severity_and_facility
       command: /bin/grep "\<no_severity_and_facility\>" {{ __test_forward_conf }}
       register: no_severity_and_facility
-      changed_when: not no_severity_and_facility.stdout
+      changed_when: false
 
     - name: Check no_severity_and_facility
       assert:
@@ -99,7 +99,7 @@
     - name: Grep no_severity_and_facility_protocol
       command: /bin/grep "\<no_severity_and_facility_protocol\>" {{ __test_forward_conf }}
       register: no_severity_and_facility_protocol
-      changed_when: not no_severity_and_facility_protocol.stdout
+      changed_when: false
 
     - name: Check no_severity_and_facility_protocol
       assert:
@@ -108,7 +108,7 @@
     - name: Grep no_severity_and_facility_udp
       command: /bin/grep "\<no_severity_and_facility_udp\>" {{ __test_forward_conf }}
       register: no_severity_and_facility_udp
-      changed_when: not no_severity_and_facility_udp.stdout
+      changed_when: false
 
     - name: Check no_severity_and_facility_udp
       assert:
@@ -117,7 +117,7 @@
     - name: Grep no_severity_and_facility_protocol_port
       command: /bin/grep "\<no_severity_and_facility_protocol_port\>" {{ __test_forward_conf }}
       register: no_severity_and_facility_protocol_port
-      changed_when: not no_severity_and_facility_protocol_port.stdout
+      changed_when: false
 
     - name: Check no_severity_and_facility_protocol_port
       assert:
@@ -126,11 +126,11 @@
     - name: Grep no_severity_and_facility_protocol_port_target
       command: /bin/grep "\<no_severity_and_facility_protocol_port_target\>" {{ __test_forward_conf }}
       register: result
-      changed_when: result.stdout
+      changed_when: false
       failed_when: result.rc != 1
 
     - name: Grep no_name
       command: /bin/grep "\<no_name\.localdomain\>" {{ __test_forward_conf }}
       register: result
-      changed_when: result.stdout
+      changed_when: false
       failed_when: result.rc != 1

--- a/tests/tests_listen.yml
+++ b/tests/tests_listen.yml
@@ -43,7 +43,7 @@
         set -o pipefail
         lsof -i -nP | grep rsyslogd
       register: lsof_output0
-      changed_when: not lsof_output0.stdout
+      changed_when: false
 
     - debug:
         msg: "lsof returned {{ lsof_output0.stdout }}"
@@ -53,11 +53,11 @@
         set -o pipefail
         lsof -i -nP | grep rsyslogd | grep TCP | grep 514
       register: lsof_output1
-      changed_when: not lsof_output1.stdout
+      changed_when: false
 
     - name: Check port 514 is open for UDP
       shell: |
         set -o pipefail
         lsof -i -nP | grep rsyslogd | grep UDP | grep 514
       register: lsof_output2
-      changed_when: not lsof_output2.stdout
+      changed_when: false

--- a/tests/tests_listen.yml
+++ b/tests/tests_listen.yml
@@ -1,4 +1,3 @@
-
 - name: Ensure that rsyslog configured as a server listens on the port 514
   hosts: all
   become: true
@@ -33,21 +32,32 @@
 
     - name: Check rsyslog.conf size
       assert:
-        that: rsyslog_conf_line_count.stdout.0|int <= 7
+        that: rsyslog_conf_line_count.stdout.0 | int <= 7
 
     - name: Check file counts in rsyslog.d
       assert:
         that: rsyslog_d_file_count.matched >= 7
 
     - name: lsof outputs for rsyslogd
-      shell: lsof -i -nP | grep rsyslogd
-      register: lsof_output
+      shell: |
+        set -o pipefail
+        lsof -i -nP | grep rsyslogd
+      register: lsof_output0
+      changed_when: not lsof_output0.stdout
 
     - debug:
-        msg: "lsof returned {{ lsof_output.stdout }}"
+        msg: "lsof returned {{ lsof_output0.stdout }}"
 
     - name: Check port 514 is open for TCP
-      shell: lsof -i -nP | grep rsyslogd | grep TCP | grep 514
+      shell: |
+        set -o pipefail
+        lsof -i -nP | grep rsyslogd | grep TCP | grep 514
+      register: lsof_output1
+      changed_when: not lsof_output1.stdout
 
     - name: Check port 514 is open for UDP
-      shell: lsof -i -nP | grep rsyslogd | grep UDP | grep 514
+      shell: |
+        set -o pipefail
+        lsof -i -nP | grep rsyslogd | grep UDP | grep 514
+      register: lsof_output2
+      changed_when: not lsof_output2.stdout


### PR DESCRIPTION
- Gathering package facts with package_facts first.
- Using ansible_facts.packages['rsyslog'][0].version for the rsyslog version.
- Renaming a variable rsyslog_packages with rsyslog_extra_packages to make it clearer. With this variable, customers are allowed to install extra rsyslog packages required for their custom configurations if any.
- Renaming a variable backupdir with rsyslog_backup_dir. Pre-existing config files are copied to the directory.  Default to /tmp/rsyslog.d-DATETIME.
- Renaming a pair of variables rsyslog_role_packages and rsyslog_role_rules with __rsyslog_packages and __rsyslog_rules, respectively.  Note: the vars start with `__` since they are internal.  By the same token, the underneath sub rule names and their items are also changed to start with __, e.g.,
      rsyslog_common_rules --> __rsyslog_common_rules
      rsyslog_conf_global_options --> __rsyslog_conf_global_options
- The internal variables are moved from defaults/main.yaml to vars/main.yaml.
- Fixing the relative path from role_path in roles/rsyslog/roles/*_roles/*/tasks/main.yaml.
- Removing set_test from CI tests.
- To call include_role, instead of setting variables to pass with set_fact, set them with "vars" to make them local in the scope.
- If rsyslog is not found, e.g., in case of the check mode, set 0.0.0 to __rsyslog_version.

Fixing travis-ci
- forcing to install molecule < 3.
- fixing yamllint and ansible-lint errors excepot 'state: latest' for the package module, lines longer than 160 chars, and commands should not change things if nothing needs doing.
- replacing var use_rsyslog_image with rsylog_in_image and set it to false by default.
