### PR TITLE
Fixing obsolete default paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,8 +176,8 @@ Variables in vars.yml
 - `logging_collector`: The logs collector to use for the logs collection. Currently Rsyslog is the only supported logs collector. Defaults to `rsyslog`.
 - `logging_enabled` : When 'true', logging role will deploy specified configuration file set. Default to 'true'.
 - `logging_purge_confs`: By default, the Rsyslog configuration files are applied on top of pre-existing configuration files. To purge local files prior to setting new ones, set logging_purge_confs variable to 'true', it will move all Rsyslog configuration files to a backup directory, `/tmp/rsyslog.d-XXXXXX/backup.tgz`, before deploying the new configuration files. Defaults to 'false'.
-- `logging_mmk8s_token`: Path to token for kubernetes.  Default to "/etc/rsyslog.d/viaq/mmk8s.token".
-- `logging_mmk8s_ca_cert`: Path to CA cert for kubernetes.  Default to "/etc/rsyslog.d/viaq/mmk8s.ca.crt".
+- `logging_mmk8s_token`: Path to token for kubernetes.  Default to "/etc/rsyslog.d/mmk8s.token".
+- `logging_mmk8s_ca_cert`: Path to CA cert for kubernetes.  Default to "/etc/rsyslog.d/mmk8s.ca.crt".
 
 - `logging_outputs`: A set of following variables to specify output configurations.  It could be an list if multiple outputs that should to be configured.
    -  **If `type: elasticsearch`**, send logs to one or more remote elasticsearch or Viaq installations.
@@ -191,9 +191,9 @@ Variables in vars.yml
       - `server_host`: Hostname elasticsearch is running on.
       - `server_port`: Port number elasticsearch is listening to.
       - `index_prefix`: Elasticsearch index prefix the particular log will be indexed to.
-      - `ca_cert`: Path to CA cert for ElasticSearch.  Default to '/etc/rsyslog.d/elasticsearch/es-ca.crt'
-      - `cert`: Path to cert for ElasticSearch.  Default to '/etc/rsyslog.d/elasticsearch/es-cert.pem'
-      - `key`: Path to key for ElasticSearch.  Default to "/etc/rsyslog.d/elasticsearch/es-key.pem"
+      - `ca_cert`: Path to CA cert for ElasticSearch.  Default to '/etc/rsyslog.d/es-ca.crt'
+      - `cert`: Path to cert for ElasticSearch.  Default to '/etc/rsyslog.d/es-cert.pem'
+      - `key`: Path to key for ElasticSearch.  Default to "/etc/rsyslog.d/es-key.pem"
    -  **If `type: custom`** To include existing config files in the new ansible deployment, add the paths to custom_config_files as follows.  The specified files are copied to /etc/rsyslog.d.
       - `name`: Name of the custom file output element.
       - `type`: Type of the output element.

--- a/roles/rsyslog/README.md
+++ b/roles/rsyslog/README.md
@@ -151,8 +151,8 @@ logging_outputs:
 ```
 logging_enabled: true
 # If 'viaq-k8s' is in logs collections, logging_mmk8s_* need to be specified.
-logging_mmk8s_token: "{{ rsyslog_viaq_config_dir }}/mmk8s.token"
-logging_mmk8s_ca_cert: "{{ rsyslog_viaq_config_dir }}/mmk8s.ca.crt"
+logging_mmk8s_token: "{{ rsyslog_config_dir }}/mmk8s.token"
+logging_mmk8s_ca_cert: "{{ rsyslog_config_dir }}/mmk8s.ca.crt"
 # If use_omelasticsearch_cert is true, ca_cert, cert and key in rsyslog_outputs needs to be set.
 use_omelasticsearch_cert: true
 # If use_local_omelasticsearch_cert is true, local files ca_cert_src, cert_src and key_src will be deployed to the remote host.
@@ -170,9 +170,9 @@ rsyslog_outputs:
     server_host: logging-es
     server_port: 9200
     index_prefix: project.
-    ca_cert: "{{ rsyslog_viaq_config_dir }}/es-ca.crt"
-    cert: "{{ rsyslog_viaq_config_dir }}/es-cert.pem"
-    key: "{{ rsyslog_viaq_config_dir }}/es-key.pem"
+    ca_cert: "{{ rsyslog_config_dir }}/es-ca.crt"
+    cert: "{{ rsyslog_config_dir }}/es-cert.pem"
+    key: "{{ rsyslog_config_dir }}/es-key.pem"
     ca_cert_src : "/path/to/es-ca.crt"
     cert_src : "/path/to/es-cert.pem"
     key_src : "/path/to/es-key.pem"
@@ -188,9 +188,9 @@ rsyslog_outputs:
     server_host: logging-es-ops
     server_port: 9200
     index_prefix: .operations.
-    ca_cert: "{{ rsyslog_viaq_config_dir }}/es-ca.crt"
-    cert: "{{ rsyslog_viaq_config_dir }}/es-cert.pem"
-    key: "{{ rsyslog_viaq_config_dir }}/es-key.pem"
+    ca_cert: "{{ rsyslog_config_dir }}/es-ca.crt"
+    cert: "{{ rsyslog_config_dir }}/es-cert.pem"
+    key: "{{ rsyslog_config_dir }}/es-key.pem"
     ca_cert_src : "/path/to/es-ca.crt"
     cert_src : "/path/to/es-cert.pem"
     key_src : "/path/to/es-key.pem"
@@ -204,9 +204,9 @@ if index_prefix starts with "project." then {
       server="logging-es"
       serverport="9200"
       ....
-      tls.cacert="/etc/rsyslog.d/viaq/es-ca.crt"
-      tls.mycert="/etc/rsyslog.d/viaq/es-cert.pem"
-      tls.myprivkey="/etc/rsyslog.d/viaq/es-key.pem"
+      tls.cacert="/etc/rsyslog.d/es-ca.crt"
+      tls.mycert="/etc/rsyslog.d/es-cert.pem"
+      tls.myprivkey="/etc/rsyslog.d/es-key.pem"
   )
 } else {
   action( 
@@ -215,9 +215,9 @@ if index_prefix starts with "project." then {
       server="logging-es-ops"
       serverport="9200"
       ....
-      tls.cacert="/etc/rsyslog.d/viaq/es-ca.crt"
-      tls.mycert="/etc/rsyslog.d/viaq/es-cert.pem"
-      tls.myprivkey="/etc/rsyslog.d/viaq/es-key.pem"
+      tls.cacert="/etc/rsyslog.d/es-ca.crt"
+      tls.mycert="/etc/rsyslog.d/es-cert.pem"
+      tls.myprivkey="/etc/rsyslog.d/es-key.pem"
   )
 }
 ```
@@ -303,10 +303,9 @@ Files input_role sub-variables
 
 Viaq input_role sub-variables
 -----------------------------
-- `rsyslog_viaq_config_dir`: Directory to store viaq configuration files.  Default to '/etc/rsyslog.d/viaq'.
 - `rsyslog_viaq_log_dir`: Viaq log directory.  Default to '/var/log/containers'.
-- `logging_mmk8s_token`: Path to token for kubernetes.  Default to "/etc/rsyslog.d/viaq/mmk8s.token"
-- `logging_mmk8s_ca_cert`: Path to CA cert for kubernetes.  Default to "/etc/rsyslog.d/viaq/mmk8s.ca.crt"
+- `logging_mmk8s_token`: Path to token for kubernetes.  Default to "/etc/rsyslog.d/mmk8s.token"
+- `logging_mmk8s_ca_cert`: Path to CA cert for kubernetes.  Default to "/etc/rsyslog.d/mmk8s.ca.crt"
 - `use_omelasticsearch_cert` : If set to 'true', omelasticsearch is configured to use the certificates specified in the elasticsearch type logging_outputs.  Default to 'false'.
 - `use_local_omelasticsearch_cert` : If set to 'true', local files ca_cert_src, cert_src and key_src in the elasticsearch type logging_outputs will be deployed to the remote host.
 
@@ -316,9 +315,9 @@ Viaq input_role sub-variables
   - `server_host`: Hostname elasticsearch is running on.
   - `server_port`: Port number elasticsearch is listening to.
   - `index_prefix`: Elasticsearch index prefix the particular log is to be indexed.
-  - `ca_cert`: Path to CA cert for ElasticSearch.  Default to '/etc/rsyslog.d/elasticsearch/es-ca.crt'
-  - `cert`: Path to cert for ElasticSearch.  Default to '/etc/rsyslog.d/elasticsearc/es-cert.pem'
-  - `key`: Path to key for ElasticSearch.  Default to "/etc/rsyslog.d/elasticsearch/es-key.pem"
+  - `ca_cert`: Path to CA cert for ElasticSearch.  Default to '/etc/rsyslog.d/es-ca.crt'
+  - `cert`: Path to cert for ElasticSearch.  Default to '/etc/rsyslog.d/es-cert.pem'
+  - `key`: Path to key for ElasticSearch.  Default to "/etc/rsyslog.d/es-key.pem"
   - `ca_cert_src`: Path to the local CA cert file to deploy for ElasticSearch.
   - `cert_src`: Path to the local cert file to deploy for ElasticSearch.
   - `key_src`: Path to the local key file to deploy for ElasticSearch.
@@ -364,14 +363,14 @@ By default, the generated configuration file starts with a comment "# Ansible ma
 
 Some full path configuration may be referred from other configuration file, e.g., 20-viaq_formattiong.conf refers parse_json.rulebase as follows.
 ```
-action(type="mmnormalize" ruleBase="{{ rsyslog_viaq_config_dir }}/parse_json.rulebase" variable="$!MESSAGE")
+action(type="mmnormalize" ruleBase="{{ rsyslog_config_dir }}/parse_json.rulebase" variable="$!MESSAGE")
 ```
 In this case, prefix is not needed.  Thus, by setting exact filename, the named configuration file "parse_json.rulebase" is generated.
 ```
   - name: parse_json
     filename: parse_json.rulebase
     nocomment: true
-    path: '{{ rsyslog_viaq_config_dir }}'
+    path: '{{ rsyslog_config_dir }}'
     sections:
 
       - options: |-

--- a/roles/rsyslog/roles/output_roles/elasticsearch/defaults/main.yml
+++ b/roles/rsyslog/roles/output_roles/elasticsearch/defaults/main.yml
@@ -121,9 +121,9 @@ __rsyslog_conf_es_elasticsearch:
                   retryruleset="{{ res.retryruleset | default("try_es") }}"
                   usehttps="{{ res.usehttps | default("on") }}"
           {% if use_omelasticsearch_cert | default(true) %}
-                  tls.cacert="{{ res.ca_cert | default("/etc/rsyslog.d/elasticsearch/es-ca.crt") }}"
-                  tls.mycert="{{ res.cert | default("/etc/rsyslog.d/elasticsearch/es-cert.pem") }}"
-                  tls.myprivkey="{{ res.key | default("/etc/rsyslog.d/elasticsearch/es-key.pem") }}"
+                  tls.cacert="{{ res.ca_cert | default('/etc/rsyslog.d/es-ca.crt') }}"
+                  tls.mycert="{{ res.cert | default('/etc/rsyslog.d/es-cert.pem') }}"
+                  tls.myprivkey="{{ res.key | default('/etc/rsyslog.d/es-key.pem') }}"
           {% endif %}
               )
           {% else %}
@@ -147,9 +147,9 @@ __rsyslog_conf_es_elasticsearch:
                     retryruleset="{{ res.retryruleset | default("try_es") }}"
                     usehttps="{{ res.usehttps | default("on") }}"
           {% if use_omelasticsearch_cert | default(true) %}
-                    tls.cacert="{{ res.ca_cert | default("/etc/rsyslog.d/elasticsearch/es-ca.crt") }}"
-                    tls.mycert="{{ res.cert | default("/etc/rsyslog.d/elasticsearch/es-cert.pem") }}"
-                    tls.myprivkey="{{ res.key | default("/etc/rsyslog.d/elasticsearch/es-key.pem") }}"
+                    tls.cacert="{{ res.ca_cert | default('/etc/rsyslog.d/es-ca.crt') }}"
+                    tls.mycert="{{ res.cert | default('/etc/rsyslog.d/es-cert.pem') }}"
+                    tls.myprivkey="{{ res.key | default('/etc/rsyslog.d/es-key.pem') }}"
           {% endif %}
                 )
           {% elif loop.last %}
@@ -174,9 +174,9 @@ __rsyslog_conf_es_elasticsearch:
           {% endif %}
                     usehttps="{{ res.usehttps | default("on") }}"
           {% if use_omelasticsearch_cert | default(true) %}
-                    tls.cacert="{{ res.ca_cert | default("/etc/rsyslog.d/elasticsearch/es-ca.crt") }}"
-                    tls.mycert="{{ res.cert | default("/etc/rsyslog.d/elasticsearch/es-cert.pem") }}"
-                    tls.myprivkey="{{ res.key | default("/etc/rsyslog.d/elasticsearch/es-key.pem") }}"
+                    tls.cacert="{{ res.ca_cert | default('/etc/rsyslog.d/es-ca.crt') }}"
+                    tls.mycert="{{ res.cert | default('/etc/rsyslog.d/es-cert.pem') }}"
+                    tls.myprivkey="{{ res.key | default('/etc/rsyslog.d/es-key.pem') }}"
           {% endif %}
                 )
           {% else %}
@@ -201,9 +201,9 @@ __rsyslog_conf_es_elasticsearch:
           {% endif %}
                     usehttps="{{ res.usehttps | default("on") }}"
           {% if use_omelasticsearch_cert | default(true) %}
-                    tls.cacert="{{ res.ca_cert | default("/etc/rsyslog.d/elasticsearch/es-ca.crt") }}"
-                    tls.mycert="{{ res.cert | default("/etc/rsyslog.d/elasticsearch/es-cert.pem") }}"
-                    tls.myprivkey="{{ res.key | default("/etc/rsyslog.d/elasticsearch/es-key.pem") }}"
+                    tls.cacert="{{ res.ca_cert | default('/etc/rsyslog.d/es-ca.crt') }}"
+                    tls.mycert="{{ res.cert | default('/etc/rsyslog.d/es-cert.pem') }}"
+                    tls.myprivkey="{{ res.key | default('/etc/rsyslog.d/es-key.pem') }}"
           {% endif %}
                 )
           {% endif %}


### PR DESCRIPTION
Fixing obsolete default paths in README.md, roles/rsyslog/README.md and roles/rsyslog/roles/output_roles/elasticsearch/defaults/main.yml.