### PR TITLE
Removing "changed_when: false" from creating a work and backup direct…

### DIFF
--- a/roles/rsyslog/tasks/main.yml
+++ b/roles/rsyslog/tasks/main.yml
@@ -70,7 +70,6 @@
         owner: '{{ rsyslog_user }}'
         group: '{{ rsyslog_file_group }}'
         mode: 0700
-      changed_when: false
 
     # Creating a backup dir for rsyslog.d
     - name: Set backup dir name


### PR DESCRIPTION
…ory.

Changed needs to be bumped even when the change is outside of the rsyslog
configuration.