### PR TITLE
Instead of using set_fact to set internal variables, use role variables in the main task file

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,6 @@ Variables in vars.yml
 
 - `logging_collector`: The logs collector to use for the logs collection. Currently Rsyslog is the only supported logs collector. Defaults to `rsyslog`. WARNING: this is going to be renamed to logging_provider.
 - `logging_enabled` : When 'true', logging role will deploy specified configuration file set. Default to 'true'.
-- `logging_purge_confs`: By default, the Rsyslog configuration files are applied on top of pre-existing configuration files. To purge local files prior to setting new ones, set logging_purge_confs variable to 'true', it will move all Rsyslog configuration files to a backup directory, `/tmp/rsyslog.d-XXXXXX/backup.tgz`, before deploying the new configuration files. Defaults to 'false'.
 - `logging_mmk8s_token`: Path to token for kubernetes.  Default to "/etc/rsyslog.d/mmk8s.token".
 - `logging_mmk8s_ca_cert`: Path to CA cert for kubernetes.  Default to "/etc/rsyslog.d/mmk8s.ca.crt".
 - `logging_outputs`: A set of following variables to specify output configurations.  It could be an list if multiple outputs that should to be configured.
@@ -241,6 +240,9 @@ Variables in vars.yml
         - `name`: Unique name of the input.
           `type`: The type of the pre-configured logs to collect. **Note:** Currently ['viaq', 'viaq-k8s', 'ovirt'] are supported for the elasticsearch output.
           `state`: The state of the configuration files states if they should be `present` or `absent`. Default to `present`.
+
+- `logging_purge_confs`: By default, the Rsyslog configuration files are applied on top of pre-existing configuration files. To purge local files prior to setting new ones, set logging_purge_confs variable to 'true', it will move all Rsyslog configuration files to a backup directory, `/tmp/rsyslog.d-XXXXXX/backup.tgz`, before deploying the new configuration files. Defaults to 'false'.
+- `logging_system_log_dir`: System log directory.  Default to '/var/log'.
 
 playbook.yml
 -------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,3 +16,6 @@ logging_flows: []
 
 # If logging_purge_confs is set to true, existing config files will be purged.
 logging_purge_confs: false
+
+# Variable to specify the directory to put the local output files to store logs.
+logging_system_log_dir: /var/log

--- a/roles/rsyslog/README.md
+++ b/roles/rsyslog/README.md
@@ -138,7 +138,7 @@ logging_flows:
 ```
 logging_enabled: true
 rsyslog_default: false
-rsyslog_purge_original_conf: true
+logging_purge_confs: true
 logging_outputs:
   - name: output-forwards0
     type: forwards
@@ -209,8 +209,6 @@ Common sub-variables
 - `rsyslog_config_dir`: Directory to store configuration files.  Default to '/etc/rsyslog.d'.
 - `rsyslog_custom_config_files`: List of custom configuration files are deployed to /etc/rsyslog.d.  The format is an array which element is the full path to each custom configuration file.  Default to none.
 - `rsyslog_in_image`: Specifies if the target host is a container and use rsyslog in the image. Default to false.
-- `rsyslog_purge_original_conf`: By default, the Rsyslog configuration files are applied on top of pre-existing configuration files. To purge local files prior to setting new ones, set `rsyslog_purge_original_conf` variable to 'true', it will move all Rsyslog configuration files to a backup directory before deploying the new configuration files. Defaults to 'false'.
-- `rsyslog_system_log_dir`: System log directory.  Default to '/var/log'.
 - `rsyslog_work_dir`: Working directory.  Default to '/var/lib/rsyslog'.
 
 Elasticsearch, Files and Forwards outputs sub-variables

--- a/roles/rsyslog/defaults/main.yml
+++ b/roles/rsyslog/defaults/main.yml
@@ -2,11 +2,6 @@
 # General configuration
 # ---------------------
 
-# rsyslog_enabled
-#
-# Enable or disable ``rsyslog`` management.
-rsyslog_enabled: true
-
 # rsyslog_in_image
 #
 # true if the target host is a container and use rsyslog in the image.
@@ -17,11 +12,6 @@ rsyslog_in_image: false
 # Diploy default ``rsyslog`` configuration file /etc/rsyslog.conf if it is set to true.
 # Otherwise, rsyslog.conf just includes configuration files in /etc/rsyslog.d.
 rsyslog_default: false
-
-# rsyslog_system_log_dir
-#
-# Top directory to place logs
-rsyslog_system_log_dir: '/var/log'
 
 # rsyslog_config_dir
 #
@@ -45,12 +35,6 @@ rsyslog_capabilities: []
 # Enable or disable message reduction. This is disabled by default so that log
 # parsers like :program:`fail2ban` can work correctly.
 rsyslog_message_reduction: false
-
-# rsyslog_purge_original_conf
-#
-# The pre-existing config files are archived in the tempdir and purged if the
-# rsyslog_purge_original_conf is set to `true`.  Default to 'false`.
-rsyslog_purge_original_conf: false
 
 # rpm packages
 # adding rsyslog packages

--- a/roles/rsyslog/tasks/main.yml
+++ b/roles/rsyslog/tasks/main.yml
@@ -3,7 +3,7 @@
     name: "{{ (__rsyslog_base_packages) + (__rsyslog_tls_packages if rsyslog_pki else []) + (rsyslog_extra_packages | flatten) }}"
     state: latest
   when:
-    - rsyslog_enabled | bool
+    - __rsyslog_enabled | bool
 
 - name: Gather package facts
   package_facts:
@@ -61,13 +61,13 @@
       archive:
         path: ["{{ rsyslog_config_dir }}", /etc/rsyslog.conf]
         dest: "{{ rsyslog_backup_dir }}/backup.tgz"
-        remove: '{{ true if rsyslog_purge_original_conf | bool else false }}'
+        remove: '{{ true if __rsyslog_purge_original_conf | bool else false }}'
       changed_when: false
 
     - name: Create logging directory if it does not exist or the ownership and/or modes are different.
       file:
         state: directory
-        path: '{{ rsyslog_system_log_dir }}'
+        path: '{{ __rsyslog_system_log_dir }}'
         owner: 'root'
         group: 'root'
         mode: '0700'
@@ -77,7 +77,7 @@
         src: 'etc/rsyslog.conf.j2'
         dest: '/etc/rsyslog.conf'
       when:
-        - rsyslog_enabled | bool
+        - __rsyslog_enabled | bool
       notify: restart rsyslogd
 
     - name: Generate common rsyslog configuration files in rsyslog.d
@@ -92,7 +92,7 @@
         mode: '{{ item.mode | d("0644") }}'
       loop: '{{ __rsyslog_common_rules | flatten }}'
       when:
-        - rsyslog_enabled | bool
+        - __rsyslog_enabled | bool
         - logging_inputs | d([])
         - item.filename | d() or item.name | d()
         - item.state is undefined or item.state != 'absent'
@@ -108,7 +108,7 @@
         state: absent
       loop: '{{ __rsyslog_common_rules | flatten }}'
       when:
-        - not rsyslog_enabled | bool
+        - not __rsyslog_enabled | bool
         - logging_inputs | d([])
         - item.filename | d() or item.name | d()
         - item.options | d() or item.sections | d()
@@ -127,7 +127,7 @@
         group: '{{ item.group | d("root") }}'
         mode: '{{ item.mode | d("0644") }}'
       loop: '{{ rsyslog_custom_config_files | flatten }}'
-      when: (rsyslog_enabled | bool)
+      when: __rsyslog_enabled | bool
       notify: restart rsyslogd
 
     - name: Include input sub-vars
@@ -139,7 +139,7 @@
       loop_control:
         loop_var: input_item
       when:
-        - rsyslog_enabled | bool
+        - __rsyslog_enabled | bool
         - input_item | d([])
       tags:
         - skip_ansible_lint
@@ -153,7 +153,7 @@
       loop_control:
         loop_var: input_item
       when:
-        - rsyslog_enabled | bool
+        - __rsyslog_enabled | bool
         - input_item | d([])
       tags:
         - skip_ansible_lint
@@ -179,7 +179,7 @@
       loop_control:
         loop_var: output_item
       when:
-        - rsyslog_enabled | bool
+        - __rsyslog_enabled | bool
         - output_item | d([])
       tags:
         - skip_ansible_lint
@@ -193,7 +193,7 @@
       loop_control:
         loop_var: output_item
       when:
-        - rsyslog_enabled | bool
+        - __rsyslog_enabled | bool
         - output_item | d([])
       tags:
         - skip_ansible_lint
@@ -204,7 +204,7 @@
         enabled: yes
         state: started
       when:
-        - rsyslog_enabled | bool
+        - __rsyslog_enabled | bool
         - not rsyslog_in_image | default(false) | bool
 
     - name: Disable rsyslog service
@@ -213,7 +213,7 @@
         enabled: no
         state: stopped
       when:
-        - not rsyslog_enabled | bool
+        - not __rsyslog_enabled | bool
         - not rsyslog_in_image | default(false) | bool
 
   when: not __rsyslog_failed_validation | d(false)

--- a/roles/rsyslog/templates/etc/rsyslog.conf.j2
+++ b/roles/rsyslog/templates/etc/rsyslog.conf.j2
@@ -53,26 +53,26 @@ $IncludeConfig {{ rsyslog_config_dir }}/*.conf
 
 # Log anything (except mail) of level info or higher.
 # Don't log private authentication messages!
-*.info;mail.none;authpriv.none;cron.none                {{ rsyslog_system_log_dir }}/messages
+*.info;mail.none;authpriv.none;cron.none                {{ __rsyslog_system_log_dir }}/messages
 
 # The authpriv file has restricted access.
-authpriv.*                                              {{ rsyslog_system_log_dir }}/secure
+authpriv.*                                              {{ __rsyslog_system_log_dir }}/secure
 
 # Log all the mail messages in one place.
-mail.*                                                  -{{ rsyslog_system_log_dir }}/maillog
+mail.*                                                  -{{ __rsyslog_system_log_dir }}/maillog
 
 
 # Log cron stuff
-cron.*                                                  {{ rsyslog_system_log_dir }}/cron
+cron.*                                                  {{ __rsyslog_system_log_dir }}/cron
 
 # Everybody gets emergency messages
 *.emerg                                                 :omusrmsg:*
 
 # Save news errors of level crit and higher in a special file.
-uucp,news.crit                                          {{ rsyslog_system_log_dir }}/spooler
+uucp,news.crit                                          {{ __rsyslog_system_log_dir }}/spooler
 
 # Save boot messages also to boot.log
-local7.*                                                {{ rsyslog_system_log_dir }}/boot.log
+local7.*                                                {{ __rsyslog_system_log_dir }}/boot.log
 
 
 # ### sample forwarding rule ###

--- a/roles/rsyslog/vars/inputs/ovirt/main.yml
+++ b/roles/rsyslog/vars/inputs/ovirt/main.yml
@@ -96,7 +96,7 @@ rsyslog_conf_ovirt_formatting:
           }
 
           {% if collect_ovirt_engine_log %}
-          input(type="imfile" file="{{ rsyslog_system_log_dir }}/ovirt-engine/engine.log" tag="ovirt.engine" reopenOnTruncate="on"
+          input(type="imfile" file="{{ __rsyslog_system_log_dir }}/ovirt-engine/engine.log" tag="ovirt.engine" reopenOnTruncate="on"
                 startmsg.regex="^[[:digit:]]{4}-[[:digit:]]{2}-[[:digit:]]{2}")
 
           if $syslogtag == 'ovirt.engine' then {
@@ -105,7 +105,7 @@ rsyslog_conf_ovirt_formatting:
           {% endif %}
 
           {% if collect_ovirt_vdsm_log %}
-          input(type="imfile" file="{{ rsyslog_system_log_dir }}/vdsm/vdsm.log" tag="ovirt.vdsm" reopenOnTruncate="on"
+          input(type="imfile" file="{{ __rsyslog_system_log_dir }}/vdsm/vdsm.log" tag="ovirt.vdsm" reopenOnTruncate="on"
                 startmsg.regex="^[[:digit:]]{4}-[[:digit:]]{2}-[[:digit:]]{2}")
 
           if $syslogtag == 'ovirt.vdsm' then {

--- a/roles/rsyslog/vars/inputs/viaq-k8s/main.yml
+++ b/roles/rsyslog/vars/inputs/viaq-k8s/main.yml
@@ -10,7 +10,7 @@ __rsyslog_viaq_k8s_packages: ['rsyslog-mmjsonparse', 'rsyslog-mmkubernetes']
 # rsyslog_viaq_log_dir
 #
 # Viaq log directory
-rsyslog_viaq_log_dir: '{{ rsyslog_system_log_dir }}/containers'
+rsyslog_viaq_log_dir: '{{ __rsyslog_system_log_dir }}/containers'
 
 # Available configuration set
 # ----------------------------

--- a/roles/rsyslog/vars/outputs/files/main.yml
+++ b/roles/rsyslog/vars/outputs/files/main.yml
@@ -34,7 +34,7 @@ __rsyslog_conf_files_output_modules:
 # __rsyslog_conf_files_output_rules:
 #
 # A set of default ``rsyslog`` options which store local system logs in files
-# located in `{{ rsyslog_system_log_dir }}/` directory. This is mostly the
+# located in `{{ __rsyslog_system_log_dir }}/` directory. This is mostly the
 # same as the default ``rsyslogd`` configuration provided in the installations.
 __rsyslog_conf_files_output_rules:
 
@@ -62,25 +62,25 @@ __rsyslog_conf_files_output_rules:
 
               # Log anything (except mail) of level info or higher.
               # Don't log private authentication messages!
-              *.info;mail.none;authpriv.none;cron.none                {{ rsyslog_system_log_dir }}/messages
+              *.info;mail.none;authpriv.none;cron.none                {{ __rsyslog_system_log_dir }}/messages
 
               # The authpriv file has restricted access.
-              authpriv.*                                              {{ rsyslog_system_log_dir }}/secure
+              authpriv.*                                              {{ __rsyslog_system_log_dir }}/secure
 
               # Log all the mail messages in one place.
-              mail.*                                                  -{{ rsyslog_system_log_dir }}/maillog
+              mail.*                                                  -{{ __rsyslog_system_log_dir }}/maillog
 
               # Log cron stuff
-              cron.*                                                  -{{ rsyslog_system_log_dir }}/cron
+              cron.*                                                  -{{ __rsyslog_system_log_dir }}/cron
 
               # Everybody gets emergency messages
               *.emerg                                                  :omusrmsg:*
 
               # Save news errors of level crit and higher in a special file.
-              uucp,news.crit                                          {{ rsyslog_system_log_dir }}/spooler
+              uucp,news.crit                                          {{ __rsyslog_system_log_dir }}/spooler
 
               # Save boot messages also to boot.log
-              local7.*                                                {{ rsyslog_system_log_dir }}/boot.log
+              local7.*                                                {{ __rsyslog_system_log_dir }}/boot.log
           }
           {%   endif %}
           {% endfor %}
@@ -108,42 +108,42 @@ __rsyslog_conf_remote_templates:
           template(
             name="RemoteMessage"
             type="string"
-            string="{{ rsyslog_system_log_dir }}/remote/msg/%HOSTNAME%/%PROGRAMNAME:::secpath-replace%.log"
+            string="{{ __rsyslog_system_log_dir }}/remote/msg/%HOSTNAME%/%PROGRAMNAME:::secpath-replace%.log"
           )
 
           # Template for Remote host auth logs
           template(
             name="RemoteHostAuthLog"
             type="string"
-            string="{{ rsyslog_system_log_dir }}/remote/auth/%HOSTNAME%/%PROGRAMNAME:::secpath-replace%.log"
+            string="{{ __rsyslog_system_log_dir }}/remote/auth/%HOSTNAME%/%PROGRAMNAME:::secpath-replace%.log"
           )
 
           # Template for Remote host cron logs
           template(
             name="RemoteHostCronLog"
             type="string"
-            string="{{ rsyslog_system_log_dir }}/remote/cron/%HOSTNAME%/%PROGRAMNAME:::secpath-replace%.log"
+            string="{{ __rsyslog_system_log_dir }}/remote/cron/%HOSTNAME%/%PROGRAMNAME:::secpath-replace%.log"
           )
 
           # Template for Remote service auth logs
           template(
             name="RemoteServiceAuthLog"
             type="string"
-            string="{{ rsyslog_system_log_dir }}/remote/services/auth/%HOSTNAME%/%PROGRAMNAME:::secpath-replace%.log"
+            string="{{ __rsyslog_system_log_dir }}/remote/services/auth/%HOSTNAME%/%PROGRAMNAME:::secpath-replace%.log"
           )
 
           # Template for Remote service cron logs
           template(
             name="RemoteServiceCronLog"
             type="string"
-            string="{{ rsyslog_system_log_dir }}/remote/services/cron/%HOSTNAME%/%PROGRAMNAME:::secpath-replace%.log"
+            string="{{ __rsyslog_system_log_dir }}/remote/services/cron/%HOSTNAME%/%PROGRAMNAME:::secpath-replace%.log"
           )
 
           # Template for Remote service mail logs
           template(
             name="RemoteServiceMailLog"
             type="string"
-            string="{{ rsyslog_system_log_dir }}/remote/services/mail/%HOSTNAME%/%PROGRAMNAME:::secpath-replace%.log"
+            string="{{ __rsyslog_system_log_dir }}/remote/services/mail/%HOSTNAME%/%PROGRAMNAME:::secpath-replace%.log"
           )
 
           # Include custom templates

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,10 +2,6 @@
 - name: Set Rsyslog facts then include rsyslog role
   block:
 
-    - name: Set rsyslog_enabled
-      set_fact:
-        rsyslog_enabled: "{{ logging_enabled | d(true) }}"
-
     - name: Set rsyslog_output_elasticsearch for the omelasticsearch output
       set_fact:
         rsyslog_output_elasticsearch: "{{ logging_outputs | selectattr('name', 'defined') | selectattr('type', 'defined') | selectattr('type', '==', 'elasticsearch') | list }}"
@@ -28,11 +24,6 @@
     - name: Set rsyslog_outputs
       set_fact:
         rsyslog_outputs: '{{ rsyslog_output_elasticsearch | d([]) }} + {{ rsyslog_output_files | d([]) }} + {{ rsyslog_output_forwards | d([]) }}'
-
-    - name: Set rsyslog_purge_original_conf fact to purge all configuration files before saving the new ones.
-      set_fact:
-        rsyslog_purge_original_conf: yes
-      when: logging_purge_confs | d(false)
 
     - name: Set custom_config_files fact
       set_fact:
@@ -79,6 +70,10 @@
         - logging_debug | d(false)
 
     - name: Include Rsyslog role
+      vars:
+        __rsyslog_enabled: "{{ logging_enabled }}"
+        __rsyslog_purge_original_conf: "{{ logging_purge_confs }}"
+        __rsyslog_system_log_dir: "{{ logging_system_log_dir }}"
       include_role:
         name: "{{ role_path }}/roles/rsyslog"
 

--- a/tests/tests_default_files_log_dir.yml
+++ b/tests/tests_default_files_log_dir.yml
@@ -1,0 +1,75 @@
+- name: Ensure that the role runs with parameters to output into local files in a specified path
+  hosts: all
+  become: true
+  vars:
+    __test_files_conf: /etc/rsyslog.d/30-output-files.conf
+    logging_system_log_dir: '/var/log/rsyslog'
+
+  tasks:
+    - name: deploy config to output into local files
+      vars:
+        logging_enabled: true
+        rsyslog_default: false
+        logging_outputs:
+          - name: files-output
+            type: files
+        logging_inputs:
+          - name: basic-input
+            type: basics
+        logging_flows:
+          - name: flows0
+            inputs: [basic-input]
+            outputs: [files-output]
+      include_role:
+        name: linux-system-roles.logging
+
+    - include: set_rsyslog_variables.yml
+
+    # notify restart rsyslogd is executed at the end of this test task.
+    # thus we have to force to invoke handlers
+    - name: Force all notified handlers to run at this point, not waiting for normal sync points
+      meta: flush_handlers
+
+    - name: Check rsyslog.conf size
+      assert:
+        that: rsyslog_conf_line_count.stdout.0 | int <= 7
+
+    - name: Check file counts in rsyslog.d
+      assert:
+        that: rsyslog_d_file_count.matched >= 7
+
+    - name: Get the files config stat
+      stat:
+        path: "{{ __test_files_conf }}"
+      register: stat_output_files_system
+
+    - name: Get the forwarding config stat
+      stat:
+        path: "{{ __test_files_conf }}"
+      register: stat_output_files_system
+
+    - name: Check if the files config exists
+      assert:
+        that: stat_output_files_system.stat.exists
+
+    - name: Run logger to generate a test log message
+      command: /bin/logger -i -p local6.info -t testTag0 testMessage0000
+      changed_when: false
+
+    - name: Grep output to messages line
+      command: /bin/grep '{{ logging_system_log_dir }}/messages' {{ __test_files_conf }}
+      register: files_conf_messages
+      changed_when: false
+
+    - name: Check the filter
+      assert:
+        that: files_conf_messages.stdout is match(" *\*.info;mail.none;authpriv.none;cron.none.*messages")
+
+    - name: Check the test log message in {{ logging_system_log_dir }}/messages
+      command: /bin/grep testMessage0000 {{ logging_system_log_dir }}/messages
+      register: testMessage0000
+      changed_when: false
+
+    - name: Check if the test message is in {{ logging_system_log_dir }}/messages
+      assert:
+        that: testMessage0000.stdout | length > 0


### PR DESCRIPTION
- Variables rsyslog_enabled, rsyslog_purge_original_conf, and rsyslog_system_log_dir are internal variables - set through external variables logging_enabled, logging_purge_confs and logging_system_log_dir, respectively. And the variables are renamed to start with '__'.
- Adding a test case tests_default_files_log_dir.yml
