### PR TITLE
do not use json_query to test for rsyslog package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ install:
   # workaround until https://github.com/ansible/molecule/issues/1727 is fixed
   - pip uninstall -y testinfra
   - pip install testinfra
-  - pip install jmespath
 script:
   - molecule test
 branches:

--- a/roles/rsyslog/tasks/main.yml
+++ b/roles/rsyslog/tasks/main.yml
@@ -13,8 +13,8 @@
   set_fact:
     __rsyslog_version: >-
       {{ ansible_facts.packages['rsyslog'][0].version
-      if ansible_facts.packages | json_query('rsyslog')
-      else '0.0.0' }}
+         if 'rsyslog' in ansible_facts.packages
+         else '0.0.0' }}
 
 - debug:
     msg: "Rsyslog_version is {{ __rsyslog_version }}, which is older than \"8.37.0-7.2\"."


### PR DESCRIPTION
We can just use the `in` test to see if `rsyslog` is
in `ansible_facts.packages` - we do not have to use
`json_query`.  I believe this also gets rid of the
dependency on `jmespath`