### PR TITLE
Workaround to execute "RUNNING HANDLER" from include_role just once.

### DIFF
--- a/roles/rsyslog/handlers/main.yml
+++ b/roles/rsyslog/handlers/main.yml
@@ -3,3 +3,10 @@
   service:
     name: rsyslog
     state: restarted
+  when: not __rsyslogd_restarted | d(false)
+  listen: 'restart rsyslogd'
+
+- name: set rsyslogd restarted
+  set_fact:
+    __rsyslogd_restarted: true
+  listen: 'restart rsyslogd'

--- a/roles/rsyslog/roles/input_roles/basics/tasks/cleanup.yml
+++ b/roles/rsyslog/roles/input_roles/basics/tasks/cleanup.yml
@@ -4,5 +4,5 @@
   vars:
     __rsyslog_rules: "{{ __rsyslog_basics_rules }}"
   include_role:
-    name: "{{ role_path | dirname | dirname | dirname ~ '/rsyslog' }}"
+    name: "{{ role_path | dirname | dirname | dirname }}"
     tasks_from: cleanup.yml

--- a/roles/rsyslog/roles/input_roles/basics/tasks/main.yml
+++ b/roles/rsyslog/roles/input_roles/basics/tasks/main.yml
@@ -5,5 +5,5 @@
     __rsyslog_packages: "{{ __rsyslog_basics_packages }}"
     __rsyslog_rules: "{{ __rsyslog_basics_rules }}"
   include_role:
-    name: "{{ role_path | dirname | dirname | dirname ~ '/rsyslog' }}"
+    name: "{{ role_path | dirname | dirname | dirname }}"
     tasks_from: deploy.yml

--- a/roles/rsyslog/roles/input_roles/files/tasks/cleanup.yml
+++ b/roles/rsyslog/roles/input_roles/files/tasks/cleanup.yml
@@ -4,5 +4,5 @@
   vars:
     __rsyslog_rules: "{{ __rsyslog_files_input_rules }}"
   include_role:
-    name: "{{ role_path | dirname | dirname | dirname ~ '/rsyslog' }}"
+    name: "{{ role_path | dirname | dirname | dirname }}"
     tasks_from: cleanup.yml

--- a/roles/rsyslog/roles/input_roles/files/tasks/main.yml
+++ b/roles/rsyslog/roles/input_roles/files/tasks/main.yml
@@ -5,5 +5,5 @@
     __rsyslog_packages: "{{ __rsyslog_files_input_packages }}"
     __rsyslog_rules: "{{ __rsyslog_files_input_rules }}"
   include_role:
-    name: "{{ role_path | dirname | dirname | dirname ~ '/rsyslog' }}"
+    name: "{{ role_path | dirname | dirname | dirname }}"
     tasks_from: deploy.yml

--- a/roles/rsyslog/roles/input_roles/ovirt/tasks/cleanup.yml
+++ b/roles/rsyslog/roles/input_roles/ovirt/tasks/cleanup.yml
@@ -4,5 +4,5 @@
   vars:
     __rsyslog_rules: "{{ __rsyslog_ovirt_rules }}"
   include_role:
-    name: "{{ role_path | dirname | dirname | dirname ~ '/rsyslog' }}"
+    name: "{{ role_path | dirname | dirname | dirname }}"
     tasks_from: cleanup.yml

--- a/roles/rsyslog/roles/input_roles/ovirt/tasks/main.yml
+++ b/roles/rsyslog/roles/input_roles/ovirt/tasks/main.yml
@@ -5,7 +5,7 @@
     __rsyslog_packages: "{{ __rsyslog_ovirt_prereq_packages + __rsyslog_ovirt_packages }}"
     __rsyslog_rules: "{{ __rsyslog_ovirt_rules }}"
   include_role:
-    name: "{{ role_path | dirname | dirname | dirname ~ '/rsyslog' }}"
+    name: "{{ role_path | dirname | dirname | dirname }}"
     tasks_from: deploy.yml
 
 - name: Allow rsyslog to listen on collectd port

--- a/roles/rsyslog/roles/input_roles/viaq-k8s/tasks/cleanup.yml
+++ b/roles/rsyslog/roles/input_roles/viaq-k8s/tasks/cleanup.yml
@@ -4,5 +4,5 @@
   vars:
     __rsyslog_rules: "{{ __rsyslog_viaq_k8s_rules }}"
   include_role:
-    name: "{{ role_path | dirname | dirname | dirname ~ '/rsyslog' }}"
+    name: "{{ role_path | dirname | dirname | dirname }}"
     tasks_from: cleanup.yml

--- a/roles/rsyslog/roles/input_roles/viaq-k8s/tasks/main.yml
+++ b/roles/rsyslog/roles/input_roles/viaq-k8s/tasks/main.yml
@@ -5,5 +5,5 @@
     __rsyslog_packages: "{{ __rsyslog_viaq_k8s_packages }}"
     __rsyslog_rules: "{{ __rsyslog_viaq_k8s_rules }}"
   include_role:
-    name: "{{ role_path | dirname | dirname | dirname ~ '/rsyslog' }}"
+    name: "{{ role_path | dirname | dirname | dirname }}"
     tasks_from: deploy.yml

--- a/roles/rsyslog/roles/input_roles/viaq/tasks/cleanup.yml
+++ b/roles/rsyslog/roles/input_roles/viaq/tasks/cleanup.yml
@@ -4,5 +4,5 @@
   vars:
     __rsyslog_rules: "{{ __rsyslog_viaq_rules }}"
   include_role:
-    name: "{{ role_path | dirname | dirname | dirname ~ '/rsyslog' }}"
+    name: "{{ role_path | dirname | dirname | dirname }}"
     tasks_from: cleanup.yml

--- a/roles/rsyslog/roles/input_roles/viaq/tasks/main.yml
+++ b/roles/rsyslog/roles/input_roles/viaq/tasks/main.yml
@@ -5,5 +5,5 @@
     __rsyslog_packages: "{{ __rsyslog_viaq_prereq_packages + __rsyslog_viaq_packages }}"
     __rsyslog_rules: "{{ __rsyslog_viaq_rules }}"
   include_role:
-    name: "{{ role_path | dirname | dirname | dirname ~ '/rsyslog' }}"
+    name: "{{ role_path | dirname | dirname | dirname }}"
     tasks_from: deploy.yml

--- a/roles/rsyslog/roles/output_roles/elasticsearch/tasks/main.yml
+++ b/roles/rsyslog/roles/output_roles/elasticsearch/tasks/main.yml
@@ -59,5 +59,5 @@
     __rsyslog_packages: "{{ __rsyslog_elasticsearch_packages }}"
     __rsyslog_rules: "{{ __rsyslog_elasticsearch_rules }}"
   include_role:
-    name: "{{ role_path | dirname | dirname | dirname ~ '/rsyslog' }}"
+    name: "{{ role_path | dirname | dirname | dirname }}"
     tasks_from: deploy.yml

--- a/roles/rsyslog/roles/output_roles/files/tasks/main.yml
+++ b/roles/rsyslog/roles/output_roles/files/tasks/main.yml
@@ -5,5 +5,5 @@
     __rsyslog_packages: "{{ __rsyslog_files_output_packages }}"
     __rsyslog_rules: "{{ __rsyslog_files_output_rules }}"
   include_role:
-    name: "{{ role_path | dirname | dirname | dirname ~ '/rsyslog' }}"
+    name: "{{ role_path | dirname | dirname | dirname }}"
     tasks_from: deploy.yml

--- a/roles/rsyslog/roles/output_roles/forwards/tasks/main.yml
+++ b/roles/rsyslog/roles/output_roles/forwards/tasks/main.yml
@@ -5,5 +5,5 @@
     __rsyslog_packages: "{{ __rsyslog_forwards_output_packages }}"
     __rsyslog_rules: "{{ __rsyslog_forwards_output_rules }}"
   include_role:
-    name: "{{ role_path | dirname | dirname | dirname ~ '/rsyslog' }}"
+    name: "{{ role_path | dirname | dirname | dirname }}"
     tasks_from: deploy.yml


### PR DESCRIPTION
Add a condition to restart rsyslogd handler when __rsyslogd_restarted is false.
Once the handler is executed, it sets __rsyslogd_restarted to true.

Revert "do not use ../ in path when including roles 3"
This reverts commit ff5fd47c8df1f5531e775ee8d98a6fde2bad0cf6.
