### PR TITLE
RHELPLAN-41773 - Logging - Best Practices - rsyslog should be set to …

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,6 @@ For more details, see also [roles/rsyslog/README.md](https://github.com/linux-sy
 Variables in vars.yml
 ----------------------
 
-- `logging_collector`: The logs collector to use for the logs collection. Currently Rsyslog is the only supported logs collector. Defaults to `rsyslog`. WARNING: this is going to be renamed to logging_provider.
 - `logging_enabled` : When 'true', logging role will deploy specified configuration file set. Default to 'true'.
 - `logging_mmk8s_token`: Path to token for kubernetes.  Default to "/etc/rsyslog.d/mmk8s.token".
 - `logging_mmk8s_ca_cert`: Path to CA cert for kubernetes.  Default to "/etc/rsyslog.d/mmk8s.ca.crt".
@@ -241,6 +240,7 @@ Variables in vars.yml
           `type`: The type of the pre-configured logs to collect. **Note:** Currently ['viaq', 'viaq-k8s', 'ovirt'] are supported for the elasticsearch output.
           `state`: The state of the configuration files states if they should be `present` or `absent`. Default to `present`.
 
+- `logging_provider`: The logging collector to use for the logging provider. Currently Rsyslog is the only supported logging provider. Defaults to `rsyslog`.
 - `logging_purge_confs`: By default, the Rsyslog configuration files are applied on top of pre-existing configuration files. To purge local files prior to setting new ones, set logging_purge_confs variable to 'true', it will move all Rsyslog configuration files to a backup directory, `/tmp/rsyslog.d-XXXXXX/backup.tgz`, before deploying the new configuration files. Defaults to 'false'.
 - `logging_system_log_dir`: System log directory.  Default to '/var/log'.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
-# Default logging collector is Rsyslog
-logging_collector: rsyslog
+# Default logging provider is Rsyslog
+logging_provider: rsyslog
 
 # Unless logging_enabled is set to true, logging role is no-op
 logging_enabled: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -69,12 +69,13 @@
         - item.key is match("rsyslog*")
         - logging_debug | d(false)
 
-    - name: Include Rsyslog role
-      vars:
-        __rsyslog_enabled: "{{ logging_enabled }}"
-        __rsyslog_purge_original_conf: "{{ logging_purge_confs }}"
-        __rsyslog_system_log_dir: "{{ logging_system_log_dir }}"
-      include_role:
-        name: "{{ role_path }}/roles/rsyslog"
+  when: logging_provider == 'rsyslog'
 
-  when: logging_collector | d('rsyslog') == 'rsyslog'
+- name: Include Rsyslog role
+  vars:
+    __rsyslog_enabled: "{{ logging_enabled }}"
+    __rsyslog_purge_original_conf: "{{ logging_purge_confs }}"
+    __rsyslog_system_log_dir: "{{ logging_system_log_dir }}"
+  include_role:
+    name: "{{ role_path }}/roles/rsyslog"
+  when: logging_provider == 'rsyslog'


### PR DESCRIPTION
…logging_provider instead of logging_collector

Replacing logging_collector with logging_provider.

Note: Removing the default filter from "when: logging_collector | d('rsyslog') == 'rsyslog'"
in tasks/main.yml causes an error while evaluating conditional (logging_provider == 'rsyslog'):
'logging_provider' is undefined, unless including defaults/main.yml in roles/rsyslog/tasks/main.yml.