### PR TITLE
Changing the exclude value from string to list.

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,11 +219,11 @@ Variables in vars.yml
    -  ** `type: files`**
       - `facility`: facility; default to `*`
       - `severity`: severity; default to `*`
-      - `exclude`: exclude; default to none.
+      - `exclude`: exclude list; default to none.
       - `path`: path to the output file.  Must have.  If `path` is not defined, the files instance is dropped.
       These values are used in the omfile action as follows:
       ```
-      facility.severity;exclude path
+      facility.severity;<semicolon separated exclude list> path
       ```
    -  ** `type: forwards`**
       - `facility`: facility; default to `*`

--- a/design_docs/rsyslog_inputs_outputs_flows.md
+++ b/design_docs/rsyslog_inputs_outputs_flows.md
@@ -40,7 +40,7 @@ logging_outputs
   - name: files_output
     type: files
     severity: info
-    exclude: authpriv.none;auth.none;cron.none;mail.none
+    exclude: [authpriv.none, auth.none, cron.none, mail.none]
     path: /var/log/messages
 ```
 

--- a/roles/rsyslog/README.md
+++ b/roles/rsyslog/README.md
@@ -110,14 +110,42 @@ logging_flows:
 ```
 If inputs are specified, but no flows or outputs are specified, the default is to write the input to the predefined system log files e.g. /var/log/messages.
 ```
-logging_enabled: true
 logging_purge_confs: true
 logging_inputs:
   - name: system-input
     type: basics
 ```
 
-**3. Deploying basic LSR/Logging config files in /etc/rsyslog.d, which handle inputs from the local system and remote rsyslog and outputs into the local files.**
+**3. Deploying basic LSR/Logging config files in /etc/rsyslog.d, which handle inputs from the local system and outputs into the local files, which each acrion is defined.
+```
+logging_purge_confs: true
+rsyslog_backup_dir: /tmp/rsyslog_backup
+logging_outputs:
+  - name: files_output0
+    type: files
+    severity: info
+    exclude:
+      - authpriv.none
+      - auth.none
+      - cron.none
+      - mail.none
+    path: /var/log/messages
+  - name: files_output1
+    type: files
+    severity: emerg
+    path: :omusrmsg:*
+  - name: files_output2
+    <<snip>>
+logging_inputs:
+  - name: system-input
+    type: basics
+logging_flows:
+  - name: flow0
+    inputs: [system-input]
+    outputs: [files_output0, files_output1, files_output2, ...]
+```
+
+**4. Deploying basic LSR/Logging config files in /etc/rsyslog.d, which handle inputs from the local system and remote rsyslog and outputs into the local files.**
 ```
 logging_enabled: true
 rsyslog_capabilities: [ 'network', 'remote-files' ]
@@ -134,7 +162,7 @@ logging_flows:
     outputs: [local-files]
 ```
 
-**4. Deploying basic LSR/Logging config files in /etc/rsyslog.d, which forwards the local system logs to the remote rsyslog.
+**5. Deploying basic LSR/Logging config files in /etc/rsyslog.d, which forwards the local system logs to the remote rsyslog.
 ```
 logging_enabled: true
 rsyslog_default: false
@@ -161,7 +189,7 @@ logging_flows:
     outputs: [output-forwards0, output-forwards1]
 ```
 
-**5. Sample vars.yml file for the viaq case. (not implemented yet) **
+**6. Sample vars.yml file for the viaq case. (not implemented yet) **
 ```
 logging_enabled: true
 logging_outputs:
@@ -233,7 +261,7 @@ Files output format
      type: files
      facility: <facility_in_text, e.g., "mail"; default to "*">
      severity: <severity_in_text, e.g., "info"; default to "*">
-     exclude: <excluded facility list separated by ';', e.g., "mail.none;auth.none"; default to nil>
+     exclude: <excluded facility list; default to none>
      path: </full/path/to/file/to/store/the/logs; MUST EXIST>
    ```
 - `forwards`: array of dictionary to specify the facility and severity filter and the host and port to forward logs satisfying the filter.  It takes the sub-variables - `name`, `facility`, `severity`, `exclude`, `protocol`, `target`, and `port`.  Unless the name and the target are given, the element is skipped.
@@ -243,7 +271,7 @@ Forwards output format
      type: forwards
      facility: <facility_in_text, e.g., "mail"; default to "*">
      severity: <severity_in_text, e.g., "info"; default to "*">
-     exclude: <excluded facility list separated by ';', e.g., "mail.none;auth.none"; default to nil>
+     exclude: <excluded facility list; default to none>
      protocol: <tcp_or_udp; default to "tcp">
      target: <target_host_name_or_ip_address; MUST EXIST>
      port: <port_number; default to 514>

--- a/roles/rsyslog/templates/output_files.j2
+++ b/roles/rsyslog/templates/output_files.j2
@@ -1,13 +1,11 @@
 {% if files_item.path is defined %}
-{%   if files_item.exclude is defined %}
 ruleset(name="{{ files_item.name }}") {
-    {{ files_item.facility | d('*') }}.{{ files_item.severity | d('*') }};{{ files_item.exclude }} {{ files_item.path }}
-}
+{%   if files_item.exclude | d([]) %}
+    {{ files_item.facility | d('*') }}.{{ files_item.severity | d('*') }};{{ files_item.exclude | join(';') }} {{ files_item.path }}
 {%   else %}
-ruleset(name="{{ files_item.name }}") {
     {{ files_item.facility | d('*') }}.{{ files_item.severity | d('*') }} {{ files_item.path }}
-}
 {%   endif %}
+}
 {% else %}
 ruleset(name="{{ files_item.name }}") {
     # Log all kernel messages to the console.

--- a/roles/rsyslog/templates/output_forwards.j2
+++ b/roles/rsyslog/templates/output_forwards.j2
@@ -1,9 +1,7 @@
-{% if forwards_item.exclude is defined %}
 ruleset(name="{{ forwards_item.name }}") {
-    {{ forwards_item.facility | d('*') }}.{{ forwards_item.severity | d('*') }};{{ forwards_item.exclude }} action(name="{{ forwards_item.name }}" type="omfwd" Target="{{ forwards_item.target }}" Port="{{ forwards_item.port | d(514) }}" Protocol="{{ forwards_item.protocol | d('tcp') }}")
-}
+{%   if forwards_item.exclude | d([]) %}
+    {{ forwards_item.facility | d('*') }}.{{ forwards_item.severity | d('*') }};{{ forwards_item.exclude | join(';') }} action(name="{{ forwards_item.name }}" type="omfwd" Target="{{ forwards_item.target }}" Port="{{ forwards_item.port | d(514) }}" Protocol="{{ forwards_item.protocol | d('tcp') }}")
 {% else %}
-ruleset(name="{{ forwards_item.name }}") {
     {{ forwards_item.facility | d('*') }}.{{ forwards_item.severity | d('*') }} action(name="{{ forwards_item.name }}" type="omfwd" Target="{{ forwards_item.target }}" Port="{{ forwards_item.port | d(514) }}" Protocol="{{ forwards_item.protocol | d('tcp') }}")
-}
 {% endif %}
+}

--- a/tests/tests_combination.yml
+++ b/tests/tests_combination.yml
@@ -21,7 +21,11 @@
           - name: files_test0
             type: files
             severity: info
-            exclude: authpriv.none;auth.none;cron.none;mail.none
+            exclude:
+              - authpriv.none
+              - auth.none
+              - cron.none
+              - mail.none
             path: /var/log/messages
           - name: files_test1
             type: files

--- a/tests/tests_combination2.yml
+++ b/tests/tests_combination2.yml
@@ -21,7 +21,11 @@
           - name: files_test0
             type: files
             severity: info
-            exclude: authpriv.none;auth.none;cron.none;mail.none
+            exclude:
+              - authpriv.none
+              - auth.none
+              - cron.none
+              - mail.none
             path: /var/log/messages
           - name: files_test1
             type: files

--- a/tests/tests_files.yml
+++ b/tests/tests_files.yml
@@ -16,7 +16,11 @@
           - name: files_output1
             type: files
             severity: info
-            exclude: authpriv.none;auth.none;cron.none;mail.none
+            exclude:
+              - authpriv.none
+              - auth.none
+              - cron.none
+              - mail.none
             path: /var/log/messages
           - name: files_output2
             type: files

--- a/tests/tests_files_files.yml
+++ b/tests/tests_files_files.yml
@@ -15,7 +15,11 @@
           - name: files_output0
             type: files
             severity: info
-            exclude: authpriv.none;auth.none;cron.none;mail.none
+            exclude:
+              - authpriv.none
+              - auth.none
+              - cron.none
+              - mail.none
             path: /var/log/messages
           - name: files_output1
             type: files

--- a/tests/tests_files_forwards.yml
+++ b/tests/tests_files_forwards.yml
@@ -12,7 +12,11 @@
           - name: files_test0
             type: files
             severity: info
-            exclude: authpriv.none;auth.none;cron.none;mail.none
+            exclude:
+              - authpriv.none
+              - auth.none
+              - cron.none
+              - mail.none
             path: /var/log/messages
           - name: files_test1
             type: files


### PR DESCRIPTION
Files and forwards output uses a filter
  `<facility>.<severity>;<exclude0>;<exclude1>;... <output>`
E.g.,
  `*.info;authpriv.none;cron.none    /var/log/messages`
Files and forwards logging_output takes exclude subvariable, which used to be
  `exclude: <exclude0>;<exclude1>;...`
but by changing it to
  `exclude: ;<exclude0>;<exclude1>;...`
by adding `;` at the first column, `output_{files,forwards}.j2` template could
be simplified as follows.
  `{{ files_item.facility | d('*') }}.{{ files_item.severity | d('*') }}{{ files_item.exclude | d() }} {{ files_item.path }}`