### PR TITLE
RHELPLAN-32453 - Add remote inputs (imtcp, imptcp, imudp) and their r…

### DIFF
--- a/design_docs/logging_subsystem.md
+++ b/design_docs/logging_subsystem.md
@@ -8,7 +8,7 @@ It is designed to satisfy following requirements.
 - The existing scenario, especially an input ovirt + output elasticsearch should not be affected by the updates.
 
 ```
-logging/
+logging
 ├── defaults
 │   └── main.yml
 ├── design_docs
@@ -46,6 +46,9 @@ logging/
 │       │   │   │   └── main.yml
 │       │   │   ├── ovirt
 │       │   │   │   └── main.yml
+│       │   │   ├── remote
+│       │   │   │   ├── cleanup.yml
+│       │   │   │   └── main.yml
 │       │   │   ├── viaq
 │       │   │   │   └── main.yml
 │       │   │   └── viaq-k8s
@@ -56,7 +59,9 @@ logging/
 │       │       │   └── main.yml
 │       │       ├── files
 │       │       │   └── main.yml
-│       │       └── forwards
+│       │       ├── forwards
+│       │       │   └── main.yml
+│       │       └── remote_files
 │       │           └── main.yml
 │       ├── templates
 │       │   ├── etc
@@ -67,7 +72,8 @@ logging/
 │       │   ├── ovirt_input_files.j2
 │       │   ├── output_elasticsearch.j2
 │       │   ├── output_files.j2
-│       │   └── output_forwards.j2
+│       │   ├── output_forwards.j2
+│       │   └── output_remote_files.j2
 │       └── vars
 │           ├── inputs
 │           │   ├── basics
@@ -75,6 +81,8 @@ logging/
 │           │   ├── files
 │           │   │   └── main.yml
 │           │   ├── ovirt
+│           │   │   └── main.yml
+│           │   ├── remote
 │           │   │   └── main.yml
 │           │   ├── viaq
 │           │   │   └── main.yml
@@ -86,7 +94,9 @@ logging/
 │               │   └── main.yml
 │               ├── files
 │               │   └── main.yml
-│               └── forwards
+│               ├── forwards
+│               │   └── main.yml
+│               └── remote_files
 │                   └── main.yml
 └── tasks
     └── main.yml

--- a/design_docs/rsyslog_templates.md
+++ b/design_docs/rsyslog_templates.md
@@ -71,4 +71,4 @@ Each sub-configuration uses the following template to generate a configuration f
 - [output_elasticsearch.j2](../roles/rsyslog/templates/output_elasticsearch.j2)
 - [output_files.j2](../roles/rsyslog/templates/output_files.j2)
 - [output_forwards.j2](../roles/rsyslog/templates/output_forwards.j2)
-
+- [output_remote_files.j2](../roles/rsyslog/templates/output_remote_files.j2)

--- a/roles/rsyslog/defaults/main.yml
+++ b/roles/rsyslog/defaults/main.yml
@@ -150,60 +150,11 @@ rsyslog_permitted_peers: ['*.{{ rsyslog_domain }}']
 # server over TLS.
 rsyslog_send_permitted_peers: '{{ rsyslog_permitted_peers }}'
 
-
-# Firewall, UDP, TCP ports
-# ------------------------
-
-# rsyslog_udp_port
-#
-# The incoming UDP port used for remote logging.
-rsyslog_udp_port: '514'
-
-# rsyslog_tcp_port
-#
-# The incoming TCP port used for remote logging.
-rsyslog_tcp_port: '514'
-
-# rsyslog_tcp_tls_port
-#
-# The incoming TCP TLS port used for remote logging.
-rsyslog_tcp_tls_port: '6514'
-
 # Files and Forwards outputs
 # --------------------------
 
 rsyslog_output_files: []
 rsyslog_output_forwards: []
-
-# Rsyslog configuration rules
-# ---------------------------
-
-# rsyslog_weight_map
-#
-# This is a dictionary map of different configuration "types" corresponding to
-# numbers used to sort configuration files in `{{ rsyslog_config_dir }}` directory
-# (configuration order is important). You can specify a type in the
-# configuration by using the ``item.type`` parameter.
-#
-# If you change the default weight map values, you will most likely need to
-# remove all files from `{{ rsyslog_config_dir }}` to reset the configuration.
-rsyslog_weight_map:
-  'global': '05'
-  'globals': '05'
-  'module': '10'
-  'modules': '10'
-  'template': '20'
-  'templates': '20'
-  'output': '30'
-  'outputs': '30'
-  'service': '30'
-  'services': '30'
-  'rule': '50'
-  'rules': '50'
-  'ruleset': '50'
-  'rulesets': '50'
-  'input': '90'
-  'inputs': '90'
 
 # __rsyslog_.*_rules
 #
@@ -215,7 +166,6 @@ __rsyslog_common_rules:
   - '{{ __rsyslog_conf_global_options }}'
   - '{{ __rsyslog_conf_local_modules }}'
   - '{{ __rsyslog_conf_common_defaults }}'
-  - '{{ __rsyslog_conf_default_rulesets }}'
 
 
 # Default configuration options
@@ -276,19 +226,3 @@ __rsyslog_conf_common_defaults:
       - comment: 'Log every message'
         options: |-
           $RepeatedMsgReduction {{ "on" if rsyslog_message_reduction | bool else "off" }}
-
-# __rsyslog_conf_default_rulesets
-#
-# ruleset `remote` directs to the files output role, which is implemented in `filename.remote`.
-__rsyslog_conf_default_rulesets:
-
-  - name: 'default-rulesets'
-    type: 'rules'
-    state: '{{ "present" if ("network" in rsyslog_capabilities) else "absent" }}'
-    sections:
-
-      - comment: 'Rules for logs incoming from remote hosts'
-        options: |-
-          ruleset(name="remote") {
-            $IncludeConfig {{ rsyslog_config_dir }}/*.remote
-          }

--- a/roles/rsyslog/tasks/inputs/remote/cleanup.yml
+++ b/roles/rsyslog/tasks/inputs/remote/cleanup.yml
@@ -1,0 +1,7 @@
+---
+# Deploy configuration files
+- name: Remove basics input configuration files from /etc/rsyslog.d
+  vars:
+    __rsyslog_rules: "{{ __rsyslog_basics_rules }}"
+  include_tasks:
+    file: basics_cleanup.yml

--- a/roles/rsyslog/tasks/inputs/remote/main.yml
+++ b/roles/rsyslog/tasks/inputs/remote/main.yml
@@ -1,0 +1,30 @@
+---
+# Deploy configuration files
+- name: Install/Update remote input packages and generate configuration files in /etc/rsyslog.d
+  vars:
+    __rsyslog_packages: []
+    __rsyslog_rules:
+      - name: "input-remote-modules"
+        type: modules
+        sections:
+          - options: "{{ lookup('template', 'input_remote_module.j2') }}"
+  include_tasks:
+    file: deploy.yml
+
+- name: Create basics input configuration files in /etc/rsyslog.d
+  vars:
+    __rsyslog_input_name: "{{ remote_item.name }}"
+    __rsyslog_input_type: "{{ remote_item.type }}"
+    __rsyslog_packages: []
+    __rsyslog_rules:
+      - name: "input-remote-{{ remote_item.name }}"
+        type: input
+        weight: "11"
+        sections:
+          - options: "{{ lookup('template', 'input_remote.j2') }}"
+  include_tasks:
+    file: deploy.yml
+  loop: '{{ logging_inputs }}'
+  loop_control:
+    loop_var: remote_item
+  when: remote_item.type | d() == 'remote'

--- a/roles/rsyslog/tasks/outputs/remote_files/main.yml
+++ b/roles/rsyslog/tasks/outputs/remote_files/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Create files output configuration files in /etc/rsyslog.d
+  vars:
+    __rsyslog_packages: "{{ __rsyslog_remote_files_output_packages }}"
+    __rsyslog_rules:
+      - name: "output-files-{{ remote_files_item.name }}"
+        type: "output"
+        sections:
+          - options: "{{ lookup('template', 'output_remote_files.j2') }}"
+  include_tasks:
+    file: deploy.yml
+  loop: '{{ rsyslog_output_remote_files }}'
+  loop_control:
+    loop_var: remote_files_item

--- a/roles/rsyslog/templates/input_remote.j2
+++ b/roles/rsyslog/templates/input_remote.j2
@@ -1,0 +1,11 @@
+{% if remote_item.udp_port | d() %}
+# Log messages from remote hosts over UDP
+input(name="{{ remote_item.name }}" type="imudp" port="{{ remote_item.udp_port | d(__rsyslog_default_port) }}")
+{% elif remote_item.tcp_port | d() %}
+# Log messages from remote hosts over plain TCP
+input(name="{{ remote_item.name }}" type="imptcp" port="{{ remote_item.tcp_port | d(__rsyslog_default_port) }}")
+{% else %}
+# Log messages from remote hosts over TLS
+input(name="{{ remote_item.name }}" type="imtcp" port="{{ remote_item.tcp_tls_port | d(__rsyslog_default_tls_port) }}")
+{% endif %}
+{{ lookup('template', 'input_template.j2') }}

--- a/roles/rsyslog/templates/input_remote_module.j2
+++ b/roles/rsyslog/templates/input_remote_module.j2
@@ -1,0 +1,38 @@
+{% set ns0 = namespace(use_tls = false) %}
+{% set ns1 = namespace(use_tcp = false) %}
+{% set ns2 = namespace(use_udp = false) %}
+{% for elm in logging_inputs %}
+{%   if elm.type == 'remote' %}
+{%     if elm.tcp_tls_port is defined %}
+{%       set ns0.use_tls = true %}
+{%     elif elm.tcp_port is defined %}
+{%       set ns1.use_tcp = true %}
+{%     elif elm.udp_port is defined %}
+{%       set ns2.use_udp = true %}
+{%     endif %}
+{%   endif %}
+{% endfor %}
+{% if ns2.use_udp %}
+# Read messages sent over plain TCP
+module(load="imudp")
+{% endif %}
+{% if ns1.use_tcp %}
+# Read messages sent over UDP
+module(load="imptcp")
+{% endif %}
+{% if ns0.use_tls %}
+# Read messages sent over TCP with TLS
+module(
+  load="imtcp"
+  streamDriver.name="{{ rsyslog_default_netstream_driver }}"
+  streamDriver.mode="1"
+  streamDriver.authMode="{{ rsyslog_default_driver_authmode }}"
+{%   if rsyslog_default_driver_authmode != "anon" %}
+{%     if rsyslog_permitted_peers is string %}
+    permittedPeer="{{ rsyslog_permitted_peers }}"
+{%     else %}
+    permittedPeer=["{{ rsyslog_permitted_peers | join('","') }}"]
+{% endif %}
+{%   endif %}
+)
+{% endif %}

--- a/roles/rsyslog/templates/input_template.j2
+++ b/roles/rsyslog/templates/input_template.j2
@@ -22,6 +22,8 @@ if
 {%         set input = indict[inputname] %}
 {%         if input.type == "basics" %}
   ($inputname == "imjournal")
+{%         elif input.type == "remote" %}
+  ($inputname == "{{ input.name }}" )
 {%         elif input.type == __rsyslog_input_type %}
   ($syslogtag == "{{ input.name }}" or (strlen($.syslogtag) > 0 and ($.syslogtag == "{{ input.name }}")))
 {%         endif %}

--- a/roles/rsyslog/templates/output_remote_files.j2
+++ b/roles/rsyslog/templates/output_remote_files.j2
@@ -1,0 +1,60 @@
+{% if remote_files_item.remote_log_path | d() or remote_files_item.remote_sub_path | d() %}
+{%   if remote_files_item.remote_log_path | d() %}
+{%     set __remote_log_path = remote_files_item.remote_log_path %}
+{%   else %}
+{%     set __remote_log_path = __rsyslog_system_log_dir ~ remote_files_item.remote_sub_path %}
+{%   endif %}
+{%   if remote_files_item.comment | d() %}
+# {{ remote_files_item.comment }}
+{%   endif %}
+template(
+  name="{{ remote_files_item.name }}_template"
+  type="string"
+  string="{{ __remote_log_path }}"
+)
+ruleset(name="{{ remote_files_item.name }}") {
+    # Store remote logs in separate logfiles
+{%   if forwards_item.exclude | d([]) %}
+    {{ remote_files_item.facility | d('*') }}.{{ remote_files_item.severity | d('*') }};{{ remote_files_item.exclude | join(';') }} action(name="{{ remote_files_item.name }}" type="omfile" DynaFile="{{ remote_files_item.name }}_template")
+{% else %}
+    {{ remote_files_item.facility | d('*') }}.{{ remote_files_item.severity | d('*') }} action(name="{{ remote_files_item.name }}" type="omfile" DynaFile="{{ remote_files_item.name }}_template")
+{% endif %}
+}
+{% else %}
+{%   set __remote_log_path = __rsyslog_system_log_dir ~ '/remote' %}
+# Per-Host Templates for Remote Systems
+template(
+  name="RemoteMessage"
+  type="string"
+  string="{{ __remote_log_path }}/msg/%HOSTNAME%/%PROGRAMNAME:::secpath-replace%.log"
+)
+
+# Template for Remote host auth logs
+template(
+  name="RemoteHostAuthLog"
+  type="string"
+  string="{{ __remote_log_path }}/auth/%HOSTNAME%/%PROGRAMNAME:::secpath-replace%.log"
+)
+
+# Template for Remote host cron logs
+template(
+  name="RemoteHostCronLog"
+  type="string"
+  string="{{ __remote_log_path }}/cron/%HOSTNAME%/%PROGRAMNAME:::secpath-replace%.log"
+)
+
+# Template for Remote service mail logs
+template(
+  name="RemoteHostMailLog"
+  type="string"
+  string="{{ __remote_log_path }}/mail/%HOSTNAME%/%PROGRAMNAME:::secpath-replace%.log"
+)
+
+ruleset(name="{{ remote_files_item.name }}") {
+    # Store remote logs in separate logfiles
+    authpriv.*   action(name="remote_authpriv_host_log" type="omfile" DynaFile="RemoteHostAuthLog")
+    *.info;mail.none;authpriv.none;cron.none action(name="remote_message" type="omfile" DynaFile="RemoteMessage")
+    cron.*       action(name="remote_cron_log" type="omfile" DynaFile="RemoteHostCronLog")
+    mail.*       action(name="remote_mail_service_log" type="omfile" DynaFile="RemoteHostMailLog")
+}
+{% endif %}

--- a/roles/rsyslog/vars/inputs/basics/main.yml
+++ b/roles/rsyslog/vars/inputs/basics/main.yml
@@ -19,10 +19,6 @@ rsyslog_capabilities: []
 
 rsyslog_use_imuxsock: false
 
-# rsyslog_input_log_path is a parameter for the imfile.
-# rsyslog_input_log_path specifies the files to read. Wildcard '*' is allowed in the path
-rsyslog_input_log_path: "/var/log/containers/*.log"
-
 # __rsyslog_basics_rules
 #
 # List of YAML dictionaries, each dictionary should contain ``rsyslogd`` configuration
@@ -30,7 +26,6 @@ rsyslog_input_log_path: "/var/log/containers/*.log"
 __rsyslog_basics_rules:
   - '{{ __rsyslog_conf_local_basics_modules }}'
   - '{{ __rsyslog_conf_system_input }}'
-  - '{{ __rsyslog_conf_network_input }}'
 
 # __rsyslog_conf_local_basics_modules
 #
@@ -69,34 +64,6 @@ __rsyslog_conf_local_basics_modules:
           {%   endif %}
           {% endfor %}
 
-  - name: 'remote-modules'
-    type: 'modules'
-    state: '{{ "present" if "network" in rsyslog_capabilities else "absent" }}'
-    sections:
-
-      - comment: 'Read messages sent over UDP or plain TCP without TLS'
-        options: |-
-          module(load="imudp")
-          module(load="imptcp")
-        state: '{{ "present" if not rsyslog_send_over_tls_only else "absent" }}'
-
-      - comment: 'Read messages sent over Secure TCP with TLS'
-        options: |-
-          module(
-            load="imtcp"
-            streamDriver.name="{{ rsyslog_default_netstream_driver }}"
-            streamDriver.mode="1"
-            streamDriver.authMode="{{ rsyslog_default_driver_authmode }}"
-          {% if rsyslog_default_driver_authmode != "anon" %}
-            {% if rsyslog_permitted_peers is string %}
-              permittedPeer="{{ rsyslog_permitted_peers }}"
-            {% else %}
-              permittedPeer=["{{ rsyslog_permitted_peers | join('","') }}"]
-            {% endif %}
-          {% endif %}
-          )
-        state: '{{ "present" if "tls" in rsyslog_capabilities else "absent" }}'
-
 # __rsyslog_conf_system_input
 #
 __rsyslog_conf_system_input:
@@ -109,47 +76,3 @@ __rsyslog_conf_system_input:
       - comment: 'Log messages from imuxsock'
         options: |-
           input(name="basics_imuxsock" type="imuxsock" socket="/dev/log")
-
-# __rsyslog_conf_network_input
-#
-# Configuration of UDP, TCP and TCP over TLS inputs to receive logs from remote
-# hosts, enabled by the ``network`` capability.
-__rsyslog_conf_network_input:
-
-  - name: 'network-input'
-    type: 'input'
-    state: '{{ "present"
-              if ("network" in rsyslog_capabilities)
-              else "absent" }}'
-    sections:
-
-      - options: |-
-          # Log messages from remote hosts over UDP
-          input(
-            name="basics_imudp"
-            type="imudp"
-            port="{{ rsyslog_udp_port }}"
-            ruleset="remote"
-          )
-          # Log messages from remote hosts over plain TCP
-          input(
-            name="basics_imptcp"
-            type="imptcp"
-            port="{{ rsyslog_tcp_port }}"
-            ruleset="remote"
-          )
-        state: '{{ "present"
-                  if (not rsyslog_send_over_tls_only)
-                  else "absent" }}'
-
-      - comment: 'Log messages from remote hosts over TLS'
-        options: |-
-          input(
-            name="basics_imtcp"
-            type="imtcp"
-            port="{{ rsyslog_tcp_tls_port }}"
-            ruleset="remote"
-          )
-        state: '{{ "present"
-                  if ("tls" in rsyslog_capabilities)
-                  else "absent" }}'

--- a/roles/rsyslog/vars/inputs/remote/main.yml
+++ b/roles/rsyslog/vars/inputs/remote/main.yml
@@ -1,0 +1,13 @@
+---
+# Basic logs configuration set
+# ----------------------------
+
+rsyslog_pki: true
+
+# rsyslog_capabilities is an array which takes 'network', 'remote-files', 'tls'
+# 'network' enables input and output over network.
+# 'remote-files' allows input from remote hosts are separately stored from the local logs.
+# 'tls' specifies the input and output could be processed over tls.
+#       Note: unles rsyslog_send_over_tls_only is set to true, insecure network connection
+#       is also allowed.
+rsyslog_capabilities: []

--- a/roles/rsyslog/vars/main.yml
+++ b/roles/rsyslog/vars/main.yml
@@ -9,3 +9,46 @@ __rsyslog_base_packages: ['rsyslog']
 __rsyslog_tls_packages: ['rsyslog-gnutls', 'ca-certificates']
 
 rsyslog_use_imuxsock: false
+#
+# Firewall, UDP, TCP ports
+# ------------------------
+
+# default rsyslog port
+#
+# The incoming TCP/UDP port used for remote logging.
+__rsyslog_default_port: '514'
+
+# default rsyslog tcp port
+#
+# The incoming TCP TLS port used for remote logging.
+__rsyslog_default_tls_port: '6514'
+
+# Rsyslog configuration rules
+# ---------------------------
+
+# rsyslog_weight_map
+#
+# This is a dictionary map of different configuration "types" corresponding to
+# numbers used to sort configuration files in `{{ rsyslog_config_dir }}` directory
+# (configuration order is important). You can specify a type in the
+# configuration by using the ``item.type`` parameter.
+#
+# If you change the default weight map values, you will most likely need to
+# remove all files from `{{ rsyslog_config_dir }}` to reset the configuration.
+rsyslog_weight_map:
+  'global': '05'
+  'globals': '05'
+  'module': '10'
+  'modules': '10'
+  'template': '20'
+  'templates': '20'
+  'output': '30'
+  'outputs': '30'
+  'service': '30'
+  'services': '30'
+  'rule': '50'
+  'rules': '50'
+  'ruleset': '50'
+  'rulesets': '50'
+  'input': '90'
+  'inputs': '90'

--- a/roles/rsyslog/vars/outputs/files/main.yml
+++ b/roles/rsyslog/vars/outputs/files/main.yml
@@ -12,8 +12,6 @@ __rsyslog_files_output_packages: []
 # ---------------------------------
 __rsyslog_files_output_rules:
   - '{{ __rsyslog_conf_files_output_modules }}'
-  - '{{ __rsyslog_conf_remote_templates }}'
-  - '{{ __rsyslog_conf_remote_output }}'
 
 # __rsyslog_conf_files_output_modules:
 __rsyslog_conf_files_output_modules:
@@ -29,89 +27,3 @@ __rsyslog_conf_files_output_modules:
           {% else %}
           module(load="builtin:omfile")
           {% endif %}
-
-# __rsyslog_conf_remote_templates
-#
-# List of ``rsyslogd`` templates which are used to generate dynamic filenames for remote logs,
-# based on hostnames. You can add additional template configuration by writing it in the
-# `{{ rsyslog_config_dir }}/*.template` files, they will be included by the main configuration.
-#
-# This section will create 20-remote-templates.conf
-__rsyslog_conf_remote_templates:
-
-  - name: 'remote-templates'
-    type: 'template'
-    state: '{{ "present"
-               if ("network" in rsyslog_capabilities and "remote-files" in rsyslog_capabilities)
-               else "absent" }}'
-    sections:
-
-      - options: |-
-          #
-          # Per-Host Templates for Remote Systems
-          #
-          template(
-            name="RemoteMessage"
-            type="string"
-            string="{{ __rsyslog_system_log_dir }}/remote/msg/%HOSTNAME%/%PROGRAMNAME:::secpath-replace%.log"
-          )
-
-          # Template for Remote host auth logs
-          template(
-            name="RemoteHostAuthLog"
-            type="string"
-            string="{{ __rsyslog_system_log_dir }}/remote/auth/%HOSTNAME%/%PROGRAMNAME:::secpath-replace%.log"
-          )
-
-          # Template for Remote host cron logs
-          template(
-            name="RemoteHostCronLog"
-            type="string"
-            string="{{ __rsyslog_system_log_dir }}/remote/cron/%HOSTNAME%/%PROGRAMNAME:::secpath-replace%.log"
-          )
-
-          # Template for Remote service auth logs
-          template(
-            name="RemoteServiceAuthLog"
-            type="string"
-            string="{{ __rsyslog_system_log_dir }}/remote/services/auth/%HOSTNAME%/%PROGRAMNAME:::secpath-replace%.log"
-          )
-
-          # Template for Remote service cron logs
-          template(
-            name="RemoteServiceCronLog"
-            type="string"
-            string="{{ __rsyslog_system_log_dir }}/remote/services/cron/%HOSTNAME%/%PROGRAMNAME:::secpath-replace%.log"
-          )
-
-          # Template for Remote service mail logs
-          template(
-            name="RemoteServiceMailLog"
-            type="string"
-            string="{{ __rsyslog_system_log_dir }}/remote/services/mail/%HOSTNAME%/%PROGRAMNAME:::secpath-replace%.log"
-          )
-
-          # Include custom templates
-          $IncludeConfig {{ rsyslog_config_dir }}/*.template
-
-# __rsyslog_conf_remote_output
-#
-__rsyslog_conf_remote_output:
-
-  - name: 'dynamic-logs'
-    comment: 'Store remote logs in separate logfiles'
-    type: 'output'
-    suffix: 'remote'
-    state: '{{ "present"
-               if ("network" in rsyslog_capabilities and "remote-files" in rsyslog_capabilities)
-               else "absent" }}'
-    sections:
-
-      - comment: 'Per-Host Templates for Remote Systems'
-        options: |-
-          authpriv.*   action(name="remote_authpriv_host_log" type="omfile" DynaFile="RemoteHostAuthLog")
-          authpriv.*   action(name="remote_authpriv_service_log" type="omfile" DynaFile="RemoteServiceAuthLog")
-          *.info;mail.none;authpriv.none;cron.none action(name="remote_message" type="omfile" DynaFile="RemoteMessage")
-          cron.*       action(name="remote_cron_log" type="omfile" DynaFile="RemoteHostCronLog")
-          cron.*       action(name="remote_cron_service_log" type="omfile" DynaFile="RemoteServiceCronLog")
-          mail.*       action(name="remote_mail_service_log" type="omfile" DynaFile="RemoteServiceMailLog")

--- a/roles/rsyslog/vars/outputs/remote_files/main.yml
+++ b/roles/rsyslog/vars/outputs/remote_files/main.yml
@@ -1,0 +1,6 @@
+# Local file output rpm packages
+
+# __rsyslog_files_output_packages
+#
+# List of rpm packages for Files output.
+__rsyslog_remote_files_output_packages: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,9 +21,13 @@
       set_fact:
         rsyslog_output_forwards: "{{ logging_outputs | selectattr('name', 'defined') | selectattr('type', 'defined') | selectattr('target', 'defined') | selectattr('type', '==', 'forwards') | list }}"
 
+    - name: Set rsyslog_output_remote_files for the omfwd output for the remote input
+      set_fact:
+        rsyslog_output_remote_files: "{{ logging_outputs | selectattr('name', 'defined') | selectattr('type', 'defined') | selectattr('type', '==', 'remote_files') | list }}"
+
     - name: Set rsyslog_outputs
       set_fact:
-        rsyslog_outputs: '{{ rsyslog_output_elasticsearch | d([]) }} + {{ rsyslog_output_files | d([]) }} + {{ rsyslog_output_forwards | d([]) }}'
+        rsyslog_outputs: '{{ rsyslog_output_elasticsearch | d([]) }} + {{ rsyslog_output_files | d([]) }} + {{ rsyslog_output_forwards | d([]) }} + {{ rsyslog_output_remote_files | d([]) }}'
 
     - name: Set custom_config_files fact
       set_fact:

--- a/tests/tests_remote_default_remote.yml
+++ b/tests/tests_remote_default_remote.yml
@@ -1,0 +1,79 @@
+- name: Ensure that the role runs from inputs from the remote rsyslog to the default local files outputs.
+  hosts: all
+  become: true
+
+  tasks:
+    - name: deploy config receiving from the remote hosts and writing them to the default local files
+      vars:
+        logging_purge_confs: true
+        logging_outputs:
+          - name: remote_files_output
+            type: remote_files
+        logging_inputs:
+          - name: remote_udp_input
+            type: remote
+            udp_port: 514
+          - name: remote_tcp_input
+            type: remote
+            tcp_port: 514
+        logging_flows:
+          - name: flow_0
+            inputs: [remote_udp_input, remote_tcp_input]
+            outputs: [remote_files_output]
+      include_role:
+        name: linux-system-roles.logging
+
+    - include: set_rsyslog_variables.yml
+
+    # notify restart rsyslogd is executed at the end of this test task.
+    # thus we have to force to invoke handlers
+    - name: Force all notified handlers to run at this point, not waiting for normal sync points
+      meta: flush_handlers
+
+    - name: Check rsyslog.conf size
+      assert:
+        that: rsyslog_conf_line_count.stdout.0 | int <= 7
+
+    - name: Check file counts in rsyslog.d
+      assert:
+        that: rsyslog_d_file_count.matched >= 8
+
+    # Checking 'error' in stdout from systemctl status is for detecting the case in which rsyslog is running,
+    # but some functionality is disabled due to some error, e.g., error: 'tls.cacert' file couldn't be accessed.
+    - name: Check rsyslog errors
+      command: systemctl status rsyslog
+      register: systemctl_result
+      failed_when: "'error' in systemctl_result.stdout or systemctl_result.rc != 0"
+
+    - name: Install lsof
+      package:
+        name: lsof
+        state: present
+
+    - name: Check rsyslog.conf size
+      assert:
+        that: rsyslog_conf_line_count.stdout.0 | int <= 7
+
+    - name: lsof outputs for rsyslogd
+      shell: |
+        set -o pipefail
+        lsof -i -nP | grep rsyslogd
+      register: lsof_output0
+      changed_when: false
+
+    - debug:
+        msg: "lsof returned {{ lsof_output0.stdout }}"
+
+    - name: Check port 514 is open for TCP
+      shell: |
+        set -o pipefail
+        lsof -i -nP | grep rsyslogd | grep TCP | grep 514
+      register: lsof_output1
+      changed_when: false
+
+    - name: Check port 514 is open for UDP
+      shell: |
+        set -o pipefail
+        lsof -i -nP | grep rsyslogd | grep UDP | grep 514
+      register: lsof_output2
+      changed_when: false

--- a/tests/tests_remote_remote.yml
+++ b/tests/tests_remote_remote.yml
@@ -1,22 +1,34 @@
-- name: Ensure that rsyslog configured as a server listens on the port 514
+- name: Ensure that the role runs from inputs from the remote rsyslog to the local files outputs.
   hosts: all
   become: true
 
   tasks:
-    - name: Deploy rsyslog config on the target host as a server
+    - name: deploy config receiving from the remote hosts and writing them to the local files
       vars:
         logging_purge_confs: true
-        rsyslog_capabilities: [ 'network', 'remote-files' ]
         logging_outputs:
-          - name: files_output
-            type: files
+          - name: remote_files_output0
+            type: remote_files
+            remote_log_path: /var/log/remote/%HOSTNAME%/%PROGRAMNAME:::secpath-replace%.log
+            comment: "This is a comment 0."
+            severity: info
+            exclude:
+              - authpriv.none
+          - name: remote_files_output1
+            type: remote_files
+            remote_sub_path: others/%HOSTNAME%/%PROGRAMNAME:::secpath-replace%.log
+            facility: authpriv
         logging_inputs:
-          - name: basic_input
-            type: basics
+          - name: remote_udp_input
+            type: remote
+            udp_port: 514
+          - name: remote_tcp_input
+            type: remote
+            tcp_port: 514
         logging_flows:
-          - name: flows0
-            inputs: [ basic_input ]
-            outputs: [ files_output ]
+          - name: flow_0
+            inputs: [remote_udp_input, remote_tcp_input]
+            outputs: [remote_files_output0, remote_files_output1]
       include_role:
         name: linux-system-roles.logging
 
@@ -26,6 +38,21 @@
     # thus we have to force to invoke handlers
     - name: Force all notified handlers to run at this point, not waiting for normal sync points
       meta: flush_handlers
+
+    - name: Check rsyslog.conf size
+      assert:
+        that: rsyslog_conf_line_count.stdout.0 | int <= 7
+
+    - name: Check file counts in rsyslog.d
+      assert:
+        that: rsyslog_d_file_count.matched >= 8
+
+    # Checking 'error' in stdout from systemctl status is for detecting the case in which rsyslog is running,
+    # but some functionality is disabled due to some error, e.g., error: 'tls.cacert' file couldn't be accessed.
+    - name: Check rsyslog errors
+      command: systemctl status rsyslog
+      register: systemctl_result
+      failed_when: "'error' in systemctl_result.stdout or systemctl_result.rc != 0"
 
     - name: Install lsof
       package:
@@ -38,14 +65,7 @@
 
     - name: Check file counts in rsyslog.d
       assert:
-        that: rsyslog_d_file_count.matched >= 7
-
-    # Checking 'error' in stdout from systemctl status is for detecting the case in which rsyslog is running,
-    # but some functionality is disabled due to some error, e.g., error: 'tls.cacert' file couldn't be accessed.
-    - name: Check rsyslog errors
-      command: systemctl status rsyslog
-      register: systemctl_result
-      failed_when: "'error' in systemctl_result.stdout or systemctl_result.rc != 0"
+        that: rsyslog_d_file_count.matched >= 9
 
     - name: lsof outputs for rsyslogd
       shell: |
@@ -61,12 +81,10 @@
       shell: |
         set -o pipefail
         lsof -i -nP | grep rsyslogd | grep TCP | grep 514
-      register: lsof_output1
       changed_when: false
 
     - name: Check port 514 is open for UDP
       shell: |
         set -o pipefail
         lsof -i -nP | grep rsyslogd | grep UDP | grep 514
-      register: lsof_output2
       changed_when: false


### PR DESCRIPTION
…emote_files outputs supports

- Separating the inputs from the remote hosts from the basic input type and
  making it a remote input type.
- Separating the output into the local file from the files output type and
  making it a remote_file output type, which uses an output_remote_files.j2
  template.

- CI tests
  . adding tests_remote_default_remote.yml for testing the default output rules.
  . adding tests_remote_remote.yml for testing the configured output rules.
  . removing an obsolete tests_listen.yml.

- Updating docs:
  . README.md
  . roles/rsyslog/README.md
  . design_docs/logging_subsystem.md