### PR TITLE
Fixing the key/cert setting parameter use_cert for the elasticsearch …

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,9 +238,13 @@ Variables in vars.yml
       - `index_prefix`: Elasticsearch index prefix the particular log will be indexed to.
       - `input_type`: Specifying the input type. Type `ovirt` and `viaq` are supported. Default to `ovirt`.
       - `retryfailures`: Specifying whether retries or not in case of failure. on or off.  Default to on.
-      - `ca_cert`: Path to CA cert for ElasticSearch.  Default to '/etc/rsyslog.d/es-ca.crt'
-      - `cert`: Path to cert for ElasticSearch.  Default to '/etc/rsyslog.d/es-cert.pem'
-      - `key`: Path to key for ElasticSearch.  Default to "/etc/rsyslog.d/es-key.pem"
+      - `use_cert`: If true, key/certificates are used to access Elasticsearch. Triplets {`ca_cert`, `cert`, key`} and/or {`ca_cert_src`, `cert_src`, `key_src`} should be configured. Default to true.
+      - `ca_cert`: Path to CA cert for Elasticsearch.  Default to '/etc/rsyslog.d/es-ca.crt'
+      - `cert`: Path to cert for Elasticsearch.  Default to '/etc/rsyslog.d/es-cert.pem'
+      - `key`: Path to key for Elasticsearch.  Default to "/etc/rsyslog.d/es-key.pem"
+      - `ca_cert_src`: Path to the CA cert file on the local host to copy to the target host. If `ca_cert` is specified, copied to the location. Otherwise, to rsyslog_config_dir.
+      - `cert_src`: Path to the cert file on the local host to copy to the target host. If `cert` is specified, copied to the location. Otherwise, to rsyslog_config_dir.
+      - `key_src`: Path to the key file on the local host to copy to the target host. If `key` is specified, copied to the location. Otherwise, to rsyslog_config_dir.
    -  ** `type: files`**
       - `facility`: facility; default to `*`
       - `severity`: severity; default to `*`

--- a/roles/rsyslog/README.md
+++ b/roles/rsyslog/README.md
@@ -260,15 +260,23 @@ Elasticsearch, Files, Remote_files, and Forwards outputs sub-variables
 - `elasticsearch`: array of dictionary to specify the parameters to forward the log messages to elasticsearch.
    ```
    - name: <unique_name>
-     type: elasticsearch
-     server_host: <elasticsearch hostname>
-     server_port: <elasticsearch port, default to 9200>
-     index_prefix: <prefix to use in the elasticsearch index file>
-     input_type: <input type, e.g., ovirt>
-     retryfailures: on|off, default to on
-     ca_cert: <path to ca.crt>
-     cert: <path to es-cert.pem>
-     key: <path to es-key.pem>
+     type:          elasticsearch
+     server_host:   Hostname elasticsearch is running on.
+     server_port:   Port number elasticsearch is listening to. Default to 9200.
+     index_prefix:  Elasticsearch index prefix the particular log is to be indexed.
+     input_type:    Specifying the input type. Type ovirt and viaq are supported. Default to ovirt.
+     retryfailures: Specifying whether retries or not in case of failure. on or off.  Default to on.
+     use_cert:      If true, access to Elasticsearch using ca_cert, cert and key. Default to true.
+	                Triplets {ca_cert, cert, key} and/or {ca_cert_src, cert_src, key_src} are required.
+     ca_cert:       Path to CA cert for Elasticsearch.  Default to '/etc/rsyslog.d/es-ca.crt'
+     cert:          Path to cert for Elasticsearch.  Default to '/etc/rsyslog.d/es-cert.pem'
+     key:           Path to key for Elasticsearch.  Default to "/etc/rsyslog.d/es-key.pem"
+     ca_cert_src:   Path to the CA cert file on the local host to copy to the target host.
+	                If ca_cert is specified, copied to the location. Otherwise, to rsyslog_config_dir.
+     cert_src:      Path to the cert file on the local host to copy to the target host.
+	                If cert is specified, copied to the location. Otherwise, to rsyslog_config_dir.
+     key_src:       Path to the key file on the local host to copy to the target host.
+	                If key is specified, copied to the location. Otherwise, to rsyslog_config_dir.
    ```
 - `files`: array of dictionary to specify the facility and severity filter and the full path to store logs satisfying the filter.  It takes the sub-variables - `name`, `facility`, `severity`, `exclude`, and `path`.  Unless the name and the path are given, the element is skipped.
 Files output format
@@ -324,23 +332,6 @@ Viaq inputs sub-variables
 - `rsyslog_viaq_log_dir`: Viaq log directory.  Default to '/var/log/containers'.
 - `logging_mmk8s_token`: Path to token for kubernetes.  Default to "/etc/rsyslog.d/mmk8s.token"
 - `logging_mmk8s_ca_cert`: Path to CA cert for kubernetes.  Default to "/etc/rsyslog.d/mmk8s.ca.crt"
-- `use_omelasticsearch_cert` : If set to 'true', omelasticsearch is configured to use the certificates specified in the elasticsearch type logging_outputs.  Default to 'false'.
-- `use_local_omelasticsearch_cert` : If set to 'true', local files ca_cert_src, cert_src and key_src in the elasticsearch type logging_outputs will be deployed to the remote host.
-
-- For the elasticsearch type logging_outputs, a set of following variables are to specify output elasticsearch configurations. It could be an array if multiple elasticsearch clusters to be configured.
-   If set to 'true', ca_cert_src, cert_src and key_src must be set in each elasticsearch element. Otherwise, the deployment fails. Default to 'false'.
-  - `name`: Name of the elasticsearch element.
-  - `server_host`: Hostname elasticsearch is running on.
-  - `server_port`: Port number elasticsearch is listening to.
-  - `index_prefix`: Elasticsearch index prefix the particular log is to be indexed.
-  - `input_type`: Specifying the input type. Type `ovirt` and `viaq` are supported. Default to `ovirt`.
-  - `retryfailures`: Specifying whether retries or not in case of failure. on or off.  Default to on.
-  - `ca_cert`: Path to CA cert for Elasticsearch.  Default to '/etc/rsyslog.d/es-ca.crt'
-  - `cert`: Path to cert for Elasticsearch.  Default to '/etc/rsyslog.d/es-cert.pem'
-  - `key`: Path to key for Elasticsearch.  Default to "/etc/rsyslog.d/es-key.pem"
-  - `ca_cert_src`: Path to the local CA cert file to deploy for Elasticsearch.
-  - `cert_src`: Path to the local cert file to deploy for Elasticsearch.
-  - `key_src`: Path to the local key file to deploy for Elasticsearch.
 
 Contents of Roles
 =================

--- a/roles/rsyslog/tasks/outputs/elasticsearch/main.yml
+++ b/roles/rsyslog/tasks/outputs/elasticsearch/main.yml
@@ -25,6 +25,16 @@
         - '{{ rsyslog_output_elasticsearch }}'
       when: item.key_src | d()
 
+    - name: Check certs - use_cert is true, but triplets are not given
+      fail:
+        msg: "Error: you specified use_cert: true; you must specify all 3 of ca_cert, cert, key, or all 3 of ca_cert_src, cert_src, key_src, or set use_cert: false in the elasticsearch output named {{ item.name }}"
+      with_items:
+        - '{{ rsyslog_output_elasticsearch }}'
+      when:
+        - item.use_cert | d(true)
+        - not ((item.ca_cert | d() and item.cert | d() and item.key | d()) or
+               (item.ca_cert_src | d() and item.cert_src | d() and item.key_src | d()))
+
     - name: Update ca_cert path to /etc/rsyslog.d directory in Rsyslog
       set_fact:
         __rsyslog_elasticsearch_temp: >-
@@ -37,6 +47,16 @@
       with_items:
         - '{{ rsyslog_output_elasticsearch }}'
       when: item.ca_cert_src | d() or item.cert_src | d() or item.key_src | d()
+
+    - name: Check certs - key/certs data are provided, but use_cert is false
+      fail:
+        msg: "Error: you specified use_cert: false and also specified one or more cert/key files in the elasticsearch output named {{ item.name }}"
+      with_items:
+        - '{{ rsyslog_output_elasticsearch }}'
+      when:
+        - not (item.use_cert | d(true))
+        - item.ca_cert | d() or item.cert | d() or item.key | d()
+        - item.ca_cert_src | d() or item.cert_src | d() or item.key_src | d()
 
     - name: Set updated rsyslog_output_elasticsearch
       set_fact:

--- a/roles/rsyslog/tasks/outputs/elasticsearch/main.yml
+++ b/roles/rsyslog/tasks/outputs/elasticsearch/main.yml
@@ -4,53 +4,47 @@
     - name: Copy local Elasticsearch ca_certs to /etc/rsyslog.d directory in Rsyslog
       copy:
         src: '{{ item.ca_cert_src }}'
-        dest: '{{ rsyslog_config_dir }}'
+        dest: '{{ item.ca_cert | d(rsyslog_config_dir) }}'
       with_items:
         - '{{ rsyslog_output_elasticsearch }}'
-      when:
-        - item.ca_cert_src is defined
-        - item.ca_cert_src | length > 0
+      when: item.ca_cert_src | d()
 
     - name: Copy local Elasticsearch certs to /etc/rsyslog.d directory in Rsyslog
       copy:
         src: '{{ item.cert_src }}'
-        dest: '{{ rsyslog_config_dir }}'
+        dest: '{{ item.cert | d(rsyslog_config_dir) }}'
       with_items:
         - '{{ rsyslog_output_elasticsearch }}'
-      when:
-        - item.cert_src is defined
-        - item.cert_src | length > 0
+      when: item.cert_src | d()
 
     - name: Copy local Elasticsearch keys to /etc/rsyslog.d directory in Rsyslog
       copy:
         src: '{{ item.key_src }}'
-        dest: '{{ rsyslog_config_dir }}'
+        dest: '{{ item.key | d(rsyslog_config_dir) }}'
       with_items:
         - '{{ rsyslog_output_elasticsearch }}'
-      when:
-        - item.key_src is defined
-        - item.key_src | length > 0
+      when: item.key_src | d()
 
     - name: Update ca_cert path to /etc/rsyslog.d directory in Rsyslog
       set_fact:
         __rsyslog_elasticsearch_temp: >-
           {{ __rsyslog_elasticsearch_temp | d([]) }} +
-          {{ [ item | combine( { 'ca_cert': item.ca_cert_src | basename ,
-          'cert': item.cert_src | basename, 'key': item.key_src | basename } ) ] }}
+          {{ [ item |
+               combine( { 'ca_cert': item.ca_cert | d(rsyslog_config_dir + '/' + item.ca_cert_src | basename),
+                          'cert': item.cert | d(rsyslog_config_dir + '/' + item.cert_src | basename),
+                          'key': item.key | d(rsyslog_config_dir + '/' + item.key_src | basename) } )
+          ] }}
       with_items:
         - '{{ rsyslog_output_elasticsearch }}'
-      when:
-        - item.ca_cert_src is defined
-        - item.ca_cert_src | length > 0
-      register: result
+      when: item.ca_cert_src | d() or item.cert_src | d() or item.key_src | d()
 
     - name: Set updated rsyslog_output_elasticsearch
       set_fact:
         rsyslog_output_elasticsearch: "{{ __rsyslog_elasticsearch_temp }}"
+      when: __rsyslog_elasticsearch_temp | d([])
 
   when:
     - rsyslog_output_elasticsearch | d([])
-    - use_local_omelasticsearch_cert | default(false) | bool
 
 # Deploy configuration files
 - name: Install/Update elasticsearch logging packages and generate configuration files in /etc/rsyslog.d

--- a/roles/rsyslog/templates/output_elasticsearch.j2
+++ b/roles/rsyslog/templates/output_elasticsearch.j2
@@ -56,7 +56,7 @@ ruleset(name="{{ es_item.name }}") {
             retryfailures="off"
 {% endif %}
             usehttps="{{ es_item.usehttps | default("on") }}"
-{% if use_omelasticsearch_cert | default(true) %}
+{% if es_item.use_cert | default(true) %}
             tls.cacert="{{ es_item.ca_cert | default('/etc/rsyslog.d/es-ca.crt') }}"
             tls.mycert="{{ es_item.cert | default('/etc/rsyslog.d/es-cert.pem') }}"
             tls.myprivkey="{{ es_item.key | default('/etc/rsyslog.d/es-key.pem') }}"

--- a/roles/rsyslog/vars/outputs/elasticsearch/main.yml
+++ b/roles/rsyslog/vars/outputs/elasticsearch/main.yml
@@ -31,7 +31,7 @@ __rsyslog_conf_es_main_modules:
     sections:
 
       - options: |-
-          # Send to ElasticSearch
+          # Send to Elasticsearch
           module(load="omelasticsearch")
 
 __rsyslog_conf_es_elasticsearch:

--- a/tests/tests_files_elasticsearch.yml
+++ b/tests/tests_files_elasticsearch.yml
@@ -1,4 +1,4 @@
-- name: Ensure that the role runs with parameters from imfile to two elasticsearch outputs
+- name: Ensure that the role runs with parameters from imfile to two elasticsearch outputs without certs
   hosts: all
   become: true
   vars:

--- a/tests/tests_files_elasticsearch_certs_incomplete.yml
+++ b/tests/tests_files_elasticsearch_certs_incomplete.yml
@@ -1,0 +1,59 @@
+- name: Error case for Elasticsearch config - cert and ca_cert_src are missing
+  hosts: all
+  become: true
+  vars:
+    __test_inputfiles_dir: /var/log/inputdirectory
+    __test_inputfiles_conf: /etc/rsyslog.d/90-input-files-files_input.conf
+    __test_outputfiles_conf: /etc/rsyslog.d/31-output-elasticsearch-elasticsearch_output.conf
+    __test_ca_cert: /tmp/es-ca.crt
+    __test_cert: /tmp/es-cert.pem
+    __test_key: /tmp/es-key.pem
+
+  tasks:
+    - name: generate test files
+      copy:
+        dest: "{{ item }}"
+        content:
+          This is a fake {{ item }}.
+      delegate_to: localhost
+      loop:
+        - "{{ __test_ca_cert }}"
+        - "{{ __test_cert }}"
+        - "{{ __test_key }}"
+
+    - block:
+      - name: deploy config to send to elasticsearch
+        vars:
+          logging_outputs:
+            - name: elasticsearch_output
+              type: elasticsearch
+              server_host: logging-es
+              server_port: 9200
+              index_prefix: project.
+              input_type: ovirt
+              retryfailures: off
+              ca_cert: /etc/rsyslog.d/ca_cert.crt
+              key: /etc/rsyslog.d/key.pem
+              cert_src: "{{ __test_cert }}"
+              key_src: "{{ __test_key }}"
+          logging_inputs:
+            - name: files_input
+              type: files
+              rsyslog_input_log_path: "{{ __test_inputfiles_dir }}/*.log"
+          logging_flows:
+            - name: flow_0
+              inputs: [files_input]
+              outputs: [elasticsearch_output, elasticsearch_output_ops]
+        include_role:
+          name: linux-system-roles.logging
+
+      - name: unreachable task
+        fail:
+          msg: UNREACH
+
+      rescue:
+        - debug:
+            msg: "Caught an expected error - {{ ansible_failed_result.results }}"
+        - name: assert...
+          assert:
+            that: "'{{ ansible_failed_result.results.0.msg }}' is match('Error: you specified use_cert: true; you must specify all 3 of ca_cert, cert, key, or all 3 of ca_cert_src, cert_src, key_src, or set use_cert: false in the elasticsearch output named elasticsearch_output')"

--- a/tests/tests_files_elasticsearch_use_cert_false_with_keys.yml
+++ b/tests/tests_files_elasticsearch_use_cert_false_with_keys.yml
@@ -1,0 +1,60 @@
+- name: Error case for Elasticsearch config - although cert paths are specified, use_cert is false
+  hosts: all
+  become: true
+  vars:
+    __test_inputfiles_dir: /var/log/inputdirectory
+    __test_ca_cert: /tmp/es-ca.crt
+    __test_cert: /tmp/es-cert.pem
+    __test_key: /tmp/es-key.pem
+
+  tasks:
+    - name: generate test files
+      copy:
+        dest: "{{ item }}"
+        content:
+          This is a fake {{ item }}.
+      delegate_to: localhost
+      loop:
+        - "{{ __test_ca_cert }}"
+        - "{{ __test_cert }}"
+        - "{{ __test_key }}"
+
+    - block:
+      - name: deploy config to send to elasticsearch
+        vars:
+          logging_outputs:
+            - name: elasticsearch_output
+              type: elasticsearch
+              server_host: logging-es
+              server_port: 9200
+              index_prefix: project.
+              input_type: ovirt
+              retryfailures: off
+              use_cert: false
+              ca_cert: /etc/rsyslog.d/ca_cert.crt
+              cert: /etc/rsyslog.d/cert.pem
+              key: /etc/rsyslog.d/key.pem
+              ca_cert_src: "{{ __test_ca_cert }}"
+              cert_src: "{{ __test_cert }}"
+              key_src: "{{ __test_key }}"
+          logging_inputs:
+            - name: files_input
+              type: files
+              rsyslog_input_log_path: "{{ __test_inputfiles_dir }}/*.log"
+          logging_flows:
+            - name: flow_0
+              inputs: [files_input]
+              outputs: [elasticsearch_output, elasticsearch_output_ops]
+        include_role:
+          name: linux-system-roles.logging
+
+      - name: unreachable task
+        fail:
+          msg: UNREACH
+
+      rescue:
+        - debug:
+            msg: "Caught an expected error - {{ ansible_failed_result.results }}"
+        - name: assert...
+          assert:
+            that: "'{{ ansible_failed_result.results.0.msg }}' is match('Error: you specified use_cert: false and also specified one or more cert/key files in the elasticsearch output named elasticsearch_output')"

--- a/tests/tests_files_elasticsearch_use_local_cert.yml
+++ b/tests/tests_files_elasticsearch_use_local_cert.yml
@@ -2,12 +2,25 @@
   hosts: all
   become: true
   vars:
-    __rsyslog_version: "N/A"
     __test_inputfiles_dir: /var/log/inputdirectory
     __test_inputfiles_conf: /etc/rsyslog.d/90-input-files-files_input.conf
-    __test_outputfiles_conf: /etc/rsyslog.d/31-output-elasticsearch-elasticsearch_output_ops.conf
+    __test_outputfiles_conf: /etc/rsyslog.d/31-output-elasticsearch-elasticsearch_output.conf
+    __test_ca_cert: /tmp/es-ca.crt
+    __test_cert: /tmp/es-cert.pem
+    __test_key: /tmp/es-key.pem
 
   tasks:
+    - name: generate test files
+      copy:
+        dest: "{{ item }}"
+        content:
+          This is a fake {{ item }}.
+      delegate_to: localhost
+      loop:
+        - "{{ __test_ca_cert }}"
+        - "{{ __test_cert }}"
+        - "{{ __test_key }}"
+
     - name: deploy config to send to elasticsearch
       vars:
         logging_outputs:
@@ -18,15 +31,10 @@
             index_prefix: project.
             input_type: ovirt
             retryfailures: off
-            use_cert: false
-          - name: elasticsearch_output_ops
-            type: elasticsearch
-            server_host: logging-es-ops
-            server_port: 9200
-            index_prefix: .operations.
-            input_type: viaq
-            retryfailures: off
-            use_cert: false
+            use_cert: true
+            ca_cert_src: "{{ __test_ca_cert }}"
+            cert_src: "{{ __test_cert }}"
+            key_src: "{{ __test_key }}"
         logging_inputs:
           - name: files_input
             type: files
@@ -45,33 +53,34 @@
     - name: Force all notified handlers to run at this point, not waiting for normal sync points
       meta: flush_handlers
 
-    - name: Check rsyslog version
-      assert:
-        that: __rsyslog_version != "N/A" and __rsyslog_version != "0.0.0"
-
     - name: Check rsyslog.conf size
       assert:
-        that: rsyslog_conf_stat.stat.size < 1000
+        that: rsyslog_conf_line_count.stdout.0 | int <= 7
 
     - name: Check file counts in rsyslog.d
       assert:
         that: rsyslog_d_file_count.matched >= 9
 
-    - name: Get the output files config stat
+    - name: Check if the output files config exists
       stat:
         path: "{{ __test_outputfiles_conf }}"
-      register: stat_output_files_system
 
-    - name: Check if the output files config exists
-      assert:
-        that: stat_output_files_system.stat.exists
+    - name: Check if the copied ca cert file exists
+      stat:
+        path: "/etc/rsyslog.d/{{ __test_ca_cert | basename }}"
 
-    - name: Check ops ruleset exists in {{ __test_outputfiles_conf }}
-      command: /bin/grep "ruleset.name=.elasticsearch_output_ops" {{ __test_outputfiles_conf }}
-      register: es_ops_ruleset
-      changed_when: false
+    - name: Check if the copied cert file exists
+      stat:
+        path: "/etc/rsyslog.d/{{ __test_cert | basename }}"
 
-    - name: Check call point for ops ruleset exists in {{ __test_inputfiles_conf }}
-      command: /bin/grep "call elasticsearch_output_ops" {{ __test_inputfiles_conf }}
-      register: es_call_ops_ruleset
+    - name: Check if the copied key file exists
+      stat:
+        path: "/etc/rsyslog.d/{{ __test_key | basename }}"
+
+    - name: Check key/certs in {{ __test_outputfiles_conf }}
+      command: /bin/grep "tls\.{{ item.key }}=.\/etc\/rsyslog\.d\/{{ item.value | basename }}." {{ __test_outputfiles_conf }}
+      with_dict:
+        - cacert: "{{ __test_ca_cert }}"
+        - mycert: "{{ __test_cert }}"
+        - myprivkey: "{{ __test_key }}"
       changed_when: false

--- a/tests/tests_files_elasticsearch_use_local_cert_all.yml
+++ b/tests/tests_files_elasticsearch_use_local_cert_all.yml
@@ -1,4 +1,4 @@
-- name: Ensure that the role runs with parameters from imfile to two elasticsearch outputs
+- name: Elasticsearch config - local certs are copied to the target host with the specified path.
   hosts: all
   become: true
   vars:
@@ -8,6 +8,9 @@
     __test_ca_cert: /tmp/es-ca.crt
     __test_cert: /tmp/es-cert.pem
     __test_key: /tmp/es-key.pem
+    __test_ca_cert_target: /tmp/es-ca-target.crt
+    __test_cert_target: /tmp/es-cert-target.pem
+    __test_key_target: /tmp/es-key-target.pem
 
   tasks:
     - name: generate test files
@@ -34,6 +37,9 @@
             ca_cert_src: "{{ __test_ca_cert }}"
             cert_src: "{{ __test_cert }}"
             key_src: "{{ __test_key }}"
+            ca_cert: "{{ __test_ca_cert_target }}"
+            cert: "{{ __test_cert_target }}"
+            key: "{{ __test_key_target }}"
         logging_inputs:
           - name: files_input
             type: files
@@ -66,20 +72,20 @@
 
     - name: Check if the copied ca cert file exists
       stat:
-        path: "/etc/rsyslog.d/{{ __test_ca_cert | basename }}"
+        path: "{{ __test_ca_cert_target }}"
 
     - name: Check if the copied cert file exists
       stat:
-        path: "/etc/rsyslog.d/{{ __test_cert | basename }}"
+        path: "{{ __test_cert_target }}"
 
     - name: Check if the copied key file exists
       stat:
-        path: "/etc/rsyslog.d/{{ __test_key | basename }}"
+        path: "{{ __test_key_target }}"
 
     - name: Check key/certs in {{ __test_outputfiles_conf }}
-      command: /bin/grep "tls\.{{ item.key }}=.\/etc\/rsyslog\.d\/{{ item.value | basename }}." {{ __test_outputfiles_conf }}
+      command: /bin/grep "tls\.{{ item.key }}=\"{{ item.value }}\"" {{ __test_outputfiles_conf }}
       with_dict:
-        - cacert: "{{ __test_ca_cert }}"
-        - mycert: "{{ __test_cert }}"
-        - myprivkey: "{{ __test_key }}"
+        - cacert: "{{ __test_ca_cert_target }}"
+        - mycert: "{{ __test_cert_target }}"
+        - myprivkey: "{{ __test_key_target }}"
       changed_when: false

--- a/tests/tests_files_elasticsearch_use_local_cert_nokeys.yml
+++ b/tests/tests_files_elasticsearch_use_local_cert_nokeys.yml
@@ -1,0 +1,40 @@
+- name: Error case for Elasticsearch config - although use_cert is true, no cert data are given.
+  hosts: all
+  become: true
+  vars:
+    __test_inputfiles_dir: /var/log/inputdirectory
+
+  tasks:
+    - block:
+      - name: deploy config to send to elasticsearch
+        vars:
+          logging_outputs:
+            - name: elasticsearch_output
+              type: elasticsearch
+              server_host: logging-es
+              server_port: 9200
+              index_prefix: project.
+              input_type: ovirt
+              retryfailures: off
+              use_cert: true
+          logging_inputs:
+            - name: files_input
+              type: files
+              rsyslog_input_log_path: "{{ __test_inputfiles_dir }}/*.log"
+          logging_flows:
+            - name: flow_0
+              inputs: [files_input]
+              outputs: [elasticsearch_output, elasticsearch_output_ops]
+        include_role:
+          name: linux-system-roles.logging
+
+      - name: unreachable task
+        fail:
+          msg: UNREACH
+
+      rescue:
+        - debug:
+            msg: "Caught an expected error - {{ ansible_failed_result.results }}"
+        - name: assert...
+          assert:
+            that: "'{{ ansible_failed_result.results.0.msg }}' is match('Error: you specified use_cert: true; you must specify all 3 of ca_cert, cert, key, or all 3 of ca_cert_src, cert_src, key_src, or set use_cert: false in the elasticsearch output named elasticsearch_output')"


### PR DESCRIPTION
…output

The key/certs for the elasticsearch output is controled by an elasticsearch
boolean sub variable use_cert. If on, ca_cert, cert and key sub variables
are supposed to be configured. Alternatively, if a global variable
use_local_omelasticsearch_cert is set to true, key/certs files on the local
host are copied to rsyslog_config_dir (/etc/rsyslog.d, by default) on the
target hosts and set them.

Adding the test case tests/tests_files_elasticsearch_use_local_cert.yml