### PR TITLE
Making "state: absent" work.

### DIFF
--- a/roles/rsyslog/tasks/deploy.yml
+++ b/roles/rsyslog/tasks/deploy.yml
@@ -23,3 +23,17 @@
     - item.options | d() or item.sections | d()
     - item.state is undefined or item.state != 'absent'
   notify: restart rsyslogd
+
+- name: Remove role config files from subdir
+  file:
+    path: >-
+      {{ item.path | d(rsyslog_config_dir) }}/{{ item.filename | d((item.weight
+      if item.weight | d() else rsyslog_weight_map[item.type | d("rules")]) +
+      "-" + (item.name | d("rules")) + "." + (item.suffix | d("conf"))) }}
+    state: absent
+  loop: '{{ __rsyslog_rules | flatten }}'
+  when:
+    - item.filename | d() or item.name | d()
+    - item.options | d() or item.sections | d()
+    - item.state | d('present') == 'absent'
+  notify: restart rsyslogd

--- a/roles/rsyslog/tasks/inputs/basics/main.yml
+++ b/roles/rsyslog/tasks/inputs/basics/main.yml
@@ -15,6 +15,7 @@
     __rsyslog_rules:
       - name: "input-basics-{{ basics_item.name }}"
         type: input
+        state: "{{ basics_item.state | d('present') }}"
         sections:
           - options: "{{ lookup('template', __rsyslog_input_basics) }}"
   include_tasks:

--- a/roles/rsyslog/tasks/inputs/files/main.yml
+++ b/roles/rsyslog/tasks/inputs/files/main.yml
@@ -15,6 +15,7 @@
     __rsyslog_rules:
       - name: "input-files-{{ files_item.name }}"
         type: input
+        state: "{{ files_item.state | d('present') }}"
         sections:
           - options: |-
               input(type="imfile" file="{{ files_item.rsyslog_input_log_path | d(rsyslog_input_log_path) }}" tag="{{ files_item.name }}")

--- a/roles/rsyslog/tasks/inputs/ovirt/main.yml
+++ b/roles/rsyslog/tasks/inputs/ovirt/main.yml
@@ -15,6 +15,7 @@
         type: input
         sections:
           - options: "{{ lookup('template', 'ovirt_input_template.j2') }}"
+        state: "{{ ovirt_item.state | d('present') }}"
   include_tasks:
     file: deploy.yml
   loop: '{{ logging_inputs }}'

--- a/roles/rsyslog/tasks/inputs/remote/main.yml
+++ b/roles/rsyslog/tasks/inputs/remote/main.yml
@@ -20,6 +20,7 @@
       - name: "input-remote-{{ remote_item.name }}"
         type: input
         weight: "11"
+        state: "{{ remote_item.state | d('present') }}"
         sections:
           - options: "{{ lookup('template', 'input_remote.j2') }}"
   include_tasks:

--- a/roles/rsyslog/tasks/outputs/elasticsearch/main.yml
+++ b/roles/rsyslog/tasks/outputs/elasticsearch/main.yml
@@ -77,8 +77,13 @@
 - name: Create elasticsearch output configuration files in /etc/rsyslog.d
   vars:
     __rsyslog_packages: []
-    __rsyslog_rules: [ { "name": "output-elasticsearch-{{ es_item.name }}", "type": "output", "weight": "31",
-                         "sections": [ { "options": "{{ lookup('template', 'output_elasticsearch.j2') }}" } ] } ]
+    __rsyslog_rules:
+      - name: "output-elasticsearch-{{ es_item.name }}"
+        type: "output"
+        weight: "31"
+        state: "{{ es_item.state | d('present') }}"
+        sections:
+          - options: "{{ lookup('template', 'output_elasticsearch.j2') }}"
   include_tasks:
     file: deploy.yml
   loop: '{{ rsyslog_output_elasticsearch }}'

--- a/roles/rsyslog/tasks/outputs/files/main.yml
+++ b/roles/rsyslog/tasks/outputs/files/main.yml
@@ -10,8 +10,12 @@
 - name: Create files output configuration files in /etc/rsyslog.d
   vars:
     __rsyslog_packages: []
-    __rsyslog_rules: [ { "name": "output-files-{{ files_item.name }}", "type": "output",
-                         "sections": [ { "options": "{{ lookup('template', 'output_files.j2') }}" } ] } ]
+    __rsyslog_rules:
+      - name: "output-files-{{ files_item.name }}"
+        type: "output"
+        state: "{{ files_item.state | d('present') }}"
+        sections:
+          - options: "{{ lookup('template', 'output_files.j2') }}"
   include_tasks:
     file: deploy.yml
   loop: '{{ rsyslog_output_files }}'

--- a/roles/rsyslog/tasks/outputs/forwards/main.yml
+++ b/roles/rsyslog/tasks/outputs/forwards/main.yml
@@ -10,8 +10,12 @@
 - name: Create forwards output configuration files in /etc/rsyslog.d
   vars:
     __rsyslog_packages: []
-    __rsyslog_rules: [ { "name": "output-forwards-{{ forwards_item.name }}", "type": "output",
-                         "sections": [ { "options": "{{ lookup('template', 'output_forwards.j2') }}" } ] } ]
+    __rsyslog_rules:
+      - name: "output-forwards-{{ forwards_item.name }}"
+        type: "output"
+        state: "{{ forwards_item.state | d('present') }}"
+        sections:
+          - options: "{{ lookup('template', 'output_forwards.j2') }}"
   include_tasks:
     file: deploy.yml
   loop: '{{ rsyslog_output_forwards }}'

--- a/roles/rsyslog/tasks/outputs/remote_files/main.yml
+++ b/roles/rsyslog/tasks/outputs/remote_files/main.yml
@@ -5,6 +5,7 @@
     __rsyslog_rules:
       - name: "output-files-{{ remote_files_item.name }}"
         type: "output"
+        state: "{{ remote_files_item.state | d('present') }}"
         sections:
           - options: "{{ lookup('template', 'output_remote_files.j2') }}"
   include_tasks:

--- a/tests/tests_combination_absent.yml
+++ b/tests/tests_combination_absent.yml
@@ -1,0 +1,174 @@
+- name: Running logging role twice; in the second run, some logging_outputs are absent or eliminated.
+  hosts: all
+  become: true
+  vars:
+    __rsyslog_version: "N/A"
+    __test_tag: files_input
+    __test_inputfiles_conf: /etc/rsyslog.d/90-input-files-{{ __test_tag }}.conf
+    __test_inputfiles_dir: /var/log/inputdirectory
+    __test_basics_conf: 90-input-basics-basic_input.conf
+
+  tasks:
+    - name: Generate an input log dir {{ __test_inputfiles_dir }}
+      file:
+        path: "{{ __test_inputfiles_dir }}"
+        state: directory
+        mode: 0700
+
+    - name: deploy config to output into local files
+      vars:
+        logging_outputs:
+          - name: files_test0
+            type: files
+            severity: info
+            exclude:
+              - authpriv.none
+              - auth.none
+              - cron.none
+              - mail.none
+            path: /var/log/messages
+          - name: files_test1
+            type: files
+            facility: authpriv,auth
+            path: /var/log/secure
+          - name: forwards_severity_and_facility
+            type: forwards
+            facility: local1
+            severity: info
+            protocol: tcp
+            target: host.domain
+            port: 1514
+          - name: forwards_facility_only
+            type: forwards
+            facility: local2
+            protocol: tcp
+            target: host.domain
+            port: 2514
+        logging_inputs:
+          - name: basic_input
+            type: basics
+            rsyslog_imjournal_ratelimit_burst: 33333
+          - name: "{{ __test_tag }}"
+            type: files
+            rsyslog_input_log_path: "{{ __test_inputfiles_dir }}/*.log"
+        logging_flows:
+          - name: flow_0
+            inputs: [basic_input]
+            outputs: [files_test0, files_test1, forwards_severity_and_facility, forwards_facility_only]
+          - name: flow_1
+            inputs: ["{{ __test_tag }}"]
+            outputs: [files_test0, files_test1]
+      include_role:
+        name: linux-system-roles.logging
+
+    - include_tasks: set_rsyslog_variables.yml
+
+    # notify restart rsyslogd is executed at the end of this test task.
+    # thus we have to force to invoke handlers
+    - name: Force all notified handlers to run at this point, not waiting for normal sync points
+      meta: flush_handlers
+
+    - name: Check rsyslog version
+      assert:
+        that: __rsyslog_version != "N/A" and __rsyslog_version != "0.0.0"
+
+    - name: Check rsyslog.conf size
+      assert:
+        that: rsyslog_conf_stat.stat.size < 1000
+
+    - name: Check file counts in rsyslog.d
+      assert:
+        that: rsyslog_d_file_count.matched >= 11
+
+    - name: generate test config file
+      copy:
+        dest: "/etc/rsyslog.d/{{ __test_basics_conf }}"
+        content: |-
+          # GENERATED BASICS CONFIG FILE
+          module(load="imuxsock"    # provides support for local system logging (e.g. via logger command)
+                 SysSock.Use="off") # Turn off message reception via local log socket.
+          module(load="imjournal"
+                 StateFile="/var/lib/rsyslog/imjournal.state"
+                 RateLimit.Burst="20000"
+                 RateLimit.Interval="600"
+                 PersistStateInterval="10")
+          if
+            ($inputname == "imjournal")
+            then {
+              call files_test0
+          }
+
+    # Checking 'error' in stdout from systemctl status is for detecting the case in which rsyslog is running,
+    # but some functionality is disabled due to some error, e.g., error: 'tls.cacert' file couldn't be accessed.
+    - name: Check rsyslog errors
+      command: systemctl status rsyslog
+      register: systemctl_result
+      failed_when: "'error' in systemctl_result.stdout or systemctl_result.rc != 0"
+
+    - name: deploy reduced config to output into local files
+      vars:
+        logging_outputs:
+          - name: files_test0
+            type: files
+            severity: info
+            exclude:
+              - authpriv.none
+              - auth.none
+              - cron.none
+              - mail.none
+            path: /var/log/messages
+          - name: files_test1
+            type: files
+            facility: authpriv,auth
+            path: /var/log/secure
+            state: absent
+          - name: forwards_severity_and_facility
+            type: forwards
+            facility: local1
+            severity: info
+            protocol: tcp
+            target: host.domain
+            port: 1514
+            state: absent
+          - name: forwards_facility_only
+            type: forwards
+            facility: local2
+            protocol: tcp
+            target: host.domain
+            port: 2514
+            state: absent
+        logging_inputs:
+          - name: basic_input
+            type: basics
+            rsyslog_imjournal_ratelimit_burst: 33333
+          - name: "{{ __test_tag }}"
+            type: files
+            rsyslog_input_log_path: "{{ __test_inputfiles_dir }}/*.log"
+            state: absent
+        logging_flows:
+          - name: flow_0
+            inputs: [basic_input]
+            outputs: [files_test0]
+      include_role:
+        name: linux-system-roles.logging
+
+    - include_tasks: set_rsyslog_variables.yml
+
+    # notify restart rsyslogd is executed at the end of this test task.
+    # thus we have to force to invoke handlers
+    - name: Force all notified handlers to run at this point, not waiting for normal sync points
+      meta: flush_handlers
+
+    - name: Check file counts in rsyslog.d are less than no-absent case
+      assert:
+        that: rsyslog_d_file_count.matched < 11
+
+    - name: Check {{ __test_basics_conf }} was updated
+      command: '/bin/grep "# GENERATED BASICS CONFIG FILE" /etc/rsyslog.d/{{ __test_basics_conf }}'
+      register: result
+      failed_when: result.rc == 0
+
+    - name: Check rsyslog errors
+      command: systemctl status rsyslog
+      register: systemctl_result
+      failed_when: "'error' in systemctl_result.stdout or systemctl_result.rc != 0"


### PR DESCRIPTION
When an item in logging_inputs and outputs has an absent state,
(assuming the to-be-generated config file name is XX-filename.conf)
case 1) XX-filename.conf does not exist.
logging role does not generate XX-filename.conf
case 2) XX-filename.conf exists.
logging role deletes XX-filename.conf

Questionable case) XX-filename.conf exists; instead of having the
item with the absent state, delete the item from logging_inputs or
outputs. Then, the existing XX-filename.conf remains untouched.

Adding a test playbook tests_combination_absent.yml