### PR TITLE
RHELPLAN-43536 - Support tls for the remote input and forwards output

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,13 +21,50 @@ logging_purge_confs: false
 logging_system_log_dir: /var/log
 
 # Specifying rsyslog encryption library
-# one of the implementations is allowed none, ptcp, tls, gtls, gnutls, openssl
-# Note: none->ptcp, tls,gtls,gnutls->gtls, openssl->openssl
-# Default to ptcp
-logging_encryption: ptcp
+# one of the implementations is allowed none, ptcp, tls, gtls, gnutls
+# Note: none->ptcp, tls,gtls,gnutls->gtls
+# Default to ptcp (== no tls)
+logging_pki: ptcp
 
 # Mark message periodically by immark, if set to true.
 logging_mark: false
 
 # Interval for logging_mark in seconds.
 logging_mark_interval: 3600
+
+# When the provider is rsyslog, default 8192 - allows to specify maximum supported message size
+# both for sending and receiving. Must be greater than 1024.
+logging_max_message_size: 8192
+
+# list of pki files dict
+# logging_pki_files:
+#   - type: ca_cert | cert | key
+#     src:  location of the file on the local host; if given, the file is deployed to dest value path.
+#     dest: path to be deployed on the target host; if given, the path is set to the config file.
+#           Default to /etc/pki/tls/certs/ca.crt for ca_cert
+#                      /etc/pki/tls/certs/cert.pem for cert
+#                      /etc/pki/tls/private/key.pem for key
+logging_pki_files: []
+
+# logging_pki_authmode
+#
+# Specify the default network driver authetication mode.
+# `x509/name` or `anon` are available:
+logging_pki_authmode: "x509/name"
+
+# logging_domain
+#
+# The default DNS domain used to accept remote incoming logs from remote hosts.
+logging_domain: '{{ ansible_domain if ansible_domain else ansible_hostname }}'
+
+# logging_permitted_peers
+#
+# List of hostnames, IP addresses or wildcard DNS domains which will be allowed
+# by the `logging` server to connect and send logs over TLS.
+logging_permitted_peers: ['*.{{ logging_domain }}']
+
+# logging_send_permitted_peers
+#
+# List of hostnames, IP addresses or wildcard DNS domains which will be verified
+# by the `logging` client and will allow to send logs to the remote server over TLS.
+logging_send_permitted_peers: '{{ logging_permitted_peers }}'

--- a/roles/rsyslog/README.md
+++ b/roles/rsyslog/README.md
@@ -240,11 +240,28 @@ Variables in vars.yml
 ======================
 
 - `logging_enabled` : When 'true', rsyslog role will deploy specified configuration file set. Default to 'true'.
-- `logging_encryption`: Specifying an encryption. One of `none`, `ptcp`, `tls`, `gtls`, `gnutls`, and `openssl`. Default to `ptcp`.
-                        Note: `none`=`ptcp`, `tls`=`gtls`=`gnutls`.
-                        When logging_encryption is _not_ `ptcp`, rsyslog_pki_path`, `rsyslog_pki_realm`, `rsyslog_pki_ca`, `rsyslog_pki_crt`, `rsyslog_pki_key` are configured.
 - `logging_mark`: Mark message periodically by immark, if set to `true`. Default to `false`.
 - `logging_mark_interval`: Interval for `logging_mark` in seconds. Default to 3600.
+- `logging_pki`: Specifying an encryption. One of `none`, `ptcp`, `tls`, `gtls`, and `gnutls`. Default to `ptcp`.
+                 Note: `none`=`ptcp`, `tls`=`gtls`=`gnutls`.
+                 When logging_pki is _not_ `ptcp`; rsyslog_pki_path`, `rsyslog_pki_realm`, `rsyslog_pki_ca`,
+                 `rsyslog_pki_crt`, `rsyslog_pki_key` will be configured.
+- `logging_pki_files`: list of pki files dict
+  ```
+   logging_pki_files:
+     - type: ca_cert | cert | key
+       src:  location of the file on the local host;
+             if given, the file is deployed to dest value path.
+       dest: path to be deployed on the target host;
+             if given, the path is set to the config file.
+             Default to /etc/pki/tls/certs/ca.crt for ca_cert
+                        /etc/pki/tls/certs/cert.pem for cert
+                        /etc/pki/tls/private/key.pem for key
+  ```
+- `logging_pki_authmode`: Specify the default network driver authentication mode. `x509/name` or `anon` are available: Default to "x509/name".
+- `logging_domain`: The default DNS domain used to accept remote incoming logs from remote hosts. Default to {{ ansible_domain if ansible_domain else ansible_hostname }}
+- `logging_permitted_peers`: List of hostnames, IP addresses or wildcard DNS domains which will be allowed by the `logging` server to connect and send logs over TLS.  Default to ['*.{{ logging_domain }}']
+- `logging_send_permitted_peers`: List of hostnames, IP addresses or wildcard DNS domains which will be verified by the `logging` client and will allow to send logs to the remote server over TLS. Default to '{{ logging_permitted_peers }}'.
 
 Common sub-variables
 --------------------

--- a/roles/rsyslog/defaults/main.yml
+++ b/roles/rsyslog/defaults/main.yml
@@ -58,7 +58,7 @@ __rsyslog_default_netstream_driver: '{{ __rsyslog_pki_map[logging_pki] | d("ptcp
 rsyslog_send_over_tls: |-
   $ActionSendStreamDriver {{ __rsyslog_default_netstream_driver }}
   $ActionSendStreamDriverAuthMode {{ logging_pki_authmode }}
-  {% if logging_pki_authmode != "anon" %}
+  {% if logging_pki_authmode == "x509/name" %}
   {%   if logging_send_permitted_peers is string %}
   $ActionSendStreamDriverPermittedPeer {{ logging_send_permitted_peers }}
   {%   else %}

--- a/roles/rsyslog/defaults/main.yml
+++ b/roles/rsyslog/defaults/main.yml
@@ -46,91 +46,28 @@ rsyslog_custom_config_files: []
 # By setting false, it'd change 2020-03-27T14:16:47.139796+00:00)
 rsyslog_basics_use_traditional_timestamp_format: true
 
-# Encrypted communication
+# communication over tls
 # ------------------------
 
-# X.509 certificates related variables
-
-# rsyslog_pki_path
-#
-# Path to the directory with PKI realms.
-rsyslog_pki_path: "/etc/pki"
-
-# rsyslog_pki_realm
-#
-# Name of the PKi realm to use with ``rsyslogd``.
-rsyslog_pki_realm: "domain"
-
-# rsyslog_pki_ca
-#
-# Name of the root CA certificate used by the ``rsyslog`` role.
-rsyslog_pki_ca: "CA.crt"
-
-# rsyslog_pki_crt
-#
-# Name of the client certificate file used by the ``rsyslog`` role.
-rsyslog_pki_crt: "default.crt"
-
-# rsyslog_pki_key
-#
-# Name of the private key file used by the ``rsyslog`` role.
-rsyslog_pki_key: "default.key"
-
-# Lookup rsyslog network stream driver
-__rsyslog_encryption_map:
-  none: ptcp
-  ptcp: ptcp
-  tls: gtls
-  gtls: gtls
-  gnutls: gtls
-  openssl: openssl
-
-# rsyslog_default_netstream_driver
-#
-# Specify the default netstream driver used by the ``imtcp`` module.
-rsyslog_default_netstream_driver: '{{ __rsyslog_encryption_map[logging_encryption] | d("ptcp") }}'
-
-# rsyslog_default_driver_authmode
-#
-# Specify the default network driver authetication mode. Actualy only
-# `x509/name` or `anon` are available:
-rsyslog_default_driver_authmode: "x509/name"
+__rsyslog_default_netstream_driver: '{{ __rsyslog_pki_map[logging_pki] | d("ptcp") }}'
 
 # rsyslog_send_over_tls
 #
 # This configuration is added to the forward options when ``tls`` capability is
 # enabled. It's used to configure TLS options.
 rsyslog_send_over_tls: |-
-  $ActionSendStreamDriver {{ rsyslog_default_netstream_driver }}
-  $ActionSendStreamDriverAuthMode {{ rsyslog_default_driver_authmode }}
-  {% if rsyslog_default_driver_authmode != "anon" %}
-  {%   if rsyslog_send_permitted_peers is string %}
-  $ActionSendStreamDriverPermittedPeer {{ rsyslog_send_permitted_peers }}
+  $ActionSendStreamDriver {{ __rsyslog_default_netstream_driver }}
+  $ActionSendStreamDriverAuthMode {{ logging_pki_authmode }}
+  {% if logging_pki_authmode != "anon" %}
+  {%   if logging_send_permitted_peers is string %}
+  $ActionSendStreamDriverPermittedPeer {{ logging_send_permitted_peers }}
   {%   else %}
-  {%     for peer in rsyslog_send_permitted_peers %}
+  {%     for peer in logging_send_permitted_peers %}
   $ActionSendStreamDriverPermittedPeer {{ peer }}
   {%     endfor %}
   {%   endif %}
   {% endif %}
   $ActionSendStreamDriverMode 1
-
-# rsyslog_domain
-#
-# The default DNS domain used to accept remote incoming logs from remote hosts.
-rsyslog_domain: '{{ ansible_domain if ansible_domain else ansible_hostname }}'
-
-# rsyslog_permitted_peers
-#
-# List of hostnames, IP addresses or wildcard DNS domains which will be allowed
-# by the ``rsyslogd`` server to connect and send logs over TLS.
-rsyslog_permitted_peers: ['*.{{ rsyslog_domain }}']
-
-# rsyslog_send_permitted_peers
-#
-# List of hostnames, IP addresses or wildcard DNS domains which will be
-# verified by the ``rsyslogd`` client and will allow to send logs to the remote
-# server over TLS.
-rsyslog_send_permitted_peers: '{{ rsyslog_permitted_peers }}'
 
 # Files and Forwards outputs
 # --------------------------
@@ -145,38 +82,8 @@ rsyslog_output_forwards: []
 # configuration enabled in the role.
 __rsyslog_common_rules:
 
-  - '{{ __rsyslog_conf_global_options }}'
   - '{{ __rsyslog_conf_local_modules }}'
   - '{{ __rsyslog_conf_common_defaults }}'
-
-
-# Default configuration options
-# -----------------------------
-
-# __rsyslog_conf_global_options
-#
-# Some of the global ``rsyslogd`` configuration options. See
-# http://www.rsyslog.com/doc/v8-stable/rainerscript/global.html for more
-# details.
-__rsyslog_conf_global_options:
-
-  - filename: '00-global.conf'
-    comment: 'Global options'
-    options: |-
-      global(
-        defaultNetstreamDriver="{{ rsyslog_default_netstream_driver }}"
-        workDirectory="{{ rsyslog_work_dir }}"
-      {% if rsyslog_default_netstream_driver != "ptcp" %}
-        defaultNetstreamDriverCAFile="{{ rsyslog_pki_path + '/' + rsyslog_pki_realm + '/' + rsyslog_pki_ca }}"
-      {%   if rsyslog_default_driver_authmode != "anon" %}
-        defaultNetstreamDriverCertFile="{{ rsyslog_pki_path + '/' + rsyslog_pki_realm + '/' + rsyslog_pki_crt }}"
-        defaultNetstreamDriverKeyFile="{{ rsyslog_pki_path + '/' + rsyslog_pki_realm + '/' + rsyslog_pki_key }}"
-      {%   endif %}
-      {% endif %}
-      {% if rsyslog_max_message_size is defined %}
-        maxMessageSize="{{ rsyslog_max_message_size }}"
-      {% endif %}
-      )
 
 # __rsyslog_conf_local_modules
 #

--- a/roles/rsyslog/tasks/main.yml
+++ b/roles/rsyslog/tasks/main.yml
@@ -1,7 +1,7 @@
 - name: Install/Update required packages
   package:
     name: "{{ __rsyslog_base_packages }} +
-           {{ __rsyslog_tls_packages if rsyslog_default_netstream_driver != 'ptcp' else [] }} +
+           {{ __rsyslog_tls_packages if __rsyslog_default_netstream_driver != 'ptcp' else [] }} +
            {{ rsyslog_extra_packages | flatten }}"
     state: latest
   when:
@@ -83,6 +83,17 @@
         - logging_inputs | d([])
       notify: restart rsyslogd
 
+    - name: Generate global rule to add to __rsyslog_common_rules
+      vars:
+        __rsyslog_global_rule:
+          - filename: '00-global.conf'
+            comment: 'Global options'
+            options: "{{ lookup('template', 'global.j2') }}"
+      set_fact:
+        __rsyslog_common_rules: "{{ __rsyslog_global_rule + __rsyslog_common_rules }}"
+      when:
+        - __rsyslog_enabled | bool
+
     - name: Generate common rsyslog configuration files in rsyslog.d
       template:
         src: 'rules.conf.j2'
@@ -131,6 +142,20 @@
         mode: '{{ item.mode | d("0644") }}'
       loop: '{{ rsyslog_custom_config_files | flatten }}'
       when: __rsyslog_enabled | bool
+      notify: restart rsyslogd
+
+    - name: Copy local key/cert files to the target if needed
+      vars:
+        __pki_dir: '{{ __rsyslog_default_pki_key_dir if item.type == "key" else __rsyslog_default_pki_cert_dir }}'
+        __pki_file: '{{ item.src | basename }}'
+      copy:
+        src: '{{ item.src }}'
+        dest: '{{ item.dest if item.dest is defined else (__rsyslog_default_pki_path + __pki_dir + __pki_file) }}'
+        mode: '{{ "0400" if item.type == "key" else "0600" }}'
+      loop: '{{ logging_pki_files }}'
+      when:
+        - __rsyslog_enabled | bool
+        - item.src | d("")
       notify: restart rsyslogd
 
     - name: Include input sub-vars

--- a/roles/rsyslog/templates/global.j2
+++ b/roles/rsyslog/templates/global.j2
@@ -1,0 +1,27 @@
+{% set ns = namespace() %}
+{% set ns.ca_cert_path = __rsyslog_default_pki_path + __rsyslog_default_pki_cert_dir + __rsyslog_default_pki_ca_cert_name %}
+{% set ns.cert_path = __rsyslog_default_pki_path + __rsyslog_default_pki_cert_dir + __rsyslog_default_pki_cert_name %}
+{% set ns.key_path = __rsyslog_default_pki_path + __rsyslog_default_pki_key_dir + __rsyslog_default_pki_key_name %}
+{% for file in logging_pki_files %}
+{%   if file.type == 'ca_cert' %}
+{%     set ns.ca_cert_path = file.dest | d(__rsyslog_default_pki_path + __rsyslog_default_pki_cert_dir + file.src | basename) %}
+{%   elif file.type == 'cert' %}
+{%     set ns.cert_path = file.dest | d(__rsyslog_default_pki_path + __rsyslog_default_pki_cert_dir + file.src | basename) %}
+{%   elif file.type == 'key' %}
+{%     set ns.key_path = file.dest | d(__rsyslog_default_pki_path + __rsyslog_default_pki_key_dir + file.src | basename) %}
+{%   endif %}
+{% endfor %}
+global(
+  defaultNetstreamDriver="{{ __rsyslog_default_netstream_driver }}"
+  workDirectory="{{ rsyslog_work_dir }}"
+{% if __rsyslog_default_netstream_driver != "ptcp" %}
+  defaultNetstreamDriverCAFile="{{ ns.ca_cert_path }}"
+{%   if logging_pki_authmode != "anon" %}
+  defaultNetstreamDriverCertFile="{{ ns.cert_path }}"
+  defaultNetstreamDriverKeyFile="{{ ns.key_path }}"
+{%   endif %}
+{% endif %}
+{% if rsyslog_max_message_size is defined %}
+  maxMessageSize="{{ logging_max_message_size }}"
+{% endif %}
+)

--- a/roles/rsyslog/templates/input_remote_module.j2
+++ b/roles/rsyslog/templates/input_remote_module.j2
@@ -24,14 +24,14 @@ module(load="imptcp")
 # Read messages sent over TCP with TLS
 module(
   load="imtcp"
-  streamDriver.name="{{ rsyslog_default_netstream_driver }}"
+  streamDriver.name="{{ __rsyslog_default_netstream_driver }}"
   streamDriver.mode="1"
   streamDriver.authMode="{{ rsyslog_default_driver_authmode }}"
 {%   if rsyslog_default_driver_authmode != "anon" %}
-{%     if rsyslog_permitted_peers is string %}
-    permittedPeer="{{ rsyslog_permitted_peers }}"
+{%     if logging_permitted_peers is string %}
+    permittedPeer="{{ logging_permitted_peers }}"
 {%     else %}
-    permittedPeer=["{{ rsyslog_permitted_peers | join('","') }}"]
+    permittedPeer=["{{ logging_permitted_peers | join('","') }}"]
 {% endif %}
 {%   endif %}
 )

--- a/roles/rsyslog/vars/main.yml
+++ b/roles/rsyslog/vars/main.yml
@@ -78,7 +78,7 @@ rsyslog_weight_map:
   'inputs': '90'
 
 # X.509 certificates related variables
-# Lookup rsyslog netwrok stream driver
+# Lookup rsyslog network stream driver
 __rsyslog_pki_map:
   none: ptcp
   ptcp: ptcp

--- a/roles/rsyslog/vars/main.yml
+++ b/roles/rsyslog/vars/main.yml
@@ -22,6 +22,31 @@ __rsyslog_default_port: '514'
 # The incoming TCP TLS port used for remote logging.
 __rsyslog_default_tls_port: '6514'
 
+# __rsyslog_default_pki_path
+#
+# standard tls path
+__rsyslog_default_pki_path: "/etc/pki/tls/"
+
+# __rsyslog_default_pki_key_dir
+#
+__rsyslog_default_pki_key_dir: "private/"
+
+# __rsyslog_default_pki_cert_dir
+#
+__rsyslog_default_pki_cert_dir: "certs/"
+
+# __rsyslog_default_pki_ca_cert_name
+#
+__rsyslog_default_pki_ca_cert_name: "ca.crt"
+
+# __rsyslog_default_pki_key_name
+#
+__rsyslog_default_pki_key_name: "key.pem"
+
+# __rsyslog_default_pki_cert_name
+#
+__rsyslog_default_pki_cert_name: "cert.pem"
+
 # Rsyslog configuration rules
 # ---------------------------
 
@@ -51,3 +76,12 @@ rsyslog_weight_map:
   'rulesets': '50'
   'input': '90'
   'inputs': '90'
+
+# X.509 certificates related variables
+# Lookup rsyslog netwrok stream driver
+__rsyslog_pki_map:
+  none: ptcp
+  ptcp: ptcp
+  tls: gtls
+  gtls: gtls
+  gnutls: gtls

--- a/roles/rsyslog/vars/outputs/forwards/main.yml
+++ b/roles/rsyslog/vars/outputs/forwards/main.yml
@@ -16,7 +16,7 @@ __rsyslog_conf_forwards_output_tls_rules:
 
   - name: 'output-forwards-tls'
     type: 'output'
-    state: '{{ "present" if rsyslog_default_netstream_driver != "ptcp"
+    state: '{{ "present" if __rsyslog_default_netstream_driver != "ptcp"
                else "absent" }}'
     sections:
       - comment: 'Forward logs over TLS by default'

--- a/tests/tests_forwards_cert.yml
+++ b/tests/tests_forwards_cert.yml
@@ -1,0 +1,89 @@
+- name: Ensure that the role runs from imjournal inputs to the multiple omfwd output with noop configs
+  hosts: all
+  become: true
+  vars:
+    __rsyslog_version: "N/A"
+    __test_forward_conf_s_f: /etc/rsyslog.d/30-output-forwards-forwards-severity_and_facility.conf
+    __test_ca_cert_name: test-ca.crt
+    __test_cert_name: test-cert.pem
+    __test_key_name: test-key.pem
+    __test_ca_cert: /tmp/{{ __test_ca_cert_name }}
+    __test_cert: /tmp/{{ __test_cert_name }}
+    __test_key: /tmp/{{ __test_key_name }}
+
+  tasks:
+    - name: generate test files
+      copy:
+        dest: "{{ item }}"
+        content:
+          This is a fake {{ item }}.
+      delegate_to: localhost
+      loop:
+        - "{{ __test_ca_cert }}"
+        - "{{ __test_cert }}"
+        - "{{ __test_key }}"
+
+    - name: Deploy rsyslog config on the target host
+      vars:
+        logging_purge_confs: true
+        logging_pki: tls
+        logging_pki_files:
+          - type: ca_cert
+            src: "{{ __test_ca_cert }}"
+            dest: "/etc/pki/tls/certs/{{ __test_ca_cert_name }}"
+          - type: cert
+            src: "{{ __test_cert }}"
+          - type: key
+            src: "{{ __test_key }}"
+        logging_outputs:
+          - name: forwards-severity_and_facility
+            type: forwards
+            facility: local1
+            severity: info
+            protocol: tcp
+            target: host.domain
+            port: 1514
+        logging_inputs:
+          - name: basic_input
+            type: basics
+        logging_flows:
+          - name: flows0
+            inputs: [basic_input]
+            outputs: [forwards-severity_and_facility]
+      include_role:
+        name: linux-system-roles.logging
+
+    - include: set_rsyslog_variables.yml
+
+    # notify restart rsyslogd is executed at the end of this test task.
+    # thus we have to force to invoke handlers
+    - name: Force all notified handlers to run at this point, not waiting for normal sync points
+      meta: flush_handlers
+
+    - name: Check rsyslog version
+      assert:
+        that: __rsyslog_version != "N/A" and __rsyslog_version != "0.0.0"
+
+    - name: Check rsyslog.conf size
+      assert:
+        that: rsyslog_conf_stat.stat.size < 1000
+
+    - name: Check file counts in rsyslog.d
+      assert:
+        that: rsyslog_d_file_count.matched >= 6
+
+    # Checking 'error' in stdout from systemctl status is for detecting the case in which rsyslog is running,
+    # but some functionality is disabled due to some error, e.g., error: 'tls.cacert' file couldn't be accessed.
+    - name: Check rsyslog errors
+      command: systemctl status rsyslog
+      register: systemctl_result
+      failed_when: "'error' in systemctl_result.stdout or systemctl_result.rc != 0"
+
+    - name: Grep severity_and_facility
+      command: /bin/grep "\<action.*forwards-severity_and_facility\>" {{ __test_forward_conf_s_f }}
+      register: severity_and_facility
+      changed_when: false
+
+    - name: Check severity_and_facility
+      assert:
+        that: severity_and_facility.stdout is match(" *local1\.info action.name=.forwards-severity_and_facility.* Target=.host.domain. Port=.1514. Protocol=.tcp.*")


### PR DESCRIPTION
- New variables for configuring tls
  - logging_pki - Specifying rsyslog encryption library
                  one of the implementations is allowed none, ptcp, tls, gtls, gnutls
                  Note: none->ptcp, tls,gtls,gnutls->gtls
                  Default to ptcp (== no tls)
                  Note: renaming logging_encryption from the previous PR121.
  - logging_pki_files - list of pki files dict
    logging_pki_files:
      - type: ca_cert | cert | key
        src:  location of the file on the local host;
              if given, the file is deployed to dest value path.
        dest: path to be deployed on the target host;
              if given, the path is set to the config file.
              Default to /etc/pki/tls/certs/ca.crt for ca_cert
                         /etc/pki/tls/certs/cert.pem for cert
                         /etc/pki/tls/private/key.pem for key
    Note: the paths are adjusted to the certificate system.

- Variables renamed from starting with rsyslog_ to logging_
  - logging_pki_authmode - Specify the default network driver authentication mode.
    `x509/name` or `anon` are available: Default to "x509/name".
  - logging_domain - The default DNS domain used to accept remote incoming logs from
    remote hosts. Default to {{ ansible_domain if ansible_domain else ansible_hostname }}
  - logging_permitted_peers - List of hostnames, IP addresses or wildcard DNS domains
    which will be allowed by the `logging` server to connect and send logs over TLS.
    Default to ['*.{{ logging_domain }}']
  - logging_send_permitted_peers - List of hostnames, IP addresses or wildcard DNS
    domains which will be verified by the `logging` client and will allow to send logs
    to the remote server over TLS. Default to '{{ logging_permitted_peers }}'.

- Implementation details
  - Moving __rsyslog_conf_global_options from the rsyslog defaults main.yml to global.j2.
  - Introduced __rsyslog_pki_map to specify gnutls or ptcp.

- Test playbook
  - tests/tests_forwards_cert.yml

- Doc - adding the new and updated variables to roles/rsyslog/README.md