### PR TITLE
RHELPLAN-32352 - Add performance tuning parameters

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,6 +20,24 @@ logging_purge_confs: false
 # Variable to specify the directory to put the local output files to store logs.
 logging_system_log_dir: /var/log
 
+# Performance optimization parameters for the server.
+# Input thread count listening on the udp port.
+logging_udp_threads: 1
+
+# Input thread count listening on the tcp port.
+logging_tcp_threads: 1
+
+# Every value times, get the system time. Effective for udp.
+logging_udp_system_time_requery: 2
+
+# Specifies the maximum number of udp messages.
+logging_udp_batch_size: 32
+
+# Queue configuration for the files outputs for the server
+logging_server_queue_type: LinkedList
+logging_server_queue_size: 50000
+logging_server_threads: "{{ logging_udp_threads | int + logging_tcp_threads | int }}"
+
 # Specifying rsyslog encryption library
 # one of the implementations is allowed none, ptcp, tls, gtls, gnutls
 # Note: none->ptcp, tls,gtls,gnutls->gtls
@@ -48,7 +66,7 @@ logging_pki_files: []
 
 # logging_pki_authmode
 #
-# Specify the default network driver authetication mode.
+# Specify the default network driver authentication mode.
 # `x509/name` or `anon` are available:
 logging_pki_authmode: "x509/name"
 

--- a/design_docs/rsyslog_inputs_outputs_flows.md
+++ b/design_docs/rsyslog_inputs_outputs_flows.md
@@ -187,16 +187,16 @@ logging_outputs:
       - name: basic-input0
         type: basics
         journal_persist_state_interval: 1000
-        journal_ratelimit_interval: 10
-        journal_ratelimit_burst: 100000
+        ratelimit_interval: 10
+        ratelimit_burst: 100000
   - name: file-output
     type: files
     logging_inputs:
       - name: basic-input1
         type: basics
-        journal_persist_state_interval: 3000
-        journal_ratelimit_interval: 30
-        journal_ratelimit_burst: 300000
+        persist_state_interval: 3000
+        ratelimit_interval: 30
+        ratelimit_burst: 300000
 ```
 
 ### logging_outputs, logging_inputs and logging_flows

--- a/roles/rsyslog/templates/input_basics.j2
+++ b/roles/rsyslog/templates/input_basics.j2
@@ -3,6 +3,8 @@ module(load="imklog" permitnonkernelfacility="on")
 {% endif %}
 {% if item.use_imuxsock | d(false) | bool %}
 module(load="imuxsock"    # provides support for local system logging (e.g. via logger command)
+       SysSock.RateLimit.Burst="{{ input.ratelimit_burst | d(200) }}"
+       SysSock.RateLimit.Interval="{{ input.ratelimit_burst | d(0) }}"
        SysSock.Use="on")  # Turn on message reception via local log socket.
 input(name="basics_imuxsock" type="imuxsock" socket="/dev/log")
 {% else %}
@@ -10,8 +12,8 @@ module(load="imuxsock"    # provides support for local system logging (e.g. via 
        SysSock.Use="off") # Turn off message reception via local log socket.
 module(load="imjournal"
        StateFile="{{ rsyslog_work_dir }}/imjournal.state"
-       RateLimit.Burst="{{ input.journal_ratelimit_burst | d(20000) }}"
-       RateLimit.Interval="{{ input.journal_ratelimit_interval | d(600) }}"
+       RateLimit.Burst="{{ input.ratelimit_burst | d(20000) }}"
+       RateLimit.Interval="{{ input.ratelimit_interval | d(600) }}"
        PersistStateInterval="{{ input.journal_persist_state_interval | d(10) }}")
 {% endif %}
 {{ lookup('template', 'input_template.j2') }}

--- a/roles/rsyslog/templates/input_remote_module.j2
+++ b/roles/rsyslog/templates/input_remote_module.j2
@@ -14,16 +14,19 @@
 {% endfor %}
 {% if ns2.use_udp %}
 # Read messages sent over plain TCP
-module(load="imudp")
+module(load="imudp" threads="{{ logging_udp_threads }}"
+       TimeRequery="{{ logging_udp_system_time_requery }}"
+       BatchSize="{{ logging_udp_batch_size }}")
 {% endif %}
 {% if ns1.use_tcp %}
 # Read messages sent over UDP
-module(load="imptcp")
+module(load="imptcp" threads="{{ logging_tcp_threads }}")
 {% endif %}
 {% if ns0.use_tls %}
 # Read messages sent over TCP with TLS
 module(
   load="imtcp"
+  threads="{{ logging_tcp_threads }}"
   streamDriver.name="{{ __rsyslog_default_netstream_driver }}"
   streamDriver.mode="1"
   streamDriver.authMode="{{ rsyslog_default_driver_authmode }}"

--- a/roles/rsyslog/templates/output_remote_files.j2
+++ b/roles/rsyslog/templates/output_remote_files.j2
@@ -12,12 +12,15 @@ template(
   type="string"
   string="{{ __remote_log_path }}"
 )
-ruleset(name="{{ item.name }}") {
+ruleset(name="{{ item.name }}"
+        queue.type="{{ logging_server_queue_type }}"
+        queue.size="{{ logging_server_queue_size }}"
+        queue.workerThreads="{{ logging_server_threads }}") {
     # Store remote logs in separate logfiles
 {%   if item.exclude | d([]) %}
-    {{ item.facility | d('*') }}.{{ item.severity | d('*') }};{{ item.exclude | join(';') }} action(name="{{ item.name }}" type="omfile" DynaFile="{{ item.name }}_template")
+    {{ item.facility | d('*') }}.{{ item.severity | d('*') }};{{ item.exclude | join(';') }} action(name="{{ item.name }}" type="omfile" DynaFile="{{ item.name }}_template" DynaFileCacheSize="{{ item.client_count | d(10) }}" ioBufferSize="{{ item.io_buffer_size | d('65536') }}" asyncWriting="{{ 'on' if item.async_writing | d('off') | bool else 'off' }}")
 {%   else %}
-    {{ item.facility | d('*') }}.{{ item.severity | d('*') }} action(name="{{ item.name }}" type="omfile" DynaFile="{{ item.name }}_template")
+    {{ item.facility | d('*') }}.{{ item.severity | d('*') }} action(name="{{ item.name }}" type="omfile" DynaFile="{{ item.name }}_template" DynaFileCacheSize="{{ item.client_count | d(10) }}" ioBufferSize="{{ item.io_buffer_size | d('65536') }}" asyncWriting="{{ 'on' if item.async_writing | d('off') | bool else 'off' }}")
 {%   endif %}
 }
 {% else %}

--- a/tests/tests_combination.yml
+++ b/tests/tests_combination.yml
@@ -76,7 +76,7 @@
         logging_inputs:
           - name: basic_input
             type: basics
-            journal_ratelimit_burst: 33333
+            ratelimit_burst: 33333
           - name: "{{ __test_tag }}"
             type: files
             input_log_path: "{{ __test_inputfiles_dir }}/*.log"

--- a/tests/tests_combination2.yml
+++ b/tests/tests_combination2.yml
@@ -82,7 +82,7 @@
         logging_inputs:
           - name: basic_input
             type: basics
-            journal_ratelimit_burst: 33333
+            ratelimit_burst: 33333
           - name: "{{ __test_tag }}"
             type: files
             input_log_path: "{{ __test_inputfiles_dir }}/*.log"

--- a/tests/tests_combination_absent.yml
+++ b/tests/tests_combination_absent.yml
@@ -73,7 +73,7 @@
         logging_inputs:
           - name: basic_input
             type: basics
-            rsyslog_imjournal_ratelimit_burst: 33333
+            ratelimit_burst: 33333
           - name: "{{ __test_tag }}"
             type: files
             input_log_path: "{{ __test_inputfiles_dir }}/*.log"
@@ -155,7 +155,7 @@
         logging_inputs:
           - name: basic_input
             type: basics
-            rsyslog_imjournal_ratelimit_burst: 33333
+            ratelimit_burst: 33333
           - name: "{{ __test_tag }}"
             type: files
             input_log_path: "{{ __test_inputfiles_dir }}/*.log"

--- a/tests/tests_remote_remote.yml
+++ b/tests/tests_remote_remote.yml
@@ -26,6 +26,9 @@
     - name: deploy config receiving from the remote hosts and writing them to the local files
       vars:
         logging_purge_confs: true
+        logging_tcp_threads: 2
+        logging_udp_threads: 2
+        logging_server_queue_type: FixedArray
         logging_outputs:
           - name: remote_files_output0
             type: remote_files
@@ -34,6 +37,9 @@
             severity: info
             exclude:
               - authpriv.none
+            client_count: 20
+            io_buffer_size: 8192
+            async_writing: on
           - name: remote_files_output1
             type: remote_files
             remote_sub_path: others/%HOSTNAME%/%PROGRAMNAME:::secpath-replace%.log


### PR DESCRIPTION
Introducing the following parameters.
logging_inputs
- basics
  - Share parameters ratelimit_burst, ratelimit_interval between imjournal and imuxsock in the basics input.
- global variables used by the remote inputs
  - logging_tcp_threads: Input thread count listening on the tcp port. Default to 1.
  - logging_udp_threads: Input thread count listening on the udp port. Default to 1.
  - logging_udp_system_time_interval: Interval to get the system time. Effective for udp. Default to 2.
  - logging_udp_batch_size: Specifies the maximum number of udp messages. Default to 32.

logging_outputs
- remote_files
  - `async_writing`: If set to on, the files are written asynchronously. Default to off.
  - `client_count`: Count of client logging system supported this rsyslog server. Default to 10.
  - `io_buffer_size`: Buffer size used to write output data.
- global variables used to configure queue in the remote_files outputs.
  - logging_server_queue_type`: Type of queue. FixedArray is available. Default to LinkedList.
  - logging_server_queue_size`: Size of queue. Default to 50000.
  - logging_server_threads`: Number of worker threads. Default to logging_tcp_threads + logging_udp_threads.