### PR TITLE
Avoiding 'on' and 'off' for the boolean values.

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ This is a schematic logging configuration to show log messages from input_nameA 
   - `server_port`: Port number Elasticsearch is listening to. Default to `9200`.
   - `index_prefix`: Elasticsearch index prefix the particular log will be indexed to. **Required**.
   - `input_type`: Specifying the input type. Currently only type `ovirt` is supported. Default to `ovirt`.
-  - `retryfailures`: Specifying whether retries or not in case of failure. `on` or `off`.  Default to `on`.
+  - `retryfailures`: Specifying whether retries or not in case of failure. Allowed value is `true` or `false`.  Default to `true`.
   - `use_cert`: If true, key/certificates are used to access Elasticsearch. Triplets {`ca_cert`, `cert`, `key`} and/or {`ca_cert_src`, `cert_src`, `key_src`} should be configured. Default to `true`.
   - `ca_cert`: Path to CA cert for Elasticsearch.  Default to `/etc/rsyslog.d/es-ca.crt`
   - `cert`: Path to cert to connect to Elasticsearch.  Default to `/etc/rsyslog.d/es-cert.pem`.
@@ -170,7 +170,7 @@ This is a schematic logging configuration to show log messages from input_nameA 
   - `facility`: Facility; default to `*`.
   - `severity`: Severity; default to `*`.
   - `exclude`: Exclude list; default to none.
-  - `async_writing`: If set to `on`, the files are written asynchronously. Default to `off`.
+  - `async_writing`: If set to `true`, the files are written asynchronously. Allowed value is `true` or `false`. Default to `false`.
   - `client_count`: Count of client logging system supported this rsyslog server. Default to `10`.
   - `io_buffer_size`: Buffer size used to write output data. Default to `65536` bytes.
   - `remote_log_path`: Full path to store the filtered logs.

--- a/design_docs/rsyslog_ovirt_support.md
+++ b/design_docs/rsyslog_ovirt_support.md
@@ -21,7 +21,7 @@ logging_outputs:
     server_port: 9200
     index_prefix: project.
     input_type: ovirt
-    retryfailures: off
+    retryfailures: false
     ca_cert: "/etc/rsyslog.d/es-ca.crt"
     cert: "/etc/rsyslog.d/es-cert.pem"
     key: "/etc/rsyslog.d/es-key.pem"
@@ -103,7 +103,7 @@ logging_outputs:
     server_port: 9200
     index_prefix: project.
     input_type: ovirt
-    retryfailures: off
+    retryfailures: false
     ca_cert: "/etc/rsyslog.d/es-ca.crt"
     cert: "/etc/rsyslog.d/es-cert.pem"
     key: "/etc/rsyslog.d/es-key.pem"

--- a/roles/rsyslog/templates/output_remote_files.j2
+++ b/roles/rsyslog/templates/output_remote_files.j2
@@ -18,9 +18,9 @@ ruleset(name="{{ item.name }}"
         queue.workerThreads="{{ logging_server_threads }}") {
     # Store remote logs in separate logfiles
 {%   if item.exclude | d([]) %}
-    {{ item.facility | d('*') }}.{{ item.severity | d('*') }};{{ item.exclude | join(';') }} action(name="{{ item.name }}" type="omfile" DynaFile="{{ item.name }}_template" DynaFileCacheSize="{{ item.client_count | d(10) }}" ioBufferSize="{{ item.io_buffer_size | d('65536') }}" asyncWriting="{{ 'on' if item.async_writing | d('off') | bool else 'off' }}")
+    {{ item.facility | d('*') }}.{{ item.severity | d('*') }};{{ item.exclude | join(';') }} action(name="{{ item.name }}" type="omfile" DynaFile="{{ item.name }}_template" DynaFileCacheSize="{{ item.client_count | d(10) }}" ioBufferSize="{{ item.io_buffer_size | d('65536') }}" asyncWriting="{{ 'on' if item.async_writing | d(false) | bool else 'off' }}")
 {%   else %}
-    {{ item.facility | d('*') }}.{{ item.severity | d('*') }} action(name="{{ item.name }}" type="omfile" DynaFile="{{ item.name }}_template" DynaFileCacheSize="{{ item.client_count | d(10) }}" ioBufferSize="{{ item.io_buffer_size | d('65536') }}" asyncWriting="{{ 'on' if item.async_writing | d('off') | bool else 'off' }}")
+    {{ item.facility | d('*') }}.{{ item.severity | d('*') }} action(name="{{ item.name }}" type="omfile" DynaFile="{{ item.name }}_template" DynaFileCacheSize="{{ item.client_count | d(10) }}" ioBufferSize="{{ item.io_buffer_size | d('65536') }}" asyncWriting="{{ 'on' if item.async_writing | d(false) | bool else 'off' }}")
 {%   endif %}
 }
 {% else %}

--- a/tests/tests_files_elasticsearch.yml
+++ b/tests/tests_files_elasticsearch.yml
@@ -37,7 +37,7 @@
             server_port: 9200
             index_prefix: project.
             input_type: ovirt
-            retryfailures: off
+            retryfailures: false
             use_cert: false
           - name: elasticsearch_output_ops
             type: elasticsearch
@@ -45,7 +45,7 @@
             server_port: 9200
             index_prefix: .operations.
             input_type: viaq
-            retryfailures: off
+            retryfailures: false
             use_cert: false
         logging_inputs:
           - name: files_input

--- a/tests/tests_files_elasticsearch_certs_incomplete.yml
+++ b/tests/tests_files_elasticsearch_certs_incomplete.yml
@@ -57,7 +57,7 @@
                 server_port: 9200
                 index_prefix: project.
                 input_type: ovirt
-                retryfailures: off
+                retryfailures: false
                 ca_cert: /etc/rsyslog.d/ca_cert.crt
                 key: /etc/rsyslog.d/key.pem
                 cert_src: "{{ __test_cert }}"

--- a/tests/tests_files_elasticsearch_use_cert_false_with_keys.yml
+++ b/tests/tests_files_elasticsearch_use_cert_false_with_keys.yml
@@ -51,7 +51,7 @@
                 server_port: 9200
                 index_prefix: project.
                 input_type: ovirt
-                retryfailures: off
+                retryfailures: false
                 use_cert: false
                 ca_cert: /etc/rsyslog.d/ca_cert.crt
                 cert: /etc/rsyslog.d/cert.pem

--- a/tests/tests_files_elasticsearch_use_local_cert.yml
+++ b/tests/tests_files_elasticsearch_use_local_cert.yml
@@ -63,7 +63,7 @@
             server_port: 9200
             index_prefix: project.
             input_type: ovirt
-            retryfailures: off
+            retryfailures: false
             ca_cert_src: "{{ __test_ca_cert }}"
             cert_src: "{{ __test_cert }}"
             key_src: "{{ __test_key }}"

--- a/tests/tests_files_elasticsearch_use_local_cert_all.yml
+++ b/tests/tests_files_elasticsearch_use_local_cert_all.yml
@@ -69,7 +69,7 @@
             server_port: 9200
             index_prefix: project.
             input_type: ovirt
-            retryfailures: off
+            retryfailures: false
             ca_cert_src: "{{ __test_ca_cert }}"
             cert_src: "{{ __test_cert }}"
             key_src: "{{ __test_key }}"

--- a/tests/tests_files_elasticsearch_use_local_cert_nokeys.yml
+++ b/tests/tests_files_elasticsearch_use_local_cert_nokeys.yml
@@ -38,7 +38,7 @@
                 server_port: 9200
                 index_prefix: project.
                 input_type: ovirt
-                retryfailures: off
+                retryfailures: false
                 use_cert: true
             logging_inputs:
               - name: files_input

--- a/tests/tests_ovirt_elasticsearch.yml
+++ b/tests/tests_ovirt_elasticsearch.yml
@@ -56,7 +56,7 @@
             server_port: 9200
             index_prefix: project.
             input_type: ovirt
-            retryfailures: off
+            retryfailures: false
             ca_cert: "/etc/rsyslog.d/es-ca.crt"
             cert: "/etc/rsyslog.d/es-cert.pem"
             key: "/etc/rsyslog.d/es-key.pem"
@@ -66,7 +66,7 @@
             server_port: 9200
             index_prefix: .operations.
             input_type: ovirt
-            retryfailures: off
+            retryfailures: false
             ca_cert: "/etc/rsyslog.d/es-ca.crt"
             cert: "/etc/rsyslog.d/es-cert.pem"
             key: "/etc/rsyslog.d/es-key.pem"

--- a/tests/tests_ovirt_elasticsearch_params.yml
+++ b/tests/tests_ovirt_elasticsearch_params.yml
@@ -56,7 +56,7 @@
             server_port: 9200
             index_prefix: project.
             input_type: ovirt
-            retryfailures: off
+            retryfailures: false
             ca_cert: "/etc/rsyslog.d/es-ca.crt"
             cert: "/etc/rsyslog.d/es-cert.pem"
             key: "/etc/rsyslog.d/es-key.pem"
@@ -66,7 +66,7 @@
             server_port: 9200
             index_prefix: .operations.
             input_type: ovirt
-            retryfailures: off
+            retryfailures: false
             ca_cert: "/etc/rsyslog.d/es-ca.crt"
             cert: "/etc/rsyslog.d/es-cert.pem"
             key: "/etc/rsyslog.d/es-key.pem"


### PR DESCRIPTION
Rsyslog parameter retryfailures (elasticsearch output) async_writing (remote_files output)
expect on | off. The logging role inherited on | off for the allowed values for the params.
But on | off are not the valid bool in ansible. Thus, replacing the pair with true | false
in docs and tests.