### PR TITLE
Fixing performance issues.

### DIFF
--- a/roles/rsyslog/tasks/deploy.yml
+++ b/roles/rsyslog/tasks/deploy.yml
@@ -6,6 +6,7 @@
     name: "{{ __rsyslog_packages }}"
     state: latest
   when:
+    - __rsyslog_packages | length > 0
     - not rsyslog_in_image | bool
   notify: restart rsyslogd
 

--- a/roles/rsyslog/tasks/inputs/basics/main.yml
+++ b/roles/rsyslog/tasks/inputs/basics/main.yml
@@ -9,8 +9,6 @@
 
 - name: Create basics input configuration files in /etc/rsyslog.d
   vars:
-    __rsyslog_input_name: "{{ item.name }}"
-    __rsyslog_input_type: "{{ item.type }}"
     __rsyslog_packages: []
     __rsyslog_rules:
       - name: "input-basics-{{ item.name }}"

--- a/roles/rsyslog/tasks/inputs/files/main.yml
+++ b/roles/rsyslog/tasks/inputs/files/main.yml
@@ -9,8 +9,6 @@
 
 - name: Create files input configuration files in /etc/rsyslog.d
   vars:
-    __rsyslog_input_name: "{{ item.name }}"
-    __rsyslog_input_type: "{{ item.type }}"
     __rsyslog_packages: []
     __rsyslog_rules:
       - name: "input-files-{{ item.name }}"

--- a/roles/rsyslog/tasks/inputs/remote/main.yml
+++ b/roles/rsyslog/tasks/inputs/remote/main.yml
@@ -13,8 +13,6 @@
 
 - name: Create basics input configuration files in /etc/rsyslog.d
   vars:
-    __rsyslog_input_name: "{{ item.name }}"
-    __rsyslog_input_type: "{{ item.type }}"
     __rsyslog_packages: []
     __rsyslog_rules:
       - name: "input-remote-{{ item.name }}"

--- a/roles/rsyslog/templates/input_template.j2
+++ b/roles/rsyslog/templates/input_template.j2
@@ -1,13 +1,9 @@
-{% set rsyslog_flows = logging_flows | d([ {"name": "default_flow", "inputs": [ __rsyslog_input_name ], "outputs": ["default_files"]} ], true) %}
-{% set indict = {} %}
-{% for input in logging_inputs %}
-{%   set _ = indict.__setitem__(input.name, input) %}
-{% endfor %}
+{% set rsyslog_flows = logging_flows | d([ {"name": "default_flow", "inputs": [ item.name ], "outputs": ["default_files"]} ], true) %}
 {% set outdict = {} %}
 {% for flow in rsyslog_flows %}
-{%   if flow.inputs | intersect([ __rsyslog_input_name ]) %}
+{%   if flow.inputs | intersect([ item.name ]) %}
 {%     for oname in flow.outputs %}
-{%       set _ = outdict.__setitem__(oname, outdict.get(oname,[])|union([ __rsyslog_input_name ])) %}
+{%       set _ = outdict.__setitem__(oname, outdict.get(oname,[])|union([ item.name ])) %}
 {%     endfor %}
 {%   endif %}
 {% endfor %}
@@ -15,17 +11,16 @@
 {%   if outdict[output.name] | d(false) %}
 if
 {%     for inputname in outdict[output.name] %}
-{%       if inputname == __rsyslog_input_name %}
+{%       if inputname == item.name %}
 {%         if not loop.first %}
   or
 {%         endif %}
-{%         set input = indict[inputname] %}
-{%         if input.type == "basics" %}
+{%         if item.type == "basics" %}
   ($inputname == "imjournal" or $inputname == "imuxsock")
-{%         elif input.type == "remote" %}
-  ($inputname == "{{ input.name }}" )
-{%         elif input.type == __rsyslog_input_type %}
-  ($syslogtag == "{{ input.name }}")
+{%         elif item.type == "remote" %}
+  ($inputname == "{{ item.name }}" )
+{%         else %}
+  ($syslogtag == "{{ item.name }}")
 {%         endif %}
 {%       endif %}
 {%     endfor %}


### PR DESCRIPTION
- Avoid calling the package module with empty list.
- Eliminating unnecessary loop in the input template.

These changes makes the duration of the typical test (tests_basics_files2) shorter by ~25%.
before
```
real	5m0.877s
user	0m58.480s
sys	0m10.091s
```
after
```
real	3m42.993s
user	0m46.090s
sys	0m8.019s
```