### PR TITLE
RHELPLAN-45641 - All system roles should use consistent parameter/key names for TLS parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,13 +132,13 @@ This is a schematic logging configuration to show log messages from input_nameA 
   - `index_prefix`: Elasticsearch index prefix the particular log will be indexed to. **Required**.
   - `input_type`: Specifying the input type. Currently only type `ovirt` is supported. Default to `ovirt`.
   - `retryfailures`: Specifying whether retries or not in case of failure. Allowed value is `true` or `false`.  Default to `true`.
-  - `use_cert`: If true, key/certificates are used to access Elasticsearch. Triplets {`ca_cert`, `cert`, `key`} and/or {`ca_cert_src`, `cert_src`, `key_src`} should be configured. Default to `true`.
+  - `use_cert`: If true, key/certificates are used to access Elasticsearch. Triplets {`ca_cert`, `cert`, `private_key`} and/or {`ca_cert_src`, `cert_src`, `private_key_src`} should be configured. Default to `true`.
   - `ca_cert`: Path to CA cert for Elasticsearch.  Default to `/etc/rsyslog.d/es-ca.crt`
   - `cert`: Path to cert to connect to Elasticsearch.  Default to `/etc/rsyslog.d/es-cert.pem`.
-  - `key`: Path to key to connect to Elasticsearch.  Default to `/etc/rsyslog.d/es-key.pem`.
+  - `private_key`: Path to key to connect to Elasticsearch.  Default to `/etc/rsyslog.d/es-key.pem`.
   - `ca_cert_src`: Local CA cert file path which is copied to the target host. If `ca_cert` is specified, it is copied to the location. Otherwise, to logging_config_dir.
   - `cert_src`: Local cert file path which is copied to the target host. If `cert` is specified, it is copied to the location. Otherwise, to logging_config_dir.
-  - `key_src`: Local key file path which is copied to the target host. If `key` is specified, it is copied to the location. Otherwise, to logging_config_dir.
+  - `private_key_src`: Local key file path which is copied to the target host. If `private_key` is specified, it is copied to the location. Otherwise, to logging_config_dir.
 
 - `files` type - `files` output supports storing logs in the local files usually in /var/log.<br>
   **available options**
@@ -440,7 +440,7 @@ The following playbook generates the same logging configuration files.
         input_type: ovirt
         ca_cert_src: /local/path/to/ca_cert
         cert_src: /local/path/to/cert
-        key_src: /local/path/to/key
+        private_key_src: /local/path/to/key
     logging_flows:
       - name: flow0
         inputs: [files_input]

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -55,13 +55,21 @@ logging_mark_interval: 3600
 logging_max_message_size: 8192
 
 # list of pki files dict
+# either of {ca_cert_src,cert_src,private_key_src} or {ca_cert,cert,private_key}
+# or both sets should be configured if logging_pki is other than ptcp or none.
 # logging_pki_files:
-#   - type: ca_cert | cert | key
-#     src:  location of the file on the local host; if given, the file is deployed to dest value path.
-#     dest: path to be deployed on the target host; if given, the path is set to the config file.
-#           Default to /etc/pki/tls/certs/ca.crt for ca_cert
-#                      /etc/pki/tls/certs/cert.pem for cert
-#                      /etc/pki/tls/private/key.pem for key
+#   - ca_cert_src:     location of the ca_cert on the control host.
+#                      If given, it's copied to the managed host.
+#     cert_src:        location of the cert on the control host.
+#                      If given, it's copied to the managed host.
+#     private_key_src: location of the key on the control host.
+#                      If given, it's copied to the managed host.
+#     ca_cert:     path to be deployed on the managed host; the path is also used in the rsyslog config.
+#                  default to /etc/pki/tls/certs/<ca_cert_src basename>
+#     cert:        ditto
+#                  default to /etc/pki/tls/certs/<cert_src basename>
+#     private_key: ditto
+#                  default to /etc/pki/tls/private/<private_key_src basename>
 logging_pki_files: []
 
 # logging_pki_authmode

--- a/roles/rsyslog/tasks/main.yml
+++ b/roles/rsyslog/tasks/main.yml
@@ -149,7 +149,7 @@
     # How to set rsyslog_custom_config_files:
     # rsyslog_custom_config_files: [ '/path/to/custom0.conf', '/path/to/custom1.conf' ]
     # The specified custom config files are copied to /etc/rsyslog.d.
-    # If the array containse non-existing file, the deployment stops there with an error.
+    # If the array contains non-existing file, the deployment stops there with an error.
     - name: Copy custom config files if they are specified in rsyslog_custom_config_files variable array.
       copy:
         src: '{{ item }}'
@@ -161,18 +161,78 @@
       when: __rsyslog_enabled | bool
       notify: restart rsyslogd
 
-    - name: Copy local key/cert files to the target if needed
+    # Check if logging_pki is defined and
+    #          logging_pki_authmode is not anon
+    #          logging_pki_files.{ca_cert_src,cert_src,private_key_src} and/or
+    #          logging_pki_files.{ca_cert,cert,private_key}
+    #          are defined.
+    # Otherwise it fails.
+    - name: Check logging_pki, logging_pki_authmode, and logging_pki_files
+      fail:
+        msg: "Error: you specified logging_pki other than none or ptcp and logging_pki_authmode other than anon; you must specify all 3 of logging_pki_files ca_cert_src, cert_src, private_key_src, and/or all 3 of ca_cert, cert, private_key in the playbook var section."
+      when:
+        - __rsyslog_pki_map[logging_pki] | d("ptcp") != "ptcp"
+        - logging_pki_authmode != "anon"
+        - not ((logging_pki_files.0.ca_cert_src | d() and
+                logging_pki_files.0.cert_src | d() and
+                logging_pki_files.0.private_key_src | d()) or
+               (logging_pki_files.0.ca_cert | d() and
+                logging_pki_files.0.cert | d() and
+                logging_pki_files.0.private_key | d()))
+
+    # Check if logging_pki is defined and
+    #          logging_pki_authmode is anon
+    #          logging_pki_files.ca_cert_src and/or
+    #          logging_pki_files.ca_cert
+    #          are defined.
+    # Otherwise it fails.
+    - name: Check logging_pki, logging_pki_authmode, and logging_pki_files 2
+      fail:
+        msg: "Error: you specified logging_pki other than none or ptcp and logging_pki_authmode anon; you must specify logging_pki_files ca_cert_src and/or ca_cert in the playbook var section."
+      when:
+        - __rsyslog_pki_map[logging_pki] | d("ptcp") != "ptcp"
+        - logging_pki_authmode == "anon"
+        - not (logging_pki_files.0.ca_cert_src | d() or logging_pki_files.0.ca_cert | d())
+
+    - name: Copy local ca_cert file to the target if needed
       vars:
-        __pki_dir: '{{ __rsyslog_default_pki_key_dir if item.type == "key" else __rsyslog_default_pki_cert_dir }}'
-        __pki_file: '{{ item.src | basename }}'
+        __pki_file: '{{ logging_pki_files.0.ca_cert_src | basename }}'
       copy:
-        src: '{{ item.src }}'
-        dest: '{{ item.dest if item.dest is defined else (__rsyslog_default_pki_path + __pki_dir + __pki_file) }}'
-        mode: '{{ "0400" if item.type == "key" else "0600" }}'
-      loop: '{{ logging_pki_files }}'
+        src: '{{ logging_pki_files.0.ca_cert_src }}'
+        dest: '{{ logging_pki_files.0.ca_cert if logging_pki_files.0.ca_cert is defined else (__rsyslog_default_pki_path + __rsyslog_default_pki_cert_dir + __pki_file) }}'
+        mode: "0600"
       when:
         - __rsyslog_enabled | bool
-        - item.src | d("")
+        - __rsyslog_pki_map[logging_pki] | d("ptcp") != "ptcp"
+        - logging_pki_files.0.cert_src | d("")
+      notify: restart rsyslogd
+
+    - name: Copy local cert file to the target if needed
+      vars:
+        __pki_file: '{{ logging_pki_files.0.cert_src | basename }}'
+      copy:
+        src: '{{ logging_pki_files.0.cert_src }}'
+        dest: '{{ logging_pki_files.0.cert if logging_pki_files.0.cert is defined else (__rsyslog_default_pki_path + __rsyslog_default_pki_cert_dir + __pki_file) }}'
+        mode: "0600"
+      when:
+        - __rsyslog_enabled | bool
+        - __rsyslog_pki_map[logging_pki] | d("ptcp") != "ptcp"
+        - logging_pki_authmode != "anon"
+        - logging_pki_files.0.cert_src | d("")
+      notify: restart rsyslogd
+
+    - name: Copy local key file to the target if needed
+      vars:
+        __pki_file: '{{ logging_pki_files.0.private_key_src | basename }}'
+      copy:
+        src: '{{ logging_pki_files.0.private_key_src }}'
+        dest: '{{ logging_pki_files.0.private_key if logging_pki_files.0.private_key is defined else (__rsyslog_default_pki_path + __rsyslog_default_pki_key_dir + __pki_file) }}'
+        mode: "0400"
+      when:
+        - __rsyslog_enabled | bool
+        - __rsyslog_pki_map[logging_pki] | d("ptcp") != "ptcp"
+        - logging_pki_authmode != "anon"
+        - logging_pki_files.0.private_key_src | d("")
       notify: restart rsyslogd
 
     - name: Include input sub-vars

--- a/roles/rsyslog/tasks/outputs/elasticsearch/main.yml
+++ b/roles/rsyslog/tasks/outputs/elasticsearch/main.yml
@@ -19,21 +19,21 @@
 
     - name: Copy local Elasticsearch keys to /etc/rsyslog.d directory in Rsyslog
       copy:
-        src: '{{ item.key_src }}'
-        dest: '{{ item.key | d(__rsyslog_config_dir) }}'
+        src: '{{ item.private_key_src }}'
+        dest: '{{ item.private_key | d(__rsyslog_config_dir) }}'
       with_items:
         - '{{ rsyslog_output_elasticsearch }}'
-      when: item.key_src | d()
+      when: item.private_key_src | d()
 
     - name: Check certs - use_cert is true, but triplets are not given
       fail:
-        msg: "Error: you specified use_cert: true; you must specify all 3 of ca_cert, cert, key, or all 3 of ca_cert_src, cert_src, key_src, or set use_cert: false in the elasticsearch output named {{ item.name }}"
+        msg: "Error: you specified use_cert: true; you must specify all 3 of ca_cert, cert, private_key, or all 3 of ca_cert_src, cert_src, private_key_src, or set use_cert: false in the elasticsearch output named {{ item.name }}"
       with_items:
         - '{{ rsyslog_output_elasticsearch }}'
       when:
         - item.use_cert | d(true)
-        - not ((item.ca_cert | d() and item.cert | d() and item.key | d()) or
-               (item.ca_cert_src | d() and item.cert_src | d() and item.key_src | d()))
+        - not ((item.ca_cert | d() and item.cert | d() and item.private_key | d()) or
+               (item.ca_cert_src | d() and item.cert_src | d() and item.private_key_src | d()))
 
     - name: Update ca_cert path to /etc/rsyslog.d directory in Rsyslog
       set_fact:
@@ -42,11 +42,11 @@
           {{ [ item |
                combine( { 'ca_cert': item.ca_cert | d(__rsyslog_config_dir + '/' + item.ca_cert_src | basename),
                           'cert': item.cert | d(__rsyslog_config_dir + '/' + item.cert_src | basename),
-                          'key': item.key | d(__rsyslog_config_dir + '/' + item.key_src | basename) } )
+                          'private_key': item.private_key | d(__rsyslog_config_dir + '/' + item.private_key_src | basename) } )
           ] }}
       with_items:
         - '{{ rsyslog_output_elasticsearch }}'
-      when: item.ca_cert_src | d() or item.cert_src | d() or item.key_src | d()
+      when: item.ca_cert_src | d() or item.cert_src | d() or item.private_key_src | d()
 
     - name: Check certs - key/certs data are provided, but use_cert is false
       fail:
@@ -55,8 +55,8 @@
         - '{{ rsyslog_output_elasticsearch }}'
       when:
         - not (item.use_cert | d(true))
-        - item.ca_cert | d() or item.cert | d() or item.key | d()
-        - item.ca_cert_src | d() or item.cert_src | d() or item.key_src | d()
+        - item.ca_cert | d() or item.cert | d() or item.private_key | d()
+        - item.ca_cert_src | d() or item.cert_src | d() or item.private_key_src | d()
 
     - name: Set updated rsyslog_output_elasticsearch
       set_fact:

--- a/roles/rsyslog/templates/global.j2
+++ b/roles/rsyslog/templates/global.j2
@@ -1,16 +1,17 @@
 {% set ns = namespace() %}
-{% set ns.ca_cert_path = __rsyslog_default_pki_path + __rsyslog_default_pki_cert_dir + __rsyslog_default_pki_ca_cert_name %}
-{% set ns.cert_path = __rsyslog_default_pki_path + __rsyslog_default_pki_cert_dir + __rsyslog_default_pki_cert_name %}
-{% set ns.key_path = __rsyslog_default_pki_path + __rsyslog_default_pki_key_dir + __rsyslog_default_pki_key_name %}
-{% for file in logging_pki_files %}
-{%   if file.type == 'ca_cert' %}
-{%     set ns.ca_cert_path = file.dest | d(__rsyslog_default_pki_path + __rsyslog_default_pki_cert_dir + file.src | basename) %}
-{%   elif file.type == 'cert' %}
-{%     set ns.cert_path = file.dest | d(__rsyslog_default_pki_path + __rsyslog_default_pki_cert_dir + file.src | basename) %}
-{%   elif file.type == 'key' %}
-{%     set ns.key_path = file.dest | d(__rsyslog_default_pki_path + __rsyslog_default_pki_key_dir + file.src | basename) %}
+{% if __rsyslog_default_netstream_driver != "ptcp" %}
+{%   set __ca_cert_file = logging_pki_files.0.ca_cert_src | d(__rsyslog_default_pki_ca_cert_name) | basename %}
+{%   set ns.ca_cert_path = logging_pki_files.0.ca_cert |
+		                   d(__rsyslog_default_pki_path + __rsyslog_default_pki_cert_dir + __ca_cert_file) %}
+{%   if logging_pki_authmode != "anon" %}
+{%     set __cert_file = logging_pki_files.0.cert_src | d(__rsyslog_default_pki_cert_name) | basename %}
+{%     set ns.cert_path = logging_pki_files.0.cert |
+		                  d(__rsyslog_default_pki_path + __rsyslog_default_pki_cert_dir + __cert_file) %}
+{%     set __key_file = logging_pki_files.0.private_key_src | d(__rsyslog_default_pki_key_name) | basename %}
+{%     set ns.key_path = logging_pki_files.0.private_key |
+		                 d(__rsyslog_default_pki_path + __rsyslog_default_pki_key_dir + __key_file) %}
 {%   endif %}
-{% endfor %}
+{% endif %}
 global(
   defaultNetstreamDriver="{{ __rsyslog_default_netstream_driver }}"
   workDirectory="{{ rsyslog_work_dir }}"

--- a/roles/rsyslog/templates/output_elasticsearch.j2
+++ b/roles/rsyslog/templates/output_elasticsearch.j2
@@ -59,7 +59,7 @@ ruleset(name="{{ item.name }}") {
 {% if item.use_cert | default(true) %}
             tls.cacert="{{ item.ca_cert | default('/etc/rsyslog.d/es-ca.crt') }}"
             tls.mycert="{{ item.cert | default('/etc/rsyslog.d/es-cert.pem') }}"
-            tls.myprivkey="{{ item.key | default('/etc/rsyslog.d/es-key.pem') }}"
+            tls.myprivkey="{{ item.private_key | default('/etc/rsyslog.d/es-key.pem') }}"
 {% endif %}
         )
     }

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,40 +37,44 @@
         - item.type | d('') == 'custom'
         - logging_enabled | d(true)
 
-    - name: Re-read facts after adding custom fact
-      setup:
-        filter: ansible_local
-      when: logging_debug | d(false)
+    - block:
+        - name: Re-read facts after adding custom fact
+          setup:
+            filter: ansible_local
 
-    - name: Create rsyslog debug dir
-      file:
-        path: "{{ role_path }}/debug"
-        state: directory
-        mode: 0700
-      when: logging_debug | d(false)
+        - name: Create rsyslog debug dir
+          file:
+            path: "{{ role_path }}/debug"
+            state: directory
+            mode: 0700
 
-    - name: Delete debug file
-      file:
-        path: "{{ role_path }}/debug/main.yml"
-        state: absent
-      ignore_errors: true
-      when: logging_debug | d(false)
+        - name: Delete debug file
+          file:
+            path: "{{ role_path }}/debug/main.yml"
+            state: absent
+          ignore_errors: true
 
-    - name: Create rsyslog debug file
-      lineinfile:
-        path: "{{ role_path }}/debug/main.yml"
-        create: yes
-        line: "#ANSIBLE MANAGED VARIABLES FILE"
-      when: logging_debug | d(false)
+        - name: Create rsyslog debug file
+          lineinfile:
+            path: "{{ role_path }}/debug/main.yml"
+            create: yes
+            line: "#ANSIBLE MANAGED VARIABLES FILE"
 
-    - name: Populate rsyslog debug file
-      lineinfile:
-        path: "{{ role_path }}/debug/main.yml"
-        create: yes
-        line: "{{ item.key }}: {{ item.value | d() | to_nice_json(indent=2) }}"
-      with_dict: "{{ hostvars[inventory_hostname] }}"
+        - name: Use a debug var to avoid an empty dict in with_dict
+          set_fact:
+            __logging_debug_hostname: "{{ hostvars[inventory_hostname] }}"
+
+        - name: Populate rsyslog debug file
+          when:
+            - __logging_debug_hostname | length > 0
+            - item.key is match("rsyslog*")
+          lineinfile:
+            path: "{{ role_path }}/debug/main.yml"
+            create: yes
+            line: "{{ item.key }}: {{ item.value | d() | to_nice_json(indent=2) }}"
+          with_dict: "{{ __logging_debug_hostname }}"
+
       when:
-        - item.key is match("rsyslog*")
         - logging_debug | d(false)
 
   when: logging_provider == 'rsyslog'

--- a/tests/tests_basics_forwards_cert.yml
+++ b/tests/tests_basics_forwards_cert.yml
@@ -5,17 +5,14 @@
 # logging_purge_confs: true
 # logging_pki: tls
 # logging_pki_files:
-#   - type: ca_cert
-#     src: "{{ __test_ca_cert }}" <-- local ca_cert file path to be copied from
-#     dest: "/etc/pki/tls/certs/{{ __test_ca_cert_name }}" <-- target destination
-#   - type: cert
-#     src: "{{ __test_cert }}" <-- local cert file path to be copied from
-#     <-- Since target destination is given, dest is set to /etc/pki/tls/certs/{{ __test_cert }}
-#   - type: key
-#     src: "{{ __test_key }}" <-- local key file path to be copied from
-#     <-- Since target destination is given, dest is set to /etc/pki/tls/private/{{ __test_key }}
-#     inputs: [basic_input]
-#     outputs: [forwards_severity_and_facility]
+#     ca_cert_src: "{{ __test_ca_cert }}" <-- local ca_cert file path to be copied from
+#     ca_cert: "/etc/pki/tls/certs/{{ __test_ca_cert_name }}" <-- target destination
+#     cert_src: "{{ __test_cert }}" <-- local cert file path to be copied from
+#     <-- Since target destination is not given, dest is set to /etc/pki/tls/certs/{{ __test_cert_name }}
+#     private_key_src: "{{ __test_key }}" <-- local key file path to be copied from
+#     <-- Since target destination is not given, dest is set to /etc/pki/tls/private/{{ __test_key_name }}
+#  inputs: [basic_input]
+#  outputs: [forwards_severity_and_facility]
 #
 # [Test scenario]
 # 0. Generate fake key/certs files.
@@ -62,13 +59,9 @@
         logging_purge_confs: true
         logging_pki: tls
         logging_pki_files:
-          - type: ca_cert
-            src: "{{ __test_ca_cert }}"
-            dest: "/etc/pki/tls/certs/{{ __test_ca_cert_name }}"
-          - type: cert
-            src: "{{ __test_cert }}"
-          - type: key
-            src: "{{ __test_key }}"
+          - ca_cert_src: "{{ __test_ca_cert }}"
+            cert_src: "{{ __test_cert }}"
+            private_key_src: "{{ __test_key }}"
         logging_outputs:
           - name: forwards_severity_and_facility
             type: forwards

--- a/tests/tests_basics_forwards_cert_missing.yml
+++ b/tests/tests_basics_forwards_cert_missing.yml
@@ -1,0 +1,82 @@
+# Test the configuration, basics input and a forwards output with invalid logging_pki_files
+#
+# [Configuration]
+# basics input (imjournal) -> forwards output (omfile)
+# logging_purge_confs: true
+# logging_pki: tls
+# logging_pki_files:
+#     ca_cert_src: "{{ __test_ca_cert }}" <-- local ca_cert file path to be copied from
+#     ca_cert: "/etc/pki/tls/certs/{{ __test_ca_cert_name }}" <-- target destination
+#     private_key_src: "{{ __test_key }}" <-- local key file path to be copied from
+#     Note: cert_src is missing.
+# inputs: [basic_input]
+# outputs: [forwards_severity_and_facility]
+#
+# [Test scenario]
+# 0. Generate fake key/certs files.
+# 1. Run logging role uploading the fake key/certs files, which expects to fail with {{ __expected_error }}
+#
+- name: Error case for setting logging_pki_files - missing cert_src
+  hosts: all
+  become: true
+  vars:
+    __test_ca_cert_name: test-ca.crt
+    __test_key_name: test-key.pem
+    __test_ca_cert: /tmp/{{ __test_ca_cert_name }}
+    __test_key: /tmp/{{ __test_key_name }}
+    __expected_error: "Error: you specified logging_pki other than none or ptcp and logging_pki_authmode other than anon; you must specify all 3 of logging_pki_files ca_cert_src, cert_src, private_key_src, and/or all 3 of ca_cert, cert, private_key in the playbook var section."
+
+  tasks:
+    - block:
+        - name: Generate fake key/certs files
+          copy:
+            dest: "{{ item }}"
+            content:
+              This is a fake {{ item }}.
+          delegate_to: localhost
+          loop:
+            - "{{ __test_ca_cert }}"
+            - "{{ __test_key }}"
+
+        - name: Deploy rsyslog config on the target host
+          vars:
+            logging_pki: tls
+            logging_pki_files:
+              - ca_cert_src: "{{ __test_ca_cert }}"
+                private_key_src: "{{ __test_key }}"
+            logging_outputs:
+              - name: forwards_severity_and_facility
+                type: forwards
+                facility: local1
+                severity: info
+                protocol: tcp
+                target: host.domain
+                port: 1514
+            logging_inputs:
+              - name: basic_input
+                type: basics
+            logging_flows:
+              - name: flows0
+                inputs: [basic_input]
+                outputs: [forwards_severity_and_facility]
+          include_role:
+            name: linux-system-roles.logging
+
+        - name: unreachable task
+          fail:
+            msg: UNREACH
+
+      rescue:
+        - debug:
+            msg: "Caught an expected error - {{ ansible_failed_result.msg }}"
+        - name: assert...
+          assert:
+            that: "'{{ ansible_failed_result.msg }}' is match('{{ __expected_error }}')"
+
+    - name: default run for cleanup
+      vars:
+        logging_inputs:
+          - name: basic_input
+            type: basics
+      include_role:
+        name: linux-system-roles.logging

--- a/tests/tests_files_elasticsearch_certs_incomplete.yml
+++ b/tests/tests_files_elasticsearch_certs_incomplete.yml
@@ -2,10 +2,10 @@
 #
 # Elasticsearch output has this policy:
 #   use_cert: If true, key/certificates are used to access Elasticsearch.
-#             Triplets {`ca_cert`, `cert`, key`} and/or {`ca_cert_src`,
-#             `cert_src`, `key_src`} should be configured. Default to true.
-# In this test case, use_cert is not set, i.e., true, and only {ca_cert, key}
-# and {cert_src, key_src} are set in the elasticsearch dictionary.
+#             Triplets {`ca_cert`, `cert`, private_key`} and/or {`ca_cert_src`,
+#             `cert_src`, `private_key_src`} should be configured. Default to true.
+# In this test case, use_cert is not set, i.e., true, and only {ca_cert, private_key}
+# and {cert_src, private_key_src} are set in the elasticsearch dictionary.
 # Logging role is supposed to issue {{ __expected_error }}.
 #
 # [Configuration]
@@ -13,9 +13,9 @@
 # logging_outputs:
 #   - name: elasticsearch_output
 #     ca_cert: /etc/rsyslog.d/ca_cert.crt
-#     key: /etc/rsyslog.d/key.pem
+#     private_key: /etc/rsyslog.d/key.pem
 #     cert_src: "{{ __test_cert }}"
-#     key_src: "{{ __test_key }}"
+#     private_key_src: "{{ __test_key }}"
 #     8< snip >8
 #
 # [Test scenario]
@@ -33,7 +33,7 @@
     __test_ca_cert: /tmp/es-ca.crt
     __test_cert: /tmp/es-cert.pem
     __test_key: /tmp/es-key.pem
-    __expected_error: "Error: you specified use_cert: true; you must specify all 3 of ca_cert, cert, key, or all 3 of ca_cert_src, cert_src, key_src, or set use_cert: false in the elasticsearch output named elasticsearch_output"
+    __expected_error: "Error: you specified use_cert: true; you must specify all 3 of ca_cert, cert, private_key, or all 3 of ca_cert_src, cert_src, private_key_src, or set use_cert: false in the elasticsearch output named elasticsearch_output"
 
   tasks:
     - name: Generate fake key/certs files.
@@ -59,9 +59,9 @@
                 input_type: ovirt
                 retryfailures: false
                 ca_cert: /etc/rsyslog.d/ca_cert.crt
-                key: /etc/rsyslog.d/key.pem
+                private_key: /etc/rsyslog.d/key.pem
                 cert_src: "{{ __test_cert }}"
-                key_src: "{{ __test_key }}"
+                private_key_src: "{{ __test_key }}"
             logging_inputs:
               - name: files_input
                 type: files

--- a/tests/tests_files_elasticsearch_use_cert_false_with_keys.yml
+++ b/tests/tests_files_elasticsearch_use_cert_false_with_keys.yml
@@ -2,8 +2,8 @@
 #
 # Elasticsearch output has this policy:
 #   use_cert: If true, key/certificates are used to access Elasticsearch.
-#             Triplets {`ca_cert`, `cert`, key`} and/or {`ca_cert_src`,
-#             `cert_src`, `key_src`} should be configured. Default to true.
+#             Triplets {`ca_cert`, `cert`, private_key`} and/or {`ca_cert_src`,
+#             `cert_src`, `private_key_src`} should be configured. Default to true.
 # In this test case, both triplets are properly set, but use_cert is set to false,
 # which indicates configuration error.
 #
@@ -55,10 +55,10 @@
                 use_cert: false
                 ca_cert: /etc/rsyslog.d/ca_cert.crt
                 cert: /etc/rsyslog.d/cert.pem
-                key: /etc/rsyslog.d/key.pem
+                private_key: /etc/rsyslog.d/key.pem
                 ca_cert_src: "{{ __test_ca_cert }}"
                 cert_src: "{{ __test_cert }}"
-                key_src: "{{ __test_key }}"
+                private_key_src: "{{ __test_key }}"
             logging_inputs:
               - name: files_input
                 type: files

--- a/tests/tests_files_elasticsearch_use_local_cert.yml
+++ b/tests/tests_files_elasticsearch_use_local_cert.yml
@@ -2,8 +2,8 @@
 #
 # Elasticsearch output has this policy:
 #   use_cert: If true, key/certificates are used to access Elasticsearch.
-#             Triplets {`ca_cert`, `cert`, key`} and/or {`ca_cert_src`,
-#             `cert_src`, `key_src`} should be configured. Default to true.
+#             Triplets {`ca_cert`, `cert`, private_key`} and/or {`ca_cert_src`,
+#             `cert_src`, `private_key_src`} should be configured. Default to true.
 # In this test case, src certs triplet and implicit use_cert option are properly set.
 #
 # [Configuration]
@@ -12,7 +12,7 @@
 #   - name: elasticsearch_output
 #     ca_cert_src: "{{ __test_ca_cert }}"
 #     cert_src: "{{ __test_cert }}"
-#     key_src: "{{ __test_key }}"
+#     private_key_src: "{{ __test_key }}"
 #     8< snip >8
 #
 # [Test scenario]
@@ -66,7 +66,7 @@
             retryfailures: false
             ca_cert_src: "{{ __test_ca_cert }}"
             cert_src: "{{ __test_cert }}"
-            key_src: "{{ __test_key }}"
+            private_key_src: "{{ __test_key }}"
         logging_inputs:
           - name: files_input
             type: files

--- a/tests/tests_files_elasticsearch_use_local_cert_all.yml
+++ b/tests/tests_files_elasticsearch_use_local_cert_all.yml
@@ -2,8 +2,8 @@
 #
 # Elasticsearch output has this policy:
 #   use_cert: If true, key/certificates are used to access Elasticsearch.
-#             Triplets {`ca_cert`, `cert`, key`} and/or {`ca_cert_src`,
-#             `cert_src`, `key_src`} should be configured. Default to true.
+#             Triplets {`ca_cert`, `cert`, private_key`} and/or {`ca_cert_src`,
+#             `cert_src`, `private_key_src`} should be configured. Default to true.
 # In this test case, both triplets and use_cert option are properly set.
 #
 # [Configuration]
@@ -12,10 +12,10 @@
 #   - name: elasticsearch_output
 #     ca_cert_src: "{{ __test_ca_cert }}"
 #     cert_src: "{{ __test_cert }}"
-#     key_src: "{{ __test_key }}"
+#     private_key_src: "{{ __test_key }}"
 #     ca_cert: "{{ __test_ca_cert_target }}"
 #     cert: "{{ __test_cert_target }}"
-#     key: "{{ __test_key_target }}"
+#     private_key: "{{ __test_key_target }}"
 #     8< snip >8
 #
 # [Test scenario]
@@ -72,10 +72,10 @@
             retryfailures: false
             ca_cert_src: "{{ __test_ca_cert }}"
             cert_src: "{{ __test_cert }}"
-            key_src: "{{ __test_key }}"
+            private_key_src: "{{ __test_key }}"
             ca_cert: "{{ __test_ca_cert_target }}"
             cert: "{{ __test_cert_target }}"
-            key: "{{ __test_key_target }}"
+            private_key: "{{ __test_key_target }}"
         logging_inputs:
           - name: files_input
             type: files

--- a/tests/tests_files_elasticsearch_use_local_cert_nokeys.yml
+++ b/tests/tests_files_elasticsearch_use_local_cert_nokeys.yml
@@ -2,8 +2,8 @@
 #
 # Elasticsearch output has this policy:
 #   use_cert: If true, key/certificates are used to access Elasticsearch.
-#             Triplets {`ca_cert`, `cert`, key`} and/or {`ca_cert_src`,
-#             `cert_src`, `key_src`} should be configured. Default to true.
+#             Triplets {`ca_cert`, `cert`, private_key`} and/or {`ca_cert_src`,
+#             `cert_src`, `private_key_src`} should be configured. Default to true.
 # In this test case, use_cert is set to true, but no certs triplets are
 # configured in the elasticsearch dictionary.
 # Logging role is supposed to issue {{ __expected_error }}.
@@ -25,7 +25,7 @@
   become: true
   vars:
     __test_inputfiles_dir: /var/log/inputdirectory
-    __expected_error: "Error: you specified use_cert: true; you must specify all 3 of ca_cert, cert, key, or all 3 of ca_cert_src, cert_src, key_src, or set use_cert: false in the elasticsearch output named elasticsearch_output"
+    __expected_error: "Error: you specified use_cert: true; you must specify all 3 of ca_cert, cert, private_key, or all 3 of ca_cert_src, cert_src, private_key_src, or set use_cert: false in the elasticsearch output named elasticsearch_output"
 
   tasks:
     - block:

--- a/tests/tests_ovirt_elasticsearch.yml
+++ b/tests/tests_ovirt_elasticsearch.yml
@@ -59,7 +59,7 @@
             retryfailures: false
             ca_cert: "/etc/rsyslog.d/es-ca.crt"
             cert: "/etc/rsyslog.d/es-cert.pem"
-            key: "/etc/rsyslog.d/es-key.pem"
+            private_key: "/etc/rsyslog.d/es-key.pem"
           - name: elasticsearch_output_ops
             type: elasticsearch
             server_host: logging-es-ops
@@ -69,7 +69,7 @@
             retryfailures: false
             ca_cert: "/etc/rsyslog.d/es-ca.crt"
             cert: "/etc/rsyslog.d/es-cert.pem"
-            key: "/etc/rsyslog.d/es-key.pem"
+            private_key: "/etc/rsyslog.d/es-key.pem"
         logging_inputs:
           - name: basic_input
             type: basics

--- a/tests/tests_ovirt_elasticsearch_params.yml
+++ b/tests/tests_ovirt_elasticsearch_params.yml
@@ -59,7 +59,7 @@
             retryfailures: false
             ca_cert: "/etc/rsyslog.d/es-ca.crt"
             cert: "/etc/rsyslog.d/es-cert.pem"
-            key: "/etc/rsyslog.d/es-key.pem"
+            private_key: "/etc/rsyslog.d/es-key.pem"
           - name: elasticsearch_output_ops
             type: elasticsearch
             server_host: logging-es-ops
@@ -69,7 +69,7 @@
             retryfailures: false
             ca_cert: "/etc/rsyslog.d/es-ca.crt"
             cert: "/etc/rsyslog.d/es-cert.pem"
-            key: "/etc/rsyslog.d/es-key.pem"
+            private_key: "/etc/rsyslog.d/es-key.pem"
         logging_inputs:
           - name: basic_input
             type: basics


### PR DESCRIPTION
- Complying with the consistent tls parameter/key names:
```
    logging_pki_files:
      - ca_cert_src:     ca cert path on the control host
        cert_src:        cert path on the control host
        private_key_src: key path on the control host
        ca_cert:     ca cert path on the managed host
        cert:        cert path on the managed host
        private_key: key path on the managed host
```
- Updated README.md with better parameter grouping
- In the copy task in tasks/main.yml, which copies the src files to the dest,
  added a check whether triplets are given or not.
- Adding a test playbook tests_basics_forwards_cert_missing.yml.
- Put the debug code into a block which is needed by the new test which runs
  the second logging role for the recovery from the first failure.

- Complying with the consistent tls parameter/key names in the elasticsearch output.
  Replacing key param with private_key.