### PR TITLE
2 Bug fixes in the basics input

### DIFF
--- a/roles/rsyslog/tasks/inputs/basics/main.yml
+++ b/roles/rsyslog/tasks/inputs/basics/main.yml
@@ -18,9 +18,10 @@
           - options: "{{ lookup('template', __rsyslog_input_basics) }}"
   include_tasks:
     file: "{{ role_path }}/tasks/deploy.yml"
-  loop: '{{ logging_inputs }}'
+  loop: '{{ logging_inputs | sort(attribute="type") }}'
   loop_control:
     extended: yes
   when:
     - item.type | d() == 'basics'
-    - ansible_loop.first
+    - ansible_loop.previtem is not defined or
+      (ansible_loop.previtem is defined and ansible_loop.previtem.type != 'basics')

--- a/roles/rsyslog/templates/input_basics.j2
+++ b/roles/rsyslog/templates/input_basics.j2
@@ -3,8 +3,8 @@ module(load="imklog" permitnonkernelfacility="on")
 {% endif %}
 {% if item.use_imuxsock | d(false) | bool %}
 module(load="imuxsock"    # provides support for local system logging (e.g. via logger command)
-       SysSock.RateLimit.Burst="{{ input.ratelimit_burst | d(200) }}"
-       SysSock.RateLimit.Interval="{{ input.ratelimit_burst | d(0) }}"
+       SysSock.RateLimit.Burst="{{ item.ratelimit_burst | d(200) }}"
+       SysSock.RateLimit.Interval="{{ item.ratelimit_burst | d(0) }}"
        SysSock.Use="on")  # Turn on message reception via local log socket.
 input(name="basics_imuxsock" type="imuxsock" socket="/dev/log")
 {% else %}
@@ -12,8 +12,8 @@ module(load="imuxsock"    # provides support for local system logging (e.g. via 
        SysSock.Use="off") # Turn off message reception via local log socket.
 module(load="imjournal"
        StateFile="{{ rsyslog_work_dir }}/imjournal.state"
-       RateLimit.Burst="{{ input.ratelimit_burst | d(20000) }}"
-       RateLimit.Interval="{{ input.ratelimit_interval | d(600) }}"
-       PersistStateInterval="{{ input.journal_persist_state_interval | d(10) }}")
+       RateLimit.Burst="{{ item.ratelimit_burst | d(20000) }}"
+       RateLimit.Interval="{{ item.ratelimit_interval | d(600) }}"
+       PersistStateInterval="{{ item.journal_persist_state_interval | d(10) }}")
 {% endif %}
 {{ lookup('template', 'input_template.j2') }}

--- a/tests/tests_combination.yml
+++ b/tests/tests_combination.yml
@@ -74,12 +74,15 @@
             target: host.domain
             port: 2514
         logging_inputs:
-          - name: basic_input
-            type: basics
-            ratelimit_burst: 33333
           - name: "{{ __test_tag }}"
             type: files
             input_log_path: "{{ __test_inputfiles_dir }}/*.log"
+          - name: basic_input
+            type: basics
+            ratelimit_burst: 33333
+          - name: basic_input
+            type: basics
+            ratelimit_burst: 44444
         logging_flows:
           - name: flow_0
             inputs: [basic_input]


### PR DESCRIPTION
- There should not be multiple basics input. The basics input code is implemented to
  skip the second and the rest, if any. There was a mistake in the skipping code.
  Instead of using ansible_loop.first, change to sort the loop variables by the type
  and check ansible_loop.previtem.
- There were wrong loop variables in templates/input_basics.j2. Replacing "input"
  with "item".

Adding the test case to tests_combination.yml.