### PR TITLE
Bug fix: ca cert w/o cert/key is not deployed

### DIFF
--- a/roles/rsyslog/tasks/main.yml
+++ b/roles/rsyslog/tasks/main.yml
@@ -204,7 +204,7 @@
       when:
         - __rsyslog_enabled | bool
         - __rsyslog_pki_map[logging_pki] | d("ptcp") != "ptcp"
-        - logging_pki_files.0.cert_src | d("")
+        - logging_pki_files.0.ca_cert_src | d("")
       notify: restart rsyslogd
 
     - name: Copy local cert file to the target if needed

--- a/tests/tests_basics_forwards_cacert.yml
+++ b/tests/tests_basics_forwards_cacert.yml
@@ -1,0 +1,104 @@
+# Test the configuration, basics input and a forwards output with logging_pki_files
+#
+# [Configuration]
+# basics input (imjournal) -> forwards output (omfile)
+# logging_purge_confs: true
+# logging_pki: tls
+# logging_pki_authmode: anon
+# logging_pki_files:
+#     ca_cert_src: "{{ __test_ca_cert }}" <-- local ca_cert file path to be copied from
+#     ca_cert: "/etc/pki/tls/certs/{{ __test_ca_cert_name }}" <-- target destination
+#  inputs: [basic_input]
+#  outputs: [forwards_severity_and_facility]
+#
+# [Test scenario]
+# 0. Generate fake ca cert file.
+# 1. Run logging role uploading the fake ca cert file.
+# 2. Check rsyslog.conf file size.
+#    If logging role is executed, the file size is about 100 bytes.
+#    If not executed, the default rsyslog.conf size is larger than 3000 bytes.
+#    Thus, assert the size is less than 1000.
+# 3. Check file count in /etc/rsyslog.d.
+#    If logging role is executed, 7 config files are generated.
+#    By setting logging_purge_confs, pre-existing config files are deleted.
+#    Thus, assert the the count is equal to 7.
+# 4. Check systemctl status of rsyslog as well as error or specific message in the output.
+# 5. Check the config file of a forwards output, severity_and_facility contains the expected filter and action.
+# 6. Check the fake ca cert is successfully copied.
+# 7. Check the fake ca cert path is set in the global config.
+#
+- name: Test the configuration, basics input and a forwards output with logging_pki_files
+  hosts: all
+  become: true
+  vars:
+    __test_forward_conf_s_f: /etc/rsyslog.d/30-output-forwards-forwards_severity_and_facility.conf
+    __test_ca_cert_name: test-ca.crt
+    __test_ca_cert: /tmp/{{ __test_ca_cert_name }}
+
+  tasks:
+    - name: Generate fake ca cert file
+      copy:
+        dest: "{{ __test_ca_cert }}"
+        content:
+          This is a fake "{{ __test_ca_cert }}".
+      delegate_to: localhost
+
+    - name: Deploy rsyslog config on the target host
+      vars:
+        logging_purge_confs: true
+        logging_pki: tls
+        logging_pki_authmode: anon
+        logging_pki_files:
+          - ca_cert_src: "{{ __test_ca_cert }}"
+        logging_outputs:
+          - name: forwards_severity_and_facility
+            type: forwards
+            facility: local1
+            severity: info
+            protocol: tcp
+            target: host.domain
+            port: 1514
+        logging_inputs:
+          - name: basic_input
+            type: basics
+        logging_flows:
+          - name: flows0
+            inputs: [basic_input]
+            outputs: [forwards_severity_and_facility]
+      include_role:
+        name: linux-system-roles.logging
+
+    - include: set_rsyslog_variables.yml
+
+    # notify restart rsyslogd is executed at the end of this test task.
+    # thus we have to force to invoke handlers
+    - name: Force all notified handlers to run at this point, not waiting for normal sync points
+      meta: flush_handlers
+
+    - name: Check rsyslog.conf size
+      assert:
+        that: rsyslog_conf_stat.stat.size < 1000
+
+    - name: Check file counts in rsyslog.d
+      assert:
+        that: rsyslog_d_file_count.matched == 7
+
+    # Checking 'error' in stdout from systemctl status is for detecting the case in which rsyslog is running,
+    # but some functionality is disabled due to some error, e.g., error: 'tls.cacert' file couldn't be accessed.
+    - name: Check rsyslog errors
+      command: systemctl status rsyslog
+      register: __result
+      failed_when: "'error' in __result.stdout or __result is failed"
+
+    - name: Check severity_and_facility
+      command: /bin/grep 'local1.info action(name="forwards_severity_and_facility" type="omfwd" Target="host.domain" Port="1514" Protocol="tcp")' '{{ __test_forward_conf_s_f }}'
+      changed_when: false
+
+    - name: Check the fake ca cert is successfully copied
+      stat:
+        path: "/etc/pki/tls/certs/{{ __test_ca_cert_name }}"
+      register: __result
+      failed_when: not __result.stat.exists
+
+    - name: Check the fake key/certs paths are set in the global config.
+      command: /bin/grep "/etc/pki/tls/certs/{{ __test_ca_cert_name }}" /etc/rsyslog.d/00-global.conf


### PR DESCRIPTION
When only ca cert is to be deployed, the condition to copy the ca cert was not satisfied by a typo.