### PR TITLE
RHELPLAN-50082 / Bug 1861318 - [logging role] cannot setup machine wi…

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,17 +241,11 @@ This is a schematic logging configuration to show log messages from input_nameA 
 
 These variables are set in the same level of the `logging_inputs`, `logging_output`, and `logging_flows`.
 
-- `logging_pki`: Specifying an encryption.
-  One of `none`, `ptcp`, `tls`, `gtls`, and `gnutls`. Default to `ptcp`.
-  Note: `none`=`ptcp`, `tls`=`gtls`=`gnutls`.
-  When `logging_pki` is _not_ `ptcp`, i.e., `tls` or its alias, the logging system is configured to use tls.
 - `logging_pki_files`: Specifying either of the paths of the ca_cert, cert, and key on the control host or
   the paths of theirs on the managed host or both of them.
-  The usage of `logging_pki_files` depends upon the value of `logging_pki`.
-  If `logging_pki` is `ptcp`, `logging_pki_files` is ignored. 
-  If `logging_pki` is not `ptcp`, `ca_cert_src` and/or `ca_cert` is required.
-  If both `cert_src` and `cert` are not given, certificate for the logging system is not configured.
-  If both `private_key_src` and `private_key` are not given, private key for the logging system is not configured.
+  When TLS connection is configured, `ca_cert_src` and/or `ca_cert` is required.
+  To configure the certificate of the logging system, `cert_src` and/or `cert` is required.
+  To configure the private key of the logging system, `private_key_src` and/or `private_key` is required.
 ``` 
   ca_cert_src:     location of the ca_cert on the control host; if given, the file is copied to the managed host.
   cert_src:        location of the cert on the control host; if given, the file is copied to the managed host.
@@ -500,7 +494,6 @@ The following playbook generates the same logging configuration files.
   roles:
     - linux-system-roles.logging
   vars:
-    logging_pki: tls
     logging_pki_files:
       - ca_cert_src: /local/path/to/ca_cert
         cert_src: /local/path/to/cert
@@ -514,7 +507,7 @@ The following playbook generates the same logging configuration files.
         type: forwards
         protocol: tcp
         target: your_target_host
-        port: 6514
+        port: your_target_port
         pki_authmode: x509/name
         permitted_server: '*.example.com'
     logging_flows:
@@ -557,7 +550,6 @@ The following playbook generates the same logging configuration files.
   roles:
     - linux-system-roles.logging
   vars:
-    logging_pki: tls
     logging_pki_files:
       - ca_cert_src: /local/path/to/ca_cert
         cert_src: /local/path/to/cert

--- a/README.md
+++ b/README.md
@@ -181,9 +181,9 @@ This is a schematic logging configuration to show log messages from input_nameA 
   **available options**
   - `facility`: Facility; default to `*`.
   - `severity`: Severity; default to `*`.
-  - `protocol`: Protocol; `tcp` or `udp`; default to `tcp`.
   - `target`: Target host (fqdn). **Required**.
-  - `port`: Port; default to 514.
+  - `udp_port`: UDP port number. Default to `514`.
+  - `tcp_port`: TCP port number. Default to `514`.
   - `pki`: Set to `tls` to use the `tls` enabled connection. Default to None.
   - `pki_authmode`: Specifying the default network driver authentication mode. `x509/name`, `x509/fingerprint`, `anon` is accepted. Default to `x509/name`.
   - `permitted_server`: Hostname, IP address, fingerprint(sha1) or wildcard DNS domain of the server which this client will be allowed to connect and send logs over TLS. Default to '*.{{ logging_domain }}'
@@ -471,15 +471,13 @@ The following playbook generates the same logging configuration files.
       - name: forward_output0
         type: forwards
         severity: info
-        protocol: udp
         target: your_target_hostname
-        port: 514
+        udp_port: 514
       - name: forward_output1
         type: forwards
         facility: mail
-        protocol: tcp
         target: your_target_hostname
-        port: 514
+        tcp_port: 514
     logging_flows:
       - name: flows0
         inputs: [basic_input]
@@ -505,9 +503,8 @@ The following playbook generates the same logging configuration files.
     logging_outputs:
       - name: forwards_output
         type: forwards
-        protocol: tcp
         target: your_target_host
-        port: your_target_port
+        tcp_port: your_target_port
         pki_authmode: x509/name
         permitted_server: '*.example.com'
     logging_flows:

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ These variables are set in the same level of the `logging_inputs`, `logging_outp
 
 These variables are set in the same level of the `logging_inputs`, `logging_output`, and `logging_flows`.
 
-- `logging_tcp_threads`: Input thread count listening on the tcp port. Default to `1`.
+- `logging_tcp_threads`: Input thread count listening on the plain tcp (ptcp) port. Default to `1`.
 - `logging_udp_threads`: Input thread count listening on the udp port. Default to `1`.
 - `logging_udp_system_time_requery`: Every `value` OS system calls, get the system time. Recommend not to set above 10. Default to `2` times.
 - `logging_udp_batch_size`: Maximum number of udp messages per OS system call. Recommend not to set above 128. Default to `32`.

--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ This is a schematic logging configuration to show log messages from input_nameA 
   **available options**
   - `udp_port`: UDP port number to listen. Default to `514`.
   - `tcp_port`: TCP port number to listen. Default to `514`.
+  - `pki_authmode`: Specifying the default network driver authentication mode. Default to `x509/name`.
+  - `permitted_peers`: List of hostnames, IP addresses or wildcard DNS domains which will be allowed by the `logging` server to connect and send logs over TLS. Default to ['\*.{{ logging_domain }}']
 
 #### Logging_outputs options
 
@@ -165,6 +167,8 @@ This is a schematic logging configuration to show log messages from input_nameA 
   - `protocol`: Protocol; `tcp` or `udp`; default to `tcp`.
   - `target`: Target host (fqdn). **Required**.
   - `port`: Port; default to 514.
+  - `pki_authmode`: Specifying the default network driver authentication mode. Default to `x509/name`.
+  - `permitted_peers`: Hostname, IP addresses or wildcard DNS domain which will be allowed by the `logging` server to connect and send logs over TLS. Default to '\*.{{ logging_domain }}'
 
 - `remote_files` type - `remote_files` output stores logs to the local files per remote host and program name originated the logs.<br>
   **available options**
@@ -223,19 +227,13 @@ These variables are set in the same level of the `logging_inputs`, `logging_outp
   One of `none`, `ptcp`, `tls`, `gtls`, and `gnutls`. Default to `ptcp`.
   Note: `none`=`ptcp`, `tls`=`gtls`=`gnutls`.
   When `logging_pki` is _not_ `ptcp`, i.e., `tls` or its alias, the logging system is configured to use tls.
-- `logging_pki_authmode`: Specifying the default network driver authentication mode.
-  `x509/name` or `anon` are available. Default to `x509/name`.
-  If set to `anon`, the `cert_src`, `private_key_src`, `cert`, and `private_key` specified in `logging_pki_files`
-  are ignored.
 - `logging_pki_files`: Specifying either of the paths of the ca_cert, cert, and key on the control host or
   the paths of theirs on the managed host or both of them.
-  The usage of `logging_pki_files` depends upon the value of `logging_pki` and `logging_pki_authmode`.
+  The usage of `logging_pki_files` depends upon the value of `logging_pki`.
   If `logging_pki` is `ptcp`, `logging_pki_files` is ignored. 
-  If `logging_pki` is not `ptcp` and `logging_pki_authmode` is `anon`, only `ca_cert_src` and `ca_cert`
-  parameters are processed.
-  In this case, either `ca_cert_src` or `ca_cert` or both of them are required.
-  Otherwise, all the following parameters are processed.
-  In this case, either 3 src parameters or 3 dest parameters or both sets are required.
+  If `logging_pki` is not `ptcp`, `ca_cert_src` and/or `ca_cert` is required.
+  If both `cert_src` and `cert` are not given, certificate for the logging system is not configured.
+  If both `private_key_src` and `private_key` are not given, private key for the logging system is not configured.
 ``` 
   ca_cert_src:     location of the ca_cert on the control host; if given, the file is copied to the managed host.
   cert_src:        location of the cert on the control host; if given, the file is copied to the managed host.
@@ -248,8 +246,6 @@ These variables are set in the same level of the `logging_inputs`, `logging_outp
                default to /etc/pki/tls/private/<private_key_src basename>
 ``` 
 - `logging_domain`: The default DNS domain used to accept remote incoming logs from remote hosts. Default to "{{ ansible_domain if ansible_domain else ansible_hostname }}"
-- `logging_permitted_peers`: List of hostnames, IP addresses or wildcard DNS domains which will be allowed by the `logging` server to connect and send logs over TLS.  Default to ['\*.{{ logging_domain }}']
-- `logging_send_permitted_peers`: List of hostnames, IP addresses or wildcard DNS domains which will be verified by the `logging` client and will allow to send logs to the remote server over TLS. Default to "{{ logging_permitted_peers }}".
 
 #### Server performance optimization options
 
@@ -501,6 +497,8 @@ The following playbook generates the same logging configuration files.
         protocol: tcp
         target: your_target_host
         port: 6514
+        pki_authmode: x509/name
+        permitted_peers: '*.example.com'
     logging_flows:
       - name: flows0
         inputs: [basic_input]
@@ -550,6 +548,7 @@ The following playbook generates the same logging configuration files.
       - name: remote_tcp_input
         type: remote
         tcp_port: 6514
+        permitted_peers: ['*.example.com', '*.test.com']
     logging_outputs:
       - name: remote_files_output0
         type: remote_files

--- a/README.md
+++ b/README.md
@@ -115,7 +115,6 @@ This is a schematic logging configuration to show log messages from input_nameA 
   **available options**
   - `udp_port`: UDP port number to listen. Default to `514`.
   - `tcp_port`: TCP port number to listen. Default to `514`.
-  - `tcp_tls_port`: TLS TCP number to listen. Default to `6515`. To use tcp_tls_port, `logging_pki` and `logging_pki_files` need to be configured. They are described in [Security options](#security-options).
 
 #### Logging_outputs options
 
@@ -550,7 +549,7 @@ The following playbook generates the same logging configuration files.
     logging_inputs:
       - name: remote_tcp_input
         type: remote
-        tcp_tls_port: 6514
+        tcp_port: 6514
     logging_outputs:
       - name: remote_files_output0
         type: remote_files

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ This is a schematic logging configuration to show log messages from input_nameA 
   - `udp_port`: UDP port number to listen. Default to `514`.
   - `tcp_port`: TCP port number to listen. Default to `514`.
   - `pki_authmode`: Specifying the default network driver authentication mode. Default to `x509/name`.
-  - `permitted_peers`: List of hostnames, IP addresses or wildcard DNS domains which will be allowed by the `logging` server to connect and send logs over TLS. Default to ['\*.{{ logging_domain }}']
+  - `permitted_clients`: List of hostnames, IP addresses, fingerprints(sha1), and wildcard DNS domains which will be allowed by the `logging` server to connect and send logs over TLS. Default to ['\*.{{ logging_domain }}']
 
 #### Logging_outputs options
 
@@ -168,7 +168,7 @@ This is a schematic logging configuration to show log messages from input_nameA 
   - `target`: Target host (fqdn). **Required**.
   - `port`: Port; default to 514.
   - `pki_authmode`: Specifying the default network driver authentication mode. Default to `x509/name`.
-  - `permitted_peers`: Hostname, IP addresses or wildcard DNS domain which will be allowed by the `logging` server to connect and send logs over TLS. Default to '\*.{{ logging_domain }}'
+  - `permitted_server`: Hostname, IP address, fingerprint(sha1) or wildcard DNS domain of the server which this client will be allowed to connect and send logs over TLS. Default to '*.{{ logging_domain }}'
 
 - `remote_files` type - `remote_files` output stores logs to the local files per remote host and program name originated the logs.<br>
   **available options**
@@ -498,7 +498,7 @@ The following playbook generates the same logging configuration files.
         target: your_target_host
         port: 6514
         pki_authmode: x509/name
-        permitted_peers: '*.example.com'
+        permitted_server: '*.example.com'
     logging_flows:
       - name: flows0
         inputs: [basic_input]
@@ -548,7 +548,7 @@ The following playbook generates the same logging configuration files.
       - name: remote_tcp_input
         type: remote
         tcp_port: 6514
-        permitted_peers: ['*.example.com', '*.test.com']
+        permitted_clients: ['*.example.com', '*.test.com']
     logging_outputs:
       - name: remote_files_output0
         type: remote_files

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -38,12 +38,6 @@ logging_server_queue_type: LinkedList
 logging_server_queue_size: 50000
 logging_server_threads: "{{ logging_udp_threads | int + logging_tcp_threads | int }}"
 
-# Specifying rsyslog encryption library
-# one of the implementations is allowed none, ptcp, tls, gtls, gnutls
-# Note: none->ptcp, tls,gtls,gnutls->gtls
-# Default to ptcp (== no tls)
-logging_pki: ptcp
-
 # Mark message periodically by immark, if set to true.
 logging_mark: false
 
@@ -56,7 +50,7 @@ logging_max_message_size: 8192
 
 # list of pki files dict
 # either of {ca_cert_src,cert_src,private_key_src} or {ca_cert,cert,private_key}
-# or both sets should be configured if logging_pki is other than ptcp or none.
+# or both sets should be configured.
 # logging_pki_files:
 #   - ca_cert_src:     location of the ca_cert on the control host.
 #                      If given, it's copied to the managed host.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -72,25 +72,7 @@ logging_max_message_size: 8192
 #                  default to /etc/pki/tls/private/<private_key_src basename>
 logging_pki_files: []
 
-# logging_pki_authmode
-#
-# Specify the default network driver authentication mode.
-# `x509/name` or `anon` are available:
-logging_pki_authmode: "x509/name"
-
 # logging_domain
 #
 # The default DNS domain used to accept remote incoming logs from remote hosts.
 logging_domain: '{{ ansible_domain if ansible_domain else ansible_hostname }}'
-
-# logging_permitted_peers
-#
-# List of hostnames, IP addresses or wildcard DNS domains which will be allowed
-# by the `logging` server to connect and send logs over TLS.
-logging_permitted_peers: ['*.{{ logging_domain }}']
-
-# logging_send_permitted_peers
-#
-# List of hostnames, IP addresses or wildcard DNS domains which will be verified
-# by the `logging` client and will allow to send logs to the remote server over TLS.
-logging_send_permitted_peers: '{{ logging_permitted_peers }}'

--- a/design_docs/Changelogs.md
+++ b/design_docs/Changelogs.md
@@ -1,5 +1,11 @@
 ## Changelogs
 
+### RHELPLAN-50082 / Bug 1861318 - [logging role] cannot setup machine with tls
+https://github.com/linux-system-roles/logging/pull/159
+- Eliminating logging_pki variable.
+  Instead of the top level variable logging_pki, use pki key in the individual
+  forwards output item and remote input item to switch the tls handling.
+
 ### RHELPLAN-43536 - Support tls for the remote input and forwards output
 https://github.com/linux-system-roles/logging/pull/126
 - New variables for configuring tls are introduced

--- a/design_docs/rsyslog_inputs_outputs_flows.md
+++ b/design_docs/rsyslog_inputs_outputs_flows.md
@@ -126,9 +126,8 @@ logging_inputs:
 logging_outputs:
   - name: forward-output
     type: forwards
-    protocol: tcp
     target: remote_host_name.remote_domain_name
-    port: 514
+    tcp_port: 514
   - name: file-output
     type: files
 logging_flows:
@@ -150,9 +149,8 @@ logging_outputs:
     type: forwards
     rsyslog_forwards_actions:
       - name: to-remote
-        protocol: tcp
         target: remote_host_name.remote_domain_name
-        port: 514
+        tcp_port: 514
     logging_inputs:
       - name: basic-input
         type: basics
@@ -178,9 +176,8 @@ logging_outputs:
     type: forwards
     rsyslog_forwards_actions:
       - name: to-remote
-        protocol: tcp
         target: remote_host_name.remote_domain_name
-        port: 514
+        tcp_port: 514
     logging_inputs:
       - name: basic-input0
         type: basics
@@ -206,9 +203,8 @@ In logging_flows, define which inputs are related to which outputs.
 logging_outputs:
   - name: forward-output
     type: forwards
-    protocol: tcp
     target: remote_host_name.remote_domain_name
-    port: 514
+    tcp_port: 514
   - name: file-output
     type: files
 logging_inputs:

--- a/roles/rsyslog/defaults/main.yml
+++ b/roles/rsyslog/defaults/main.yml
@@ -41,11 +41,6 @@ rsyslog_custom_config_files: []
 # By setting false, it'd change 2020-03-27T14:16:47.139796+00:00)
 rsyslog_basics_use_traditional_timestamp_format: true
 
-# communication over tls
-# ------------------------
-
-__rsyslog_default_netstream_driver: '{{ __rsyslog_pki_map[logging_pki] | d("ptcp") }}'
-
 # Files and Forwards outputs
 # --------------------------
 

--- a/roles/rsyslog/defaults/main.yml
+++ b/roles/rsyslog/defaults/main.yml
@@ -46,24 +46,6 @@ rsyslog_basics_use_traditional_timestamp_format: true
 
 __rsyslog_default_netstream_driver: '{{ __rsyslog_pki_map[logging_pki] | d("ptcp") }}'
 
-# rsyslog_send_over_tls
-#
-# This configuration is added to the forward options when ``tls`` capability is
-# enabled. It's used to configure TLS options.
-rsyslog_send_over_tls: |-
-  $ActionSendStreamDriver {{ __rsyslog_default_netstream_driver }}
-  $ActionSendStreamDriverAuthMode {{ logging_pki_authmode }}
-  {% if logging_pki_authmode == "x509/name" %}
-  {%   if logging_send_permitted_peers is string %}
-  $ActionSendStreamDriverPermittedPeer {{ logging_send_permitted_peers }}
-  {%   else %}
-  {%     for peer in logging_send_permitted_peers %}
-  $ActionSendStreamDriverPermittedPeer {{ peer }}
-  {%     endfor %}
-  {%   endif %}
-  {% endif %}
-  $ActionSendStreamDriverMode 1
-
 # Files and Forwards outputs
 # --------------------------
 

--- a/roles/rsyslog/tasks/inputs/remote/main.yml
+++ b/roles/rsyslog/tasks/inputs/remote/main.yml
@@ -1,5 +1,23 @@
 ---
 # Deploy configuration files
+- block:
+    - name: Ensure Remote inputs contain no conflict connection type
+      fail:
+        msg: "Error: {{ item.0.name }} and {{ item.1.name }} conflict."
+      loop: "{{ [__logging_remote_udp, __logging_remote_tcp, __logging_remote_tls] }}"
+      when:
+        - item | length > 1
+  vars:
+    __logging_remote_udp: "{{ logging_inputs | selectattr('type', '==', 'remote') |
+                              selectattr('udp_ports', 'defined') | list }}"
+    __logging_remote_tcp: "{{ logging_inputs | selectattr('type', '==', 'remote') |
+                              selectattr('tcp_ports', 'defined') |
+                              selectattr('pki', 'undefined') | list }}"
+    __logging_remote_tls: "{{ logging_inputs | selectattr('type', '==', 'remote') |
+                              selectattr('tcp_ports', 'defined') |
+                              selectattr('pki', 'defined') |
+                              selectattr('pki', '==', 'tls') | list }}"
+
 - name: Install/Update remote input packages and generate configuration files in /etc/rsyslog.d
   vars:
     __rsyslog_packages: "{{ __rsyslog_remote_packages }}"
@@ -13,7 +31,7 @@
   loop: '{{ logging_inputs }}'
   when: item.type | d() == 'remote'
 
-- name: Create basics input configuration files in /etc/rsyslog.d
+- name: Create remote input configuration files in /etc/rsyslog.d
   vars:
     __rsyslog_packages: []
     __rsyslog_rules:

--- a/roles/rsyslog/tasks/inputs/remote/main.yml
+++ b/roles/rsyslog/tasks/inputs/remote/main.yml
@@ -4,12 +4,14 @@
   vars:
     __rsyslog_packages: "{{ __rsyslog_remote_packages }}"
     __rsyslog_rules:
-      - name: "input-remote-modules"
+      - name: "input-remote-modules-{{ item.name }}"
         type: modules
         sections:
           - options: "{{ lookup('template', 'input_remote_module.j2') }}"
   include_tasks:
     file: "{{ role_path }}/tasks/deploy.yml"
+  loop: '{{ logging_inputs }}'
+  when: item.type | d() == 'remote'
 
 - name: Create basics input configuration files in /etc/rsyslog.d
   vars:

--- a/roles/rsyslog/tasks/main.yml
+++ b/roles/rsyslog/tasks/main.yml
@@ -162,36 +162,13 @@
       notify: restart rsyslogd
 
     # Check if logging_pki is defined and
-    #          logging_pki_authmode is not anon
-    #          logging_pki_files.{ca_cert_src,cert_src,private_key_src} and/or
-    #          logging_pki_files.{ca_cert,cert,private_key}
-    #          are defined.
+    #          logging_pki_files.{ca_cert_src,ca_cert} is defined
     # Otherwise it fails.
-    - name: Check logging_pki, logging_pki_authmode, and logging_pki_files
+    - name: Check logging_pki and logging_pki_files
       fail:
-        msg: "Error: you specified logging_pki other than none or ptcp and logging_pki_authmode other than anon; you must specify all 3 of logging_pki_files ca_cert_src, cert_src, private_key_src, and/or all 3 of ca_cert, cert, private_key in the playbook var section."
+        msg: "Error: you specified logging_pki other than none or ptcp; you must specify logging_pki_files ca_cert_src and/or ca_cert in the playbook var section."
       when:
         - __rsyslog_pki_map[logging_pki] | d("ptcp") != "ptcp"
-        - logging_pki_authmode != "anon"
-        - not ((logging_pki_files.0.ca_cert_src | d() and
-                logging_pki_files.0.cert_src | d() and
-                logging_pki_files.0.private_key_src | d()) or
-               (logging_pki_files.0.ca_cert | d() and
-                logging_pki_files.0.cert | d() and
-                logging_pki_files.0.private_key | d()))
-
-    # Check if logging_pki is defined and
-    #          logging_pki_authmode is anon
-    #          logging_pki_files.ca_cert_src and/or
-    #          logging_pki_files.ca_cert
-    #          are defined.
-    # Otherwise it fails.
-    - name: Check logging_pki, logging_pki_authmode, and logging_pki_files 2
-      fail:
-        msg: "Error: you specified logging_pki other than none or ptcp and logging_pki_authmode anon; you must specify logging_pki_files ca_cert_src and/or ca_cert in the playbook var section."
-      when:
-        - __rsyslog_pki_map[logging_pki] | d("ptcp") != "ptcp"
-        - logging_pki_authmode == "anon"
         - not (logging_pki_files.0.ca_cert_src | d() or logging_pki_files.0.ca_cert | d())
 
     - name: Copy local ca_cert file to the target if needed
@@ -217,7 +194,6 @@
       when:
         - __rsyslog_enabled | bool
         - __rsyslog_pki_map[logging_pki] | d("ptcp") != "ptcp"
-        - logging_pki_authmode != "anon"
         - logging_pki_files.0.cert_src | d("")
       notify: restart rsyslogd
 
@@ -231,7 +207,6 @@
       when:
         - __rsyslog_enabled | bool
         - __rsyslog_pki_map[logging_pki] | d("ptcp") != "ptcp"
-        - logging_pki_authmode != "anon"
         - logging_pki_files.0.private_key_src | d("")
       notify: restart rsyslogd
 

--- a/roles/rsyslog/tasks/main.yml
+++ b/roles/rsyslog/tasks/main.yml
@@ -13,9 +13,7 @@
 
 - name: Install/Update required packages
   package:
-    name: "{{ __rsyslog_base_packages }} +
-           {{ __rsyslog_tls_packages if __rsyslog_default_netstream_driver != 'ptcp' else [] }} +
-           {{ rsyslog_extra_packages | flatten }}"
+    name: "{{ __rsyslog_base_packages }} + {{ __rsyslog_tls_packages }} + {{ rsyslog_extra_packages | flatten }}"
     state: latest
   when:
     - __rsyslog_enabled | bool
@@ -161,54 +159,65 @@
       when: __rsyslog_enabled | bool
       notify: restart rsyslogd
 
-    # Check if logging_pki is defined and
-    #          logging_pki_files.{ca_cert_src,ca_cert} is defined
-    # Otherwise it fails.
-    - name: Check logging_pki and logging_pki_files
-      fail:
-        msg: "Error: you specified logging_pki other than none or ptcp; you must specify logging_pki_files ca_cert_src and/or ca_cert in the playbook var section."
-      when:
-        - __rsyslog_pki_map[logging_pki] | d("ptcp") != "ptcp"
-        - not (logging_pki_files.0.ca_cert_src | d() or logging_pki_files.0.ca_cert | d())
+    - block:
+        # Check if tls is enabled in forwards output or remote input and
+        #          logging_pki_files.{ca_cert_src,ca_cert} is defined
+        # Otherwise it fails.
+        - name: Check tls is enabled in forwards output or remote input and logging_pki_files
+          fail:
+            msg: "Error: tls is enabled in {{ item.0.name }}; you must specify logging_pki_files ca_cert_src and/or ca_cert in the playbook var section."
+          loop: "{{ [__logging_forwards_tls, __logging_remote_tls] }}"
+          when:
+            - item | length > 0
+            - not (logging_pki_files.0.ca_cert_src | d() or logging_pki_files.0.ca_cert | d())
 
-    - name: Copy local ca_cert file to the target if needed
+        - name: Copy local ca_cert file to the target if needed
+          vars:
+            __pki_file: '{{ logging_pki_files.0.ca_cert_src | basename }}'
+          copy:
+            src: '{{ logging_pki_files.0.ca_cert_src }}'
+            dest: '{{ logging_pki_files.0.ca_cert if logging_pki_files.0.ca_cert is defined else (__rsyslog_default_pki_path + __rsyslog_default_pki_cert_dir + __pki_file) }}'
+            mode: "0600"
+          when:
+            - __logging_forwards_tls | length > 0 or __logging_remote_tls | length > 0
+            - logging_pki_files.0.ca_cert_src | d("")
+          notify: restart rsyslogd
+
+        - name: Copy local cert file to the target if needed
+          vars:
+            __pki_file: '{{ logging_pki_files.0.cert_src | basename }}'
+          copy:
+            src: '{{ logging_pki_files.0.cert_src }}'
+            dest: '{{ logging_pki_files.0.cert if logging_pki_files.0.cert is defined else (__rsyslog_default_pki_path + __rsyslog_default_pki_cert_dir + __pki_file) }}'
+            mode: "0600"
+          when:
+            - __logging_forwards_tls | length > 0 or __logging_remote_tls | length > 0
+            - logging_pki_files.0.cert_src | d("")
+          notify: restart rsyslogd
+
+        - name: Copy local key file to the target if needed
+          vars:
+            __pki_file: '{{ logging_pki_files.0.private_key_src | basename }}'
+          copy:
+            src: '{{ logging_pki_files.0.private_key_src }}'
+            dest: '{{ logging_pki_files.0.private_key if logging_pki_files.0.private_key is defined else (__rsyslog_default_pki_path + __rsyslog_default_pki_key_dir + __pki_file) }}'
+            mode: "0400"
+          when:
+            - __logging_forwards_tls | length > 0 or __logging_remote_tls | length > 0
+            - logging_pki_files.0.private_key_src | d("")
+          notify: restart rsyslogd
+
       vars:
-        __pki_file: '{{ logging_pki_files.0.ca_cert_src | basename }}'
-      copy:
-        src: '{{ logging_pki_files.0.ca_cert_src }}'
-        dest: '{{ logging_pki_files.0.ca_cert if logging_pki_files.0.ca_cert is defined else (__rsyslog_default_pki_path + __rsyslog_default_pki_cert_dir + __pki_file) }}'
-        mode: "0600"
+        __logging_forwards_tls: "{{ logging_outputs | selectattr('type', '==', 'forwards') |
+                                  selectattr('pki', 'defined') |
+                                  selectattr('pki', '==', 'tls') | list }}"
+        __logging_remote_tls: "{{ logging_inputs | selectattr('type', '==', 'remote') |
+                                  selectattr('tcp_ports', 'defined') |
+                                  selectattr('pki', 'defined') |
+                                  selectattr('pki', '==', 'tls') | list }}"
+
       when:
         - __rsyslog_enabled | bool
-        - __rsyslog_pki_map[logging_pki] | d("ptcp") != "ptcp"
-        - logging_pki_files.0.ca_cert_src | d("")
-      notify: restart rsyslogd
-
-    - name: Copy local cert file to the target if needed
-      vars:
-        __pki_file: '{{ logging_pki_files.0.cert_src | basename }}'
-      copy:
-        src: '{{ logging_pki_files.0.cert_src }}'
-        dest: '{{ logging_pki_files.0.cert if logging_pki_files.0.cert is defined else (__rsyslog_default_pki_path + __rsyslog_default_pki_cert_dir + __pki_file) }}'
-        mode: "0600"
-      when:
-        - __rsyslog_enabled | bool
-        - __rsyslog_pki_map[logging_pki] | d("ptcp") != "ptcp"
-        - logging_pki_files.0.cert_src | d("")
-      notify: restart rsyslogd
-
-    - name: Copy local key file to the target if needed
-      vars:
-        __pki_file: '{{ logging_pki_files.0.private_key_src | basename }}'
-      copy:
-        src: '{{ logging_pki_files.0.private_key_src }}'
-        dest: '{{ logging_pki_files.0.private_key if logging_pki_files.0.private_key is defined else (__rsyslog_default_pki_path + __rsyslog_default_pki_key_dir + __pki_file) }}'
-        mode: "0400"
-      when:
-        - __rsyslog_enabled | bool
-        - __rsyslog_pki_map[logging_pki] | d("ptcp") != "ptcp"
-        - logging_pki_files.0.private_key_src | d("")
-      notify: restart rsyslogd
 
     - name: Include input sub-vars
       include_vars:

--- a/roles/rsyslog/templates/global.j2
+++ b/roles/rsyslog/templates/global.j2
@@ -1,12 +1,14 @@
-{% set ns = namespace() %}
+{% set ns = namespace(ca_cert_path = '', cert_path = '', key_path = '') %}
 {% if __rsyslog_default_netstream_driver != "ptcp" %}
 {%   set __ca_cert_file = logging_pki_files.0.ca_cert_src | d(__rsyslog_default_pki_ca_cert_name) | basename %}
 {%   set ns.ca_cert_path = logging_pki_files.0.ca_cert |
                            d(__rsyslog_default_pki_path + __rsyslog_default_pki_cert_dir + __ca_cert_file) %}
-{%   if logging_pki_authmode != "anon" %}
+{%   if logging_pki_files.0.cert_src | d() or logging_pki_files.0.cert | d() %}
 {%     set __cert_file = logging_pki_files.0.cert_src | d(__rsyslog_default_pki_cert_name) | basename %}
 {%     set ns.cert_path = logging_pki_files.0.cert |
                           d(__rsyslog_default_pki_path + __rsyslog_default_pki_cert_dir + __cert_file) %}
+{%   endif %}
+{%   if logging_pki_files.0.private_key_src | d() or logging_pki_files.0.private_key | d() %}
 {%     set __key_file = logging_pki_files.0.private_key_src | d(__rsyslog_default_pki_key_name) | basename %}
 {%     set ns.key_path = logging_pki_files.0.private_key |
                          d(__rsyslog_default_pki_path + __rsyslog_default_pki_key_dir + __key_file) %}
@@ -15,10 +17,12 @@
 global(
   defaultNetstreamDriver="{{ __rsyslog_default_netstream_driver }}"
   workDirectory="{{ rsyslog_work_dir }}"
-{% if __rsyslog_default_netstream_driver != "ptcp" %}
+{% if ns.ca_cert_path != '' %}
   defaultNetstreamDriverCAFile="{{ ns.ca_cert_path }}"
-{%   if logging_pki_authmode != "anon" %}
+{%   if ns.cert_path != '' %}
   defaultNetstreamDriverCertFile="{{ ns.cert_path }}"
+{%   endif %}
+{%   if ns.key_path != '' %}
   defaultNetstreamDriverKeyFile="{{ ns.key_path }}"
 {%   endif %}
 {% endif %}

--- a/roles/rsyslog/templates/global.j2
+++ b/roles/rsyslog/templates/global.j2
@@ -2,14 +2,14 @@
 {% if __rsyslog_default_netstream_driver != "ptcp" %}
 {%   set __ca_cert_file = logging_pki_files.0.ca_cert_src | d(__rsyslog_default_pki_ca_cert_name) | basename %}
 {%   set ns.ca_cert_path = logging_pki_files.0.ca_cert |
-		                   d(__rsyslog_default_pki_path + __rsyslog_default_pki_cert_dir + __ca_cert_file) %}
+                           d(__rsyslog_default_pki_path + __rsyslog_default_pki_cert_dir + __ca_cert_file) %}
 {%   if logging_pki_authmode != "anon" %}
 {%     set __cert_file = logging_pki_files.0.cert_src | d(__rsyslog_default_pki_cert_name) | basename %}
 {%     set ns.cert_path = logging_pki_files.0.cert |
-		                  d(__rsyslog_default_pki_path + __rsyslog_default_pki_cert_dir + __cert_file) %}
+                          d(__rsyslog_default_pki_path + __rsyslog_default_pki_cert_dir + __cert_file) %}
 {%     set __key_file = logging_pki_files.0.private_key_src | d(__rsyslog_default_pki_key_name) | basename %}
 {%     set ns.key_path = logging_pki_files.0.private_key |
-		                 d(__rsyslog_default_pki_path + __rsyslog_default_pki_key_dir + __key_file) %}
+                         d(__rsyslog_default_pki_path + __rsyslog_default_pki_key_dir + __key_file) %}
 {%   endif %}
 {% endif %}
 global(

--- a/roles/rsyslog/templates/global.j2
+++ b/roles/rsyslog/templates/global.j2
@@ -1,21 +1,20 @@
 {% set ns = namespace(ca_cert_path = '', cert_path = '', key_path = '') %}
-{% if __rsyslog_default_netstream_driver != "ptcp" %}
+{% if logging_pki_files.0.ca_cert_src | d() or logging_pki_files.0.ca_cert | d() %}
 {%   set __ca_cert_file = logging_pki_files.0.ca_cert_src | d(__rsyslog_default_pki_ca_cert_name) | basename %}
 {%   set ns.ca_cert_path = logging_pki_files.0.ca_cert |
                            d(__rsyslog_default_pki_path + __rsyslog_default_pki_cert_dir + __ca_cert_file) %}
-{%   if logging_pki_files.0.cert_src | d() or logging_pki_files.0.cert | d() %}
-{%     set __cert_file = logging_pki_files.0.cert_src | d(__rsyslog_default_pki_cert_name) | basename %}
-{%     set ns.cert_path = logging_pki_files.0.cert |
-                          d(__rsyslog_default_pki_path + __rsyslog_default_pki_cert_dir + __cert_file) %}
-{%   endif %}
-{%   if logging_pki_files.0.private_key_src | d() or logging_pki_files.0.private_key | d() %}
-{%     set __key_file = logging_pki_files.0.private_key_src | d(__rsyslog_default_pki_key_name) | basename %}
-{%     set ns.key_path = logging_pki_files.0.private_key |
-                         d(__rsyslog_default_pki_path + __rsyslog_default_pki_key_dir + __key_file) %}
-{%   endif %}
+{% endif %}
+{% if logging_pki_files.0.cert_src | d() or logging_pki_files.0.cert | d() %}
+{%   set __cert_file = logging_pki_files.0.cert_src | d(__rsyslog_default_pki_cert_name) | basename %}
+{%   set ns.cert_path = logging_pki_files.0.cert |
+                        d(__rsyslog_default_pki_path + __rsyslog_default_pki_cert_dir + __cert_file) %}
+{% endif %}
+{% if logging_pki_files.0.private_key_src | d() or logging_pki_files.0.private_key | d() %}
+{%   set __key_file = logging_pki_files.0.private_key_src | d(__rsyslog_default_pki_key_name) | basename %}
+{%   set ns.key_path = logging_pki_files.0.private_key |
+                       d(__rsyslog_default_pki_path + __rsyslog_default_pki_key_dir + __key_file) %}
 {% endif %}
 global(
-  defaultNetstreamDriver="{{ __rsyslog_default_netstream_driver }}"
   workDirectory="{{ rsyslog_work_dir }}"
 {% if ns.ca_cert_path != '' %}
   defaultNetstreamDriverCAFile="{{ ns.ca_cert_path }}"

--- a/roles/rsyslog/templates/input_remote.j2
+++ b/roles/rsyslog/templates/input_remote.j2
@@ -2,10 +2,12 @@
 # Log messages from remote hosts over UDP
 input(name="{{ item.name }}" type="imudp" port="{{ item.udp_port | d(__rsyslog_default_port) }}")
 {% elif item.tcp_port | d() %}
+{%   if __rsyslog_default_netstream_driver == "ptcp" %}
 # Log messages from remote hosts over plain TCP
 input(name="{{ item.name }}" type="imptcp" port="{{ item.tcp_port | d(__rsyslog_default_port) }}")
-{% else %}
+{%   else %}
 # Log messages from remote hosts over TLS
-input(name="{{ item.name }}" type="imtcp" port="{{ item.tcp_tls_port | d(__rsyslog_default_tls_port) }}")
+input(name="{{ item.name }}" type="imtcp" port="{{ item.tcp_port | d(__rsyslog_default_tls_port) }}")
+{%   endif %}
 {% endif %}
 {{ lookup('template', 'input_template.j2') }}

--- a/roles/rsyslog/templates/input_remote.j2
+++ b/roles/rsyslog/templates/input_remote.j2
@@ -1,13 +1,41 @@
-{% if item.udp_port | d() %}
+{% if item.udp_ports | d([]) %}
 # Log messages from remote hosts over UDP
-input(name="{{ item.name }}" type="imudp" port="{{ item.udp_port | d(__rsyslog_default_port) }}")
-{% elif item.tcp_port | d() %}
-{%   if __rsyslog_default_netstream_driver == "ptcp" %}
+{%   set __logging_loop_index = loop.index %}
+input(name="{{ item.name }}" type="imudp" port=["{{ item.udp_ports | join('","') }}"])
+{{ lookup('template', 'input_template.j2') }}
+{% endif %}
+{% set rsyslog_flows = logging_flows | d([ {"name": "default_flow", "inputs": [ item.name ], "outputs": ["default_files"]} ], true) %}
+{% set outdict = {} %}
+{% for flow in rsyslog_flows %}
+{%   if flow.inputs | intersect([ item.name ]) %}
+{%     for oname in flow.outputs %}
+{%       set _ = outdict.__setitem__(oname, outdict.get(oname,[])|union([ item.name ])) %}
+{%     endfor %}
+{%   endif %}
+{% endfor %}
+{% for tport in item.tcp_ports | d([]) %}
+{%   set __logging_loop_index = loop.index %}
+{%   if __rsyslog_default_netstream_driver == "ptcp" or item.pki | d() != 'tls' %}
 # Log messages from remote hosts over plain TCP
-input(name="{{ item.name }}" type="imptcp" port="{{ item.tcp_port | d(__rsyslog_default_port) }}")
+input(name="{{ item.name }}_{{ __logging_loop_index }}" type="imptcp" port="{{ tport }}")
 {%   else %}
 # Log messages from remote hosts over TLS
-input(name="{{ item.name }}" type="imtcp" port="{{ item.tcp_port | d(__rsyslog_default_tls_port) }}")
+input(name="{{ item.name }}_{{ __logging_loop_index }}" type="imtcp" port="{{ tport }}")
 {%   endif %}
-{% endif %}
-{{ lookup('template', 'input_template.j2') }}
+{%   for output in rsyslog_outputs %}
+{%     if outdict[output.name] | d(false) %}
+if
+{%       for inputname in outdict[output.name] %}
+{%         if inputname == item.name %}
+{%           if not loop.first %}
+  or
+{%           endif %}
+  ($inputname == "{{ item.name }}_{{ __logging_loop_index }}" )
+{%         endif %}
+{%       endfor %}
+  then {
+    call {{ output.name }}
+}
+{%     endif %}
+{%   endfor %}
+{% endfor %}

--- a/roles/rsyslog/templates/input_remote.j2
+++ b/roles/rsyslog/templates/input_remote.j2
@@ -15,7 +15,7 @@ input(name="{{ item.name }}" type="imudp" port=["{{ item.udp_ports | join('","')
 {% endfor %}
 {% for tport in item.tcp_ports | d([]) %}
 {%   set __logging_loop_index = loop.index %}
-{%   if __rsyslog_default_netstream_driver == "ptcp" or item.pki | d() != 'tls' %}
+{%   if item.pki | d() != 'tls' %}
 # Log messages from remote hosts over plain TCP
 input(name="{{ item.name }}_{{ __logging_loop_index }}" type="imptcp" port="{{ tport }}")
 {%   else %}

--- a/roles/rsyslog/templates/input_remote_module.j2
+++ b/roles/rsyslog/templates/input_remote_module.j2
@@ -14,8 +14,12 @@ module(load="imtcp"
        StreamDriver.Mode="1"
        StreamDriver.AuthMode="{{ item.pki_authmode | d(__rsyslog_default_pki_authmode) }}"
 {%     if item.pki_authmode | d() != 'anon' %}
-       PermittedPeer=["{{ item.permitted_peers | join('","') }}"]
+{%       if item.permitted_clients | d() %}
+       PermittedPeer=["{{ item.permitted_clients | join('","') }}"]
+{%       else %}
+       PermittedPeer=["*.{{ logging_domain }}"]
 {%       endif %}
+{%     endif %}
 )
 {%   endif %}
 {% endif %}

--- a/roles/rsyslog/templates/input_remote_module.j2
+++ b/roles/rsyslog/templates/input_remote_module.j2
@@ -1,20 +1,9 @@
-{% set ns = namespace(use_tcp = false, use_udp = false) %}
-{% for elm in logging_inputs %}
-{%   if elm.type == 'remote' %}
-{%     if elm.tcp_port is defined %}
-{%       set ns.use_tcp = true %}
-{%     elif elm.udp_port is defined %}
-{%       set ns.use_udp = true %}
-{%     endif %}
-{%   endif %}
-{% endfor %}
-{% if ns.use_udp %}
+{% if item.udp_port is defined %}
 # Read messages sent over UDP
 module(load="imudp" threads="{{ logging_udp_threads }}"
        TimeRequery="{{ logging_udp_system_time_requery }}"
        BatchSize="{{ logging_udp_batch_size }}")
-{% endif %}
-{% if ns.use_tcp %}
+{% elif item.tcp_port is defined %}
 {%   if __rsyslog_default_netstream_driver == "ptcp" %}
 # Read messages sent over plain TCP
 module(load="imptcp" threads="{{ logging_tcp_threads }}")
@@ -23,14 +12,10 @@ module(load="imptcp" threads="{{ logging_tcp_threads }}")
 module(load="imtcp"
        StreamDriver.Name="{{ __rsyslog_default_netstream_driver }}"
        StreamDriver.Mode="1"
-       StreamDriver.AuthMode="{{ logging_pki_authmode }}"
-{%     if logging_pki_authmode != "anon" %}
-{%       if logging_permitted_peers is string %}
-       PermittedPeer="{{ logging_permitted_peers }}"
-{%       else %}
-       PermittedPeer=["{{ logging_permitted_peers | join('","') }}"]
+       StreamDriver.AuthMode="{{ item.pki_authmode | d(__rsyslog_default_pki_authmode) }}"
+{%     if item.pki_authmode | d() != 'anon' %}
+       PermittedPeer=["{{ item.permitted_peers | join('","') }}"]
 {%       endif %}
-{%     endif %}
 )
 {%   endif %}
 {% endif %}

--- a/roles/rsyslog/templates/input_remote_module.j2
+++ b/roles/rsyslog/templates/input_remote_module.j2
@@ -1,10 +1,10 @@
-{% if item.udp_port is defined %}
+{% if item.udp_ports is defined %}
 # Read messages sent over UDP
 module(load="imudp" threads="{{ logging_udp_threads }}"
        TimeRequery="{{ logging_udp_system_time_requery }}"
        BatchSize="{{ logging_udp_batch_size }}")
-{% elif item.tcp_port is defined %}
-{%   if __rsyslog_default_netstream_driver == "ptcp" %}
+{% elif item.tcp_ports is defined %}
+{%   if item.pki | d() != 'tls' %}
 # Read messages sent over plain TCP
 module(load="imptcp" threads="{{ logging_tcp_threads }}")
 {%   else %}

--- a/roles/rsyslog/templates/input_remote_module.j2
+++ b/roles/rsyslog/templates/input_remote_module.j2
@@ -1,41 +1,37 @@
-{% set ns0 = namespace(use_tls = false) %}
-{% set ns1 = namespace(use_tcp = false) %}
-{% set ns2 = namespace(use_udp = false) %}
+{% set ns = namespace(use_tcp = false, use_udp = false) %}
 {% for elm in logging_inputs %}
 {%   if elm.type == 'remote' %}
-{%     if elm.tcp_tls_port is defined %}
-{%       set ns0.use_tls = true %}
-{%     elif elm.tcp_port is defined %}
-{%       set ns1.use_tcp = true %}
+{%     if elm.tcp_port is defined %}
+{%       set ns.use_tcp = true %}
 {%     elif elm.udp_port is defined %}
-{%       set ns2.use_udp = true %}
+{%       set ns.use_udp = true %}
 {%     endif %}
 {%   endif %}
 {% endfor %}
-{% if ns2.use_udp %}
-# Read messages sent over plain TCP
+{% if ns.use_udp %}
+# Read messages sent over UDP
 module(load="imudp" threads="{{ logging_udp_threads }}"
        TimeRequery="{{ logging_udp_system_time_requery }}"
        BatchSize="{{ logging_udp_batch_size }}")
 {% endif %}
-{% if ns1.use_tcp %}
-# Read messages sent over UDP
+{% if ns.use_tcp %}
+{%   if __rsyslog_default_netstream_driver == "ptcp" %}
+# Read messages sent over plain TCP
 module(load="imptcp" threads="{{ logging_tcp_threads }}")
-{% endif %}
-{% if ns0.use_tls %}
+{%   else %}
 # Read messages sent over TCP with TLS
-module(
-  load="imtcp"
-  threads="{{ logging_tcp_threads }}"
-  streamDriver.name="{{ __rsyslog_default_netstream_driver }}"
-  streamDriver.mode="1"
-  streamDriver.authMode="{{ rsyslog_default_driver_authmode }}"
-{%   if rsyslog_default_driver_authmode != "anon" %}
-{%     if logging_permitted_peers is string %}
-    permittedPeer="{{ logging_permitted_peers }}"
-{%     else %}
-    permittedPeer=["{{ logging_permitted_peers | join('","') }}"]
-{% endif %}
-{%   endif %}
+module(load="imtcp"
+       threads="{{ logging_tcp_threads }}"
+       StreamDriver.Name="{{ __rsyslog_default_netstream_driver }}"
+       StreamDriver.Mode="1"
+       StreamDriver.AuthMode="{{ logging_pki_authmode }}"
+{%     if logging_pki_authmode != "anon" %}
+{%       if logging_permitted_peers is string %}
+       PermittedPeer="{{ logging_permitted_peers }}"
+{%       else %}
+       PermittedPeer=["{{ logging_permitted_peers | join('","') }}"]
+{%       endif %}
+{%     endif %}
 )
+{%   endif %}
 {% endif %}

--- a/roles/rsyslog/templates/input_remote_module.j2
+++ b/roles/rsyslog/templates/input_remote_module.j2
@@ -21,7 +21,6 @@ module(load="imptcp" threads="{{ logging_tcp_threads }}")
 {%   else %}
 # Read messages sent over TCP with TLS
 module(load="imtcp"
-       threads="{{ logging_tcp_threads }}"
        StreamDriver.Name="{{ __rsyslog_default_netstream_driver }}"
        StreamDriver.Mode="1"
        StreamDriver.AuthMode="{{ logging_pki_authmode }}"

--- a/roles/rsyslog/templates/input_remote_module.j2
+++ b/roles/rsyslog/templates/input_remote_module.j2
@@ -10,7 +10,7 @@ module(load="imptcp" threads="{{ logging_tcp_threads }}")
 {%   else %}
 # Read messages sent over TCP with TLS
 module(load="imtcp"
-       StreamDriver.Name="{{ __rsyslog_default_netstream_driver }}"
+       StreamDriver.Name="{{ __rsyslog_tls_netstream_driver }}"
        StreamDriver.Mode="1"
        StreamDriver.AuthMode="{{ item.pki_authmode | d(__rsyslog_default_pki_authmode) }}"
 {%     if item.pki_authmode | d() != 'anon' %}

--- a/roles/rsyslog/templates/output_forwards.j2
+++ b/roles/rsyslog/templates/output_forwards.j2
@@ -15,8 +15,8 @@ ruleset(name="{{ item.name }}") {
         Protocol="{{ item.protocol | d('tcp') }}"
         StreamDriver="{{ __rsyslog_default_netstream_driver }}"
         StreamDriverMode="1"
-        StreamDriverAuthMode="{{ logging_pki_authmode }}"
-        StreamDriverPermittedPeers="{{ logging_send_permitted_peers }}"
+        StreamDriverAuthMode="{{ item.pki_authmode | d(__rsyslog_default_pki_authmode) }}"
+        StreamDriverPermittedPeers="{{ item.permitted_peers | d(logging_domain) }}"
     )
 {%   endif %}
 {% else %}
@@ -35,8 +35,8 @@ ruleset(name="{{ item.name }}") {
         Protocol="{{ item.protocol | d('tcp') }}"
         StreamDriver="{{ __rsyslog_default_netstream_driver }}"
         StreamDriverMode="1"
-        StreamDriverAuthMode="{{ logging_pki_authmode }}"
-        StreamDriverPermittedPeers="{{ logging_send_permitted_peers }}"
+        StreamDriverAuthMode="{{ item.pki_authmode | d(__rsyslog_default_pki_authmode) }}"
+        StreamDriverPermittedPeers="{{ item.permitted_peers | d(logging_domain) }}"
     )
 {%   endif %}
 {% endif %}

--- a/roles/rsyslog/templates/output_forwards.j2
+++ b/roles/rsyslog/templates/output_forwards.j2
@@ -1,43 +1,32 @@
+{% if item.tcp_port | d() %}
+{%   set __forwards_port = item.tcp_port %}
+{%   set __forwards_protocol = 'tcp' %}
+{% elif item.udp_port | d() %}
+{%   set __forwards_port = item.udp_port %}
+{%   set __forwards_protocol = 'udp' %}
+{% else %}
+{%   set __forwards_port = '' %}
+{%   set __forwards_protocol = '' %}
+{% endif %}
 ruleset(name="{{ item.name }}") {
 {% if item.exclude | d([]) %}
-{%   if item.pki | d() != "tls" %}
     {{ item.facility | d('*') }}.{{ item.severity | d('*') }};{{ item.exclude | join(';') }} action(name="{{ item.name }}"
-        type="omfwd"
-        Target="{{ item.target }}"
-        Port="{{ item.port | d(__rsyslog_default_port) }}"
-        Protocol="{{ item.protocol | d('tcp') }}"
-    )
-{%   else %}
-    {{ item.facility | d('*') }}.{{ item.severity | d('*') }};{{ item.exclude | join(';') }} action(name="{{ item.name }}"
-        type="omfwd"
-        Target="{{ item.target }}"
-        Port="{{ item.port | d(__rsyslog_default_tls_port) }}"
-        Protocol="{{ item.protocol | d('tcp') }}"
-        StreamDriver="{{ __rsyslog_tls_netstream_driver }}"
-        StreamDriverMode="1"
-        StreamDriverAuthMode="{{ item.pki_authmode | d(__rsyslog_default_pki_authmode) }}"
-        StreamDriverPermittedPeers="{{ item.permitted_server | d('*.' + logging_domain) }}"
-    )
-{%   endif %}
 {% else %}
-{%   if item.pki | d() != "tls" %}
     {{ item.facility | d('*') }}.{{ item.severity | d('*') }} action(name="{{ item.name }}"
+{% endif %}
         type="omfwd"
         Target="{{ item.target }}"
-        Port="{{ item.port | d(__rsyslog_default_port) }}"
-        Protocol="{{ item.protocol | d('tcp') }}"
-    )
-{%   else %}
-    {{ item.facility | d('*') }}.{{ item.severity | d('*') }} action(name="{{ item.name }}"
-        type="omfwd"
-        Target="{{ item.target }}"
-        Port="{{ item.port | d(__rsyslog_default_tls_port) }}"
-        Protocol="{{ item.protocol | d('tcp') }}"
+{% if item.pki | d() == "tls" %}
         StreamDriver="{{ __rsyslog_tls_netstream_driver }}"
         StreamDriverMode="1"
         StreamDriverAuthMode="{{ item.pki_authmode | d(__rsyslog_default_pki_authmode) }}"
         StreamDriverPermittedPeers="{{ item.permitted_server | d('*.' + logging_domain) }}"
-    )
-{%   endif %}
 {% endif %}
+{% if __forwards_port != '' %}
+        Port="{{ __forwards_port }}"
+{% endif %}
+{% if __forwards_protocol != '' %}
+        Protocol="{{ __forwards_protocol }}"
+{% endif %}
+    )
 }

--- a/roles/rsyslog/templates/output_forwards.j2
+++ b/roles/rsyslog/templates/output_forwards.j2
@@ -16,7 +16,7 @@ ruleset(name="{{ item.name }}") {
         StreamDriver="{{ __rsyslog_default_netstream_driver }}"
         StreamDriverMode="1"
         StreamDriverAuthMode="{{ item.pki_authmode | d(__rsyslog_default_pki_authmode) }}"
-        StreamDriverPermittedPeers="{{ item.permitted_peers | d(logging_domain) }}"
+        StreamDriverPermittedPeers="{{ item.permitted_server | d('*.' + logging_domain) }}"
     )
 {%   endif %}
 {% else %}
@@ -36,7 +36,7 @@ ruleset(name="{{ item.name }}") {
         StreamDriver="{{ __rsyslog_default_netstream_driver }}"
         StreamDriverMode="1"
         StreamDriverAuthMode="{{ item.pki_authmode | d(__rsyslog_default_pki_authmode) }}"
-        StreamDriverPermittedPeers="{{ item.permitted_peers | d(logging_domain) }}"
+        StreamDriverPermittedPeers="{{ item.permitted_server | d('*.' + logging_domain) }}"
     )
 {%   endif %}
 {% endif %}

--- a/roles/rsyslog/templates/output_forwards.j2
+++ b/roles/rsyslog/templates/output_forwards.j2
@@ -1,6 +1,6 @@
 ruleset(name="{{ item.name }}") {
 {% if item.exclude | d([]) %}
-{%   if __rsyslog_default_netstream_driver == "ptcp" or item.pki | d() != "tls" %}
+{%   if item.pki | d() != "tls" %}
     {{ item.facility | d('*') }}.{{ item.severity | d('*') }};{{ item.exclude | join(';') }} action(name="{{ item.name }}"
         type="omfwd"
         Target="{{ item.target }}"
@@ -13,14 +13,14 @@ ruleset(name="{{ item.name }}") {
         Target="{{ item.target }}"
         Port="{{ item.port | d(__rsyslog_default_tls_port) }}"
         Protocol="{{ item.protocol | d('tcp') }}"
-        StreamDriver="{{ __rsyslog_default_netstream_driver }}"
+        StreamDriver="{{ __rsyslog_tls_netstream_driver }}"
         StreamDriverMode="1"
         StreamDriverAuthMode="{{ item.pki_authmode | d(__rsyslog_default_pki_authmode) }}"
         StreamDriverPermittedPeers="{{ item.permitted_server | d('*.' + logging_domain) }}"
     )
 {%   endif %}
 {% else %}
-{%   if __rsyslog_default_netstream_driver == "ptcp" or item.pki | d() != "tls" %}
+{%   if item.pki | d() != "tls" %}
     {{ item.facility | d('*') }}.{{ item.severity | d('*') }} action(name="{{ item.name }}"
         type="omfwd"
         Target="{{ item.target }}"
@@ -33,7 +33,7 @@ ruleset(name="{{ item.name }}") {
         Target="{{ item.target }}"
         Port="{{ item.port | d(__rsyslog_default_tls_port) }}"
         Protocol="{{ item.protocol | d('tcp') }}"
-        StreamDriver="{{ __rsyslog_default_netstream_driver }}"
+        StreamDriver="{{ __rsyslog_tls_netstream_driver }}"
         StreamDriverMode="1"
         StreamDriverAuthMode="{{ item.pki_authmode | d(__rsyslog_default_pki_authmode) }}"
         StreamDriverPermittedPeers="{{ item.permitted_server | d('*.' + logging_domain) }}"

--- a/roles/rsyslog/templates/output_forwards.j2
+++ b/roles/rsyslog/templates/output_forwards.j2
@@ -1,7 +1,43 @@
 ruleset(name="{{ item.name }}") {
-{%   if item.exclude | d([]) %}
-    {{ item.facility | d('*') }}.{{ item.severity | d('*') }};{{ item.exclude | join(';') }} action(name="{{ item.name }}" type="omfwd" Target="{{ item.target }}" Port="{{ item.port | d(514) }}" Protocol="{{ item.protocol | d('tcp') }}")
+{% if item.exclude | d([]) %}
+{%   if __rsyslog_default_netstream_driver == "ptcp" %}
+    {{ item.facility | d('*') }}.{{ item.severity | d('*') }};{{ item.exclude | join(';') }} action(name="{{ item.name }}"
+        type="omfwd"
+        Target="{{ item.target }}"
+        Port="{{ item.port | d(__rsyslog_default_port) }}"
+        Protocol="{{ item.protocol | d('tcp') }}"
+    )
+{%   else %}
+    {{ item.facility | d('*') }}.{{ item.severity | d('*') }};{{ item.exclude | join(';') }} action(name="{{ item.name }}"
+        type="omfwd"
+        Target="{{ item.target }}"
+        Port="{{ item.port | d(__rsyslog_default_tls_port) }}"
+        Protocol="{{ item.protocol | d('tcp') }}"
+        StreamDriver="{{ __rsyslog_default_netstream_driver }}"
+        StreamDriverMode="1"
+        StreamDriverAuthMode="{{ logging_pki_authmode }}"
+        StreamDriverPermittedPeers="{{ logging_send_permitted_peers }}"
+    )
+{%   endif %}
 {% else %}
-    {{ item.facility | d('*') }}.{{ item.severity | d('*') }} action(name="{{ item.name }}" type="omfwd" Target="{{ item.target }}" Port="{{ item.port | d(514) }}" Protocol="{{ item.protocol | d('tcp') }}")
+{%   if __rsyslog_default_netstream_driver == "ptcp" %}
+    {{ item.facility | d('*') }}.{{ item.severity | d('*') }} action(name="{{ item.name }}"
+        type="omfwd"
+        Target="{{ item.target }}"
+        Port="{{ item.port | d(__rsyslog_default_port) }}"
+        Protocol="{{ item.protocol | d('tcp') }}"
+    )
+{%   else %}
+    {{ item.facility | d('*') }}.{{ item.severity | d('*') }} action(name="{{ item.name }}"
+        type="omfwd"
+        Target="{{ item.target }}"
+        Port="{{ item.port | d(__rsyslog_default_tls_port) }}"
+        Protocol="{{ item.protocol | d('tcp') }}"
+        StreamDriver="{{ __rsyslog_default_netstream_driver }}"
+        StreamDriverMode="1"
+        StreamDriverAuthMode="{{ logging_pki_authmode }}"
+        StreamDriverPermittedPeers="{{ logging_send_permitted_peers }}"
+    )
+{%   endif %}
 {% endif %}
 }

--- a/roles/rsyslog/templates/output_forwards.j2
+++ b/roles/rsyslog/templates/output_forwards.j2
@@ -1,6 +1,6 @@
 ruleset(name="{{ item.name }}") {
 {% if item.exclude | d([]) %}
-{%   if __rsyslog_default_netstream_driver == "ptcp" %}
+{%   if __rsyslog_default_netstream_driver == "ptcp" or item.pki | d() != "tls" %}
     {{ item.facility | d('*') }}.{{ item.severity | d('*') }};{{ item.exclude | join(';') }} action(name="{{ item.name }}"
         type="omfwd"
         Target="{{ item.target }}"
@@ -20,7 +20,7 @@ ruleset(name="{{ item.name }}") {
     )
 {%   endif %}
 {% else %}
-{%   if __rsyslog_default_netstream_driver == "ptcp" %}
+{%   if __rsyslog_default_netstream_driver == "ptcp" or item.pki | d() != "tls" %}
     {{ item.facility | d('*') }}.{{ item.severity | d('*') }} action(name="{{ item.name }}"
         type="omfwd"
         Target="{{ item.target }}"

--- a/roles/rsyslog/vars/main.yml
+++ b/roles/rsyslog/vars/main.yml
@@ -55,6 +55,11 @@ __rsyslog_default_pki_cert_name: "cert.pem"
 #
 __rsyslog_default_pki_authmode: "x509/name"
 
+# communication over tls
+#
+
+__rsyslog_tls_netstream_driver: "gtls"
+
 # Rsyslog configuration rules
 # ---------------------------
 
@@ -84,12 +89,3 @@ rsyslog_weight_map:
   'rulesets': '50'
   'input': '90'
   'inputs': '90'
-
-# X.509 certificates related variables
-# Lookup rsyslog network stream driver
-__rsyslog_pki_map:
-  none: ptcp
-  ptcp: ptcp
-  tls: gtls
-  gtls: gtls
-  gnutls: gtls

--- a/roles/rsyslog/vars/main.yml
+++ b/roles/rsyslog/vars/main.yml
@@ -51,6 +51,10 @@ __rsyslog_default_pki_key_name: "key.pem"
 #
 __rsyslog_default_pki_cert_name: "cert.pem"
 
+# The default network driver authentication mode.
+#
+__rsyslog_default_pki_authmode: "x509/name"
+
 # Rsyslog configuration rules
 # ---------------------------
 

--- a/roles/rsyslog/vars/outputs/forwards/main.yml
+++ b/roles/rsyslog/vars/outputs/forwards/main.yml
@@ -6,21 +6,4 @@
 
 # List of rpm packages for Forwards output.
 __rsyslog_forwards_output_packages: []
-
-# Forwards Rsyslog output configuration rules
-# ---------------------------------
-__rsyslog_forwards_output_rules:
-  - '{{ __rsyslog_conf_forwards_output_tls_rules }}'
-
-# __rsyslog_conf_forwards_output_rules:
-#
-# Enable log forwarding to another ``rsyslogd`` instance if `rsyslog_output_forwards` variables are defined.
-__rsyslog_conf_forwards_output_tls_rules:
-
-  - name: 'output-forwards-tls'
-    type: 'output'
-    state: '{{ "present" if __rsyslog_default_netstream_driver != "ptcp"
-               else "absent" }}'
-    sections:
-      - comment: 'Forward logs over TLS by default'
-        options: '{{ rsyslog_send_over_tls }}'
+__rsyslog_forwards_output_rules: []

--- a/tests/tests_basics_files2_missing_flows.yml
+++ b/tests/tests_basics_files2_missing_flows.yml
@@ -1,22 +1,11 @@
-# Test the configuration, basics input and 4 configured files output
+# Test the configuration, which flow contains a undefined input bogus_basic_input
 #
 # [Configuration]
-# basics input (imjournal) -> 4 files output (omfile)
-# logging_purge_confs: true
+# logging_flows contains a undefined input bogus_basic_input
 #
 # [Test scenario]
 # 0. Run logging role.
-# 1. Check rsyslog.conf file size.
-#    If logging role is executed, the file size is about 100 bytes.
-#    Thus, assert the size is less than 1000.
-# 2. Check file count in /etc/rsyslog.d.
-#    If logging role is executed, 8 config files are generated.
-#    By setting logging_purge_confs, pre-existing config files are deleted.
-#    Thus, assert the the count is equal to 8.
-# 3. Check systemctl status of rsyslog as well as error or specific message in the output.
-# 4. To verify the generated filename is correct, check the config file of files output exists.
-# 4.1 Check the config file contains the expected filter and the output file as configured.
-# 4.2 Run logger command and check the log is in the local output file {{ __default_system_log }}.
+# 1. An exception is to be captured and check the expected error message was returned or not.
 #
 - name: Ensure that the role runs with parameters from imjournal to four omfile outputs
   hosts: all

--- a/tests/tests_basics_files_forwards.yml
+++ b/tests/tests_basics_files_forwards.yml
@@ -115,6 +115,20 @@
       register: __result
       failed_when: not __result.stat.exists
 
+    - name: Generated a file to check severity_and_facility
+      copy:
+        dest: /tmp/__testfile__
+        content: |
+          # Ansible managed
+          ruleset(name="forwards_severity_and_facility") {
+              local1.info action(name="forwards_severity_and_facility"
+                  type="omfwd"
+                  Target="host.domain"
+                  Port="1514"
+                  Protocol="tcp"
+              )
+          }
+
     - name: Check severity_and_facility
-      command: /bin/grep 'local1.info action(name="forwards_severity_and_facility" type="omfwd" Target="host.domain" Port="1514" Protocol="tcp")' '{{ __test_forwards_conf }}'
+      command: diff -B /tmp/__testfile__ '{{ __test_forwards_conf }}'
       changed_when: false

--- a/tests/tests_basics_files_forwards.yml
+++ b/tests/tests_basics_files_forwards.yml
@@ -50,15 +50,13 @@
             type: forwards
             facility: local1
             severity: info
-            protocol: tcp
             target: host.domain
-            port: 1514
+            tcp_port: 1514
           - name: forwards_facility_only
             type: forwards
             facility: local2
-            protocol: tcp
             target: host.domain
-            port: 2514
+            tcp_port: 2514
         logging_inputs:
           - name: basic_input0
             type: basics

--- a/tests/tests_basics_forwards.yml
+++ b/tests/tests_basics_forwards.yml
@@ -13,9 +13,9 @@
 #    If not executed, the default rsyslog.conf size is larger than 3000 bytes.
 #    Thus, assert the size is less than 1000.
 # 2. Check file count in /etc/rsyslog.d.
-#    If logging role is executed, 12 config files are generated.
+#    If logging role is executed, 11 config files are generated.
 #    By setting logging_purge_confs, pre-existing config files are deleted.
-#    Thus, assert the the count is equal to 12.
+#    Thus, assert the the count is equal to 11.
 # 3. Check systemctl status of rsyslog as well as error or specific message in the output.
 # 4. Check 7 forwards output config files so that they contain the configured action.
 # 5. Check 2 invalid forwards output config did not generate a config file.
@@ -28,7 +28,6 @@
     __test_forward_conf_f: /etc/rsyslog.d/30-output-forwards-forwards_facility_only.conf
     __test_forward_conf_s: /etc/rsyslog.d/30-output-forwards-forwards_severity_only.conf
     __test_forward_conf_no: /etc/rsyslog.d/30-output-forwards-forwards_no_severity_and_facility.conf
-    __test_forward_conf_no_p: /etc/rsyslog.d/30-output-forwards-forwards_no_severity_and_facility_protocol.conf
     __test_forward_conf_no_udp: /etc/rsyslog.d/30-output-forwards-forwards_no_severity_and_facility_udp.conf
     __test_forward_conf_no_p_p: /etc/rsyslog.d/30-output-forwards-forwards_no_severity_and_facility_protocol_port.conf
 
@@ -41,35 +40,26 @@
             type: forwards
             facility: local1
             severity: info
-            protocol: tcp
             target: host.domain
-            port: 1514
+            tcp_port: 1514
           - name: forwards_facility_only
             type: forwards
             facility: local2
-            protocol: tcp
             target: host.domain
-            port: 2514
+            tcp_port: 2514
           - name: forwards_severity_only
             type: forwards
             severity: err
-            protocol: tcp
             target: host.domain
-            port: 3514
+            tcp_port: 3514
           - name: forwards_no_severity_and_facility
             type: forwards
-            protocol: tcp
             target: host.domain
-            port: 4514
-          - name: forwards_no_severity_and_facility_protocol
-            type: forwards
-            target: host.domain
-            port: 5514
+            tcp_port: 4514
           - name: forwards_no_severity_and_facility_udp
             type: forwards
-            protocol: udp
             target: host.domain
-            port: 6514
+            udp_port: 6514
           - name: forwards_no_severity_and_facility_protocol_port
             type: forwards
             target: host.domain
@@ -85,7 +75,7 @@
             inputs: [ basic_input ]
             outputs: [forwards_severity_and_facility, forwards_facility_only,
                       forwards_severity_only, forwards_no_severity_and_facility,
-                      forwards_no_severity_and_facility_protocol, forwards_no_severity_and_facility_udp,
+                      forwards_no_severity_and_facility_udp,
                       forwards_no_severity_and_facility_protocol_port,
                       forwards_no_severity_and_facility_protocol_port_target]
       include_role:
@@ -104,7 +94,7 @@
 
     - name: Check file counts in rsyslog.d
       assert:
-        that: rsyslog_d_file_count.matched == 12
+        that: rsyslog_d_file_count.matched == 11
 
     # Checking 'error' in stdout from systemctl status is for detecting the case in which rsyslog is running,
     # but some functionality is disabled due to some error, e.g., error: 'tls.cacert' file couldn't be accessed.
@@ -191,24 +181,6 @@
       command: diff -B /tmp/__testfile__ '{{ __test_forward_conf_no }}'
       changed_when: false
 
-    - name: Generated a file to check no_severity_and_facility_protocol
-      copy:
-        dest: /tmp/__testfile__
-        content: |
-          # Ansible managed
-          ruleset(name="forwards_no_severity_and_facility_protocol") {
-              *.* action(name="forwards_no_severity_and_facility_protocol"
-                  type="omfwd"
-                  Target="host.domain"
-                  Port="5514"
-                  Protocol="tcp"
-              )
-          }
-
-    - name: Check no_severity_and_facility_protocol
-      command: diff -B /tmp/__testfile__ '{{ __test_forward_conf_no_p }}'
-      changed_when: false
-
     - name: Generated a file to check no_severity_and_facility_udp
       copy:
         dest: /tmp/__testfile__
@@ -236,8 +208,6 @@
               *.* action(name="forwards_no_severity_and_facility_protocol_port"
                   type="omfwd"
                   Target="host.domain"
-                  Port="514"
-                  Protocol="tcp"
               )
           }
 

--- a/tests/tests_basics_forwards.yml
+++ b/tests/tests_basics_forwards.yml
@@ -119,32 +119,130 @@
       register: __result
       failed_when: not __result.stat.exists
 
+    - name: Generated a file to check severity_and_facility
+      copy:
+        dest: /tmp/__testfile__
+        content: |
+          # Ansible managed
+          ruleset(name="forwards_severity_and_facility") {
+              local1.info action(name="forwards_severity_and_facility"
+                  type="omfwd"
+                  Target="host.domain"
+                  Port="1514"
+                  Protocol="tcp"
+              )
+          }
+
     - name: Check severity_and_facility
-      command: /bin/grep 'local1.info action(name="forwards_severity_and_facility" type="omfwd" Target="host.domain" Port="1514" Protocol="tcp")' '{{ __test_forward_conf_s_f }}'
+      command: diff -B /tmp/__testfile__ '{{ __test_forward_conf_s_f }}'
       changed_when: false
 
-    - name: Grep facility_only
-      command: /bin/grep 'local2.\* action(name="forwards_facility_only" type="omfwd" Target="host.domain" Port="2514" Protocol="tcp")' '{{ __test_forward_conf_f }}'
+    - name: Generated a file to check facility_only
+      copy:
+        dest: /tmp/__testfile__
+        content: |
+          # Ansible managed
+          ruleset(name="forwards_facility_only") {
+              local2.* action(name="forwards_facility_only"
+                  type="omfwd"
+                  Target="host.domain"
+                  Port="2514"
+                  Protocol="tcp"
+              )
+          }
+
+    - name: Check facility_only
+      command: diff -B /tmp/__testfile__ '{{ __test_forward_conf_f }}'
       changed_when: false
+
+    - name: Generated a file to check severity_only
+      copy:
+        dest: /tmp/__testfile__
+        content: |
+          # Ansible managed
+          ruleset(name="forwards_severity_only") {
+              *.err action(name="forwards_severity_only"
+                  type="omfwd"
+                  Target="host.domain"
+                  Port="3514"
+                  Protocol="tcp"
+              )
+          }
 
     - name: Check severity_only
-      command: /bin/grep '\*.err action(name="forwards_severity_only" type="omfwd" Target="host.domain" Port="3514" Protocol="tcp")' '{{ __test_forward_conf_s }}'
+      command: diff -B /tmp/__testfile__ '{{ __test_forward_conf_s }}'
       changed_when: false
+
+    - name: Generated a file to check no_severity_and_facility
+      copy:
+        dest: /tmp/__testfile__
+        content: |
+          # Ansible managed
+          ruleset(name="forwards_no_severity_and_facility") {
+              *.* action(name="forwards_no_severity_and_facility"
+                  type="omfwd"
+                  Target="host.domain"
+                  Port="4514"
+                  Protocol="tcp"
+              )
+          }
 
     - name: Check no_severity_and_facility
-      command: /bin/grep '\*.\* action(name="forwards_no_severity_and_facility" type="omfwd" Target="host.domain" Port="4514" Protocol="tcp")' '{{ __test_forward_conf_no }}'
+      command: diff -B /tmp/__testfile__ '{{ __test_forward_conf_no }}'
       changed_when: false
+
+    - name: Generated a file to check no_severity_and_facility_protocol
+      copy:
+        dest: /tmp/__testfile__
+        content: |
+          # Ansible managed
+          ruleset(name="forwards_no_severity_and_facility_protocol") {
+              *.* action(name="forwards_no_severity_and_facility_protocol"
+                  type="omfwd"
+                  Target="host.domain"
+                  Port="5514"
+                  Protocol="tcp"
+              )
+          }
 
     - name: Check no_severity_and_facility_protocol
-      command: /bin/grep '\*\.\* action(name="forwards_no_severity_and_facility_protocol" type="omfwd" Target="host.domain" Port="5514" Protocol="tcp")' '{{ __test_forward_conf_no_p }}'
+      command: diff -B /tmp/__testfile__ '{{ __test_forward_conf_no_p }}'
       changed_when: false
+
+    - name: Generated a file to check no_severity_and_facility_udp
+      copy:
+        dest: /tmp/__testfile__
+        content: |
+          # Ansible managed
+          ruleset(name="forwards_no_severity_and_facility_udp") {
+              *.* action(name="forwards_no_severity_and_facility_udp"
+                  type="omfwd"
+                  Target="host.domain"
+                  Port="6514"
+                  Protocol="udp"
+              )
+          }
 
     - name: Check no_severity_and_facility_udp
-      command: /bin/grep '\*\.\* action(name="forwards_no_severity_and_facility_udp" type="omfwd" Target="host.domain" Port="6514" Protocol="udp")' '{{ __test_forward_conf_no_udp }}'
+      command: diff -B /tmp/__testfile__ '{{ __test_forward_conf_no_udp }}'
       changed_when: false
 
+    - name: Generated a file to check no_severity_and_facility_protocol_port
+      copy:
+        dest: /tmp/__testfile__
+        content: |
+          # Ansible managed
+          ruleset(name="forwards_no_severity_and_facility_protocol_port") {
+              *.* action(name="forwards_no_severity_and_facility_protocol_port"
+                  type="omfwd"
+                  Target="host.domain"
+                  Port="514"
+                  Protocol="tcp"
+              )
+          }
+
     - name: Check no_severity_and_facility_protocol_port
-      command: /bin/grep '\*\.\* action(name="forwards_no_severity_and_facility_protocol_port" type="omfwd" Target="host.domain" Port="514" Protocol="tcp")' '{{ __test_forward_conf_no_p_p }}'
+      command: diff -B /tmp/__testfile__ '{{ __test_forward_conf_no_p_p }}'
       changed_when: false
 
     - name: Grep no_severity_and_facility_protocol_port_target

--- a/tests/tests_basics_forwards_cacert.yml
+++ b/tests/tests_basics_forwards_cacert.yml
@@ -19,9 +19,9 @@
 #    If not executed, the default rsyslog.conf size is larger than 3000 bytes.
 #    Thus, assert the size is less than 1000.
 # 3. Check file count in /etc/rsyslog.d.
-#    If logging role is executed, 7 config files are generated.
+#    If logging role is executed, 6 config files are generated.
 #    By setting logging_purge_confs, pre-existing config files are deleted.
-#    Thus, assert the the count is equal to 7.
+#    Thus, assert the the count is equal to 6.
 # 4. Check systemctl status of rsyslog as well as error or specific message in the output.
 # 5. Check the config file of a forwards output, severity_and_facility contains the expected filter and action.
 # 6. Check the fake ca cert is successfully copied.
@@ -50,6 +50,8 @@
         logging_pki_authmode: anon
         logging_pki_files:
           - ca_cert_src: "{{ __test_ca_cert }}"
+        logging_permitted_peers:
+          - '*.example.com'
         logging_outputs:
           - name: forwards_severity_and_facility
             type: forwards
@@ -81,7 +83,7 @@
 
     - name: Check file counts in rsyslog.d
       assert:
-        that: rsyslog_d_file_count.matched == 7
+        that: rsyslog_d_file_count.matched == 6
 
     # Checking 'error' in stdout from systemctl status is for detecting the case in which rsyslog is running,
     # but some functionality is disabled due to some error, e.g., error: 'tls.cacert' file couldn't be accessed.
@@ -90,8 +92,26 @@
       register: __result
       failed_when: "'error' in __result.stdout or __result is failed"
 
+    - name: Generated a file to check severity_and_facility
+      copy:
+        dest: /tmp/__testfile__
+        content: |
+          # Ansible managed
+          ruleset(name="forwards_severity_and_facility") {
+              local1.info action(name="forwards_severity_and_facility"
+                  type="omfwd"
+                  Target="host.domain"
+                  Port="1514"
+                  Protocol="tcp"
+                  StreamDriver="gtls"
+                  StreamDriverMode="1"
+                  StreamDriverAuthMode="anon"
+                  StreamDriverPermittedPeers="['*.example.com']"
+              )
+          }
+
     - name: Check severity_and_facility
-      command: /bin/grep 'local1.info action(name="forwards_severity_and_facility" type="omfwd" Target="host.domain" Port="1514" Protocol="tcp")' '{{ __test_forward_conf_s_f }}'
+      command: diff -B /tmp/__testfile__ '{{ __test_forward_conf_s_f }}'
       changed_when: false
 
     - name: Check the fake ca cert is successfully copied

--- a/tests/tests_basics_forwards_cacert.yml
+++ b/tests/tests_basics_forwards_cacert.yml
@@ -3,7 +3,6 @@
 # [Configuration]
 # basics input (imjournal) -> forwards output (omfile)
 # logging_purge_confs: true
-# logging_pki: tls
 # logging_pki_files:
 #     ca_cert_src: "{{ __test_ca_cert }}" <-- local ca_cert file path to be copied from
 #     ca_cert: "/etc/pki/tls/certs/{{ __test_ca_cert_name }}" <-- target destination
@@ -45,7 +44,6 @@
     - name: Deploy rsyslog config on the target host
       vars:
         logging_purge_confs: true
-        logging_pki: tls
         logging_pki_files:
           - ca_cert_src: "{{ __test_ca_cert }}"
         logging_outputs:

--- a/tests/tests_basics_forwards_cacert.yml
+++ b/tests/tests_basics_forwards_cacert.yml
@@ -57,7 +57,7 @@
             target: host.domain
             port: 1514
             pki_authmode: anon
-            permitted_peers: '*.example.com'
+            permitted_server: '*.example.com'
         logging_inputs:
           - name: basic_input
             type: basics

--- a/tests/tests_basics_forwards_cacert.yml
+++ b/tests/tests_basics_forwards_cacert.yml
@@ -4,7 +4,6 @@
 # basics input (imjournal) -> forwards output (omfile)
 # logging_purge_confs: true
 # logging_pki: tls
-# logging_pki_authmode: anon
 # logging_pki_files:
 #     ca_cert_src: "{{ __test_ca_cert }}" <-- local ca_cert file path to be copied from
 #     ca_cert: "/etc/pki/tls/certs/{{ __test_ca_cert_name }}" <-- target destination
@@ -47,11 +46,8 @@
       vars:
         logging_purge_confs: true
         logging_pki: tls
-        logging_pki_authmode: anon
         logging_pki_files:
           - ca_cert_src: "{{ __test_ca_cert }}"
-        logging_permitted_peers:
-          - '*.example.com'
         logging_outputs:
           - name: forwards_severity_and_facility
             type: forwards
@@ -60,6 +56,8 @@
             protocol: tcp
             target: host.domain
             port: 1514
+            pki_authmode: anon
+            permitted_peers: '*.example.com'
         logging_inputs:
           - name: basic_input
             type: basics
@@ -106,7 +104,7 @@
                   StreamDriver="gtls"
                   StreamDriverMode="1"
                   StreamDriverAuthMode="anon"
-                  StreamDriverPermittedPeers="['*.example.com']"
+                  StreamDriverPermittedPeers="*.example.com"
               )
           }
 

--- a/tests/tests_basics_forwards_cacert.yml
+++ b/tests/tests_basics_forwards_cacert.yml
@@ -56,6 +56,7 @@
             protocol: tcp
             target: host.domain
             port: 1514
+            pki: tls
             pki_authmode: anon
             permitted_server: '*.example.com'
         logging_inputs:

--- a/tests/tests_basics_forwards_cacert.yml
+++ b/tests/tests_basics_forwards_cacert.yml
@@ -51,9 +51,8 @@
             type: forwards
             facility: local1
             severity: info
-            protocol: tcp
             target: host.domain
-            port: 1514
+            tcp_port: 1514
             pki: tls
             pki_authmode: anon
             permitted_server: '*.example.com'
@@ -98,12 +97,12 @@
               local1.info action(name="forwards_severity_and_facility"
                   type="omfwd"
                   Target="host.domain"
-                  Port="1514"
-                  Protocol="tcp"
                   StreamDriver="gtls"
                   StreamDriverMode="1"
                   StreamDriverAuthMode="anon"
                   StreamDriverPermittedPeers="*.example.com"
+                  Port="1514"
+                  Protocol="tcp"
               )
           }
 

--- a/tests/tests_basics_forwards_cert.yml
+++ b/tests/tests_basics_forwards_cert.yml
@@ -70,7 +70,7 @@
             protocol: tcp
             target: host.domain
             port: 1514
-            permitted_peers: '*.example.com'
+            permitted_server: '*.example.com'
         logging_inputs:
           - name: basic_input
             type: basics

--- a/tests/tests_basics_forwards_cert.yml
+++ b/tests/tests_basics_forwards_cert.yml
@@ -62,8 +62,6 @@
           - ca_cert_src: "{{ __test_ca_cert }}"
             cert_src: "{{ __test_cert }}"
             private_key_src: "{{ __test_key }}"
-        logging_permitted_peers:
-          - '*.example.com'
         logging_outputs:
           - name: forwards_severity_and_facility
             type: forwards
@@ -72,6 +70,7 @@
             protocol: tcp
             target: host.domain
             port: 1514
+            permitted_peers: '*.example.com'
         logging_inputs:
           - name: basic_input
             type: basics
@@ -118,7 +117,7 @@
                   StreamDriver="gtls"
                   StreamDriverMode="1"
                   StreamDriverAuthMode="x509/name"
-                  StreamDriverPermittedPeers="['*.example.com']"
+                  StreamDriverPermittedPeers="*.example.com"
               )
           }
 

--- a/tests/tests_basics_forwards_cert.yml
+++ b/tests/tests_basics_forwards_cert.yml
@@ -3,7 +3,6 @@
 # [Configuration]
 # basics input (imjournal) -> forwards output (omfile)
 # logging_purge_confs: true
-# logging_pki: tls
 # logging_pki_files:
 #     ca_cert_src: "{{ __test_ca_cert }}" <-- local ca_cert file path to be copied from
 #     ca_cert: "/etc/pki/tls/certs/{{ __test_ca_cert_name }}" <-- target destination
@@ -57,7 +56,6 @@
     - name: Deploy rsyslog config on the target host
       vars:
         logging_purge_confs: true
-        logging_pki: tls
         logging_pki_files:
           - ca_cert_src: "{{ __test_ca_cert }}"
             cert_src: "{{ __test_cert }}"

--- a/tests/tests_basics_forwards_cert.yml
+++ b/tests/tests_basics_forwards_cert.yml
@@ -70,6 +70,7 @@
             protocol: tcp
             target: host.domain
             port: 1514
+            pki: tls
             permitted_server: '*.example.com'
         logging_inputs:
           - name: basic_input

--- a/tests/tests_basics_forwards_cert.yml
+++ b/tests/tests_basics_forwards_cert.yml
@@ -22,9 +22,9 @@
 #    If not executed, the default rsyslog.conf size is larger than 3000 bytes.
 #    Thus, assert the size is less than 1000.
 # 3. Check file count in /etc/rsyslog.d.
-#    If logging role is executed, 7 config files are generated.
+#    If logging role is executed, 6 config files are generated.
 #    By setting logging_purge_confs, pre-existing config files are deleted.
-#    Thus, assert the the count is equal to 7.
+#    Thus, assert the the count is equal to 6.
 # 4. Check systemctl status of rsyslog as well as error or specific message in the output.
 # 5. Check the config file of a forwards output, severity_and_facility contains the expected filter and action.
 # 6. Check the fake key/certs are successfully copied.
@@ -62,6 +62,8 @@
           - ca_cert_src: "{{ __test_ca_cert }}"
             cert_src: "{{ __test_cert }}"
             private_key_src: "{{ __test_key }}"
+        logging_permitted_peers:
+          - '*.example.com'
         logging_outputs:
           - name: forwards_severity_and_facility
             type: forwards
@@ -93,7 +95,7 @@
 
     - name: Check file counts in rsyslog.d
       assert:
-        that: rsyslog_d_file_count.matched == 7
+        that: rsyslog_d_file_count.matched == 6
 
     # Checking 'error' in stdout from systemctl status is for detecting the case in which rsyslog is running,
     # but some functionality is disabled due to some error, e.g., error: 'tls.cacert' file couldn't be accessed.
@@ -102,8 +104,26 @@
       register: __result
       failed_when: "'error' in __result.stdout or __result is failed"
 
+    - name: Generated a file to check severity_and_facility
+      copy:
+        dest: /tmp/__testfile__
+        content: |
+          # Ansible managed
+          ruleset(name="forwards_severity_and_facility") {
+              local1.info action(name="forwards_severity_and_facility"
+                  type="omfwd"
+                  Target="host.domain"
+                  Port="1514"
+                  Protocol="tcp"
+                  StreamDriver="gtls"
+                  StreamDriverMode="1"
+                  StreamDriverAuthMode="x509/name"
+                  StreamDriverPermittedPeers="['*.example.com']"
+              )
+          }
+
     - name: Check severity_and_facility
-      command: /bin/grep 'local1.info action(name="forwards_severity_and_facility" type="omfwd" Target="host.domain" Port="1514" Protocol="tcp")' '{{ __test_forward_conf_s_f }}'
+      command: diff -B /tmp/__testfile__ '{{ __test_forward_conf_s_f }}'
       changed_when: false
 
     - name: Check the fake key/certs are successfully copied

--- a/tests/tests_basics_forwards_cert.yml
+++ b/tests/tests_basics_forwards_cert.yml
@@ -65,9 +65,8 @@
             type: forwards
             facility: local1
             severity: info
-            protocol: tcp
             target: host.domain
-            port: 1514
+            tcp_port: 1514
             pki: tls
             permitted_server: '*.example.com'
         logging_inputs:
@@ -111,12 +110,12 @@
               local1.info action(name="forwards_severity_and_facility"
                   type="omfwd"
                   Target="host.domain"
-                  Port="1514"
-                  Protocol="tcp"
                   StreamDriver="gtls"
                   StreamDriverMode="1"
                   StreamDriverAuthMode="x509/name"
                   StreamDriverPermittedPeers="*.example.com"
+                  Port="1514"
+                  Protocol="tcp"
               )
           }
 

--- a/tests/tests_basics_forwards_cert_missing.yml
+++ b/tests/tests_basics_forwards_cert_missing.yml
@@ -39,10 +39,9 @@
                 type: forwards
                 facility: local1
                 severity: info
-                protocol: tcp
                 target: host.domain
                 pki: tls
-                port: 1514
+                tcp_port: 1514
             logging_inputs:
               - name: basic_input
                 type: basics

--- a/tests/tests_basics_forwards_cert_missing.yml
+++ b/tests/tests_basics_forwards_cert_missing.yml
@@ -5,10 +5,8 @@
 # logging_purge_confs: true
 # logging_pki: tls
 # logging_pki_files:
-#     ca_cert_src: "{{ __test_ca_cert }}" <-- local ca_cert file path to be copied from
-#     ca_cert: "/etc/pki/tls/certs/{{ __test_ca_cert_name }}" <-- target destination
 #     private_key_src: "{{ __test_key }}" <-- local key file path to be copied from
-#     Note: cert_src is missing.
+#     Note: ca_cert_src/ca_cert is missing.
 # inputs: [basic_input]
 # outputs: [forwards_severity_and_facility]
 #
@@ -20,30 +18,24 @@
   hosts: all
   become: true
   vars:
-    __test_ca_cert_name: test-ca.crt
     __test_key_name: test-key.pem
-    __test_ca_cert: /tmp/{{ __test_ca_cert_name }}
     __test_key: /tmp/{{ __test_key_name }}
-    __expected_error: "Error: you specified logging_pki other than none or ptcp and logging_pki_authmode other than anon; you must specify all 3 of logging_pki_files ca_cert_src, cert_src, private_key_src, and/or all 3 of ca_cert, cert, private_key in the playbook var section."
+    __expected_error: "Error: you specified logging_pki other than none or ptcp; you must specify logging_pki_files ca_cert_src and/or ca_cert in the playbook var section."
 
   tasks:
     - block:
         - name: Generate fake key/certs files
           copy:
-            dest: "{{ item }}"
+            dest: "{{ __test_key }}"
             content:
-              This is a fake {{ item }}.
+              This is a fake {{ __test_key_name }}.
           delegate_to: localhost
-          loop:
-            - "{{ __test_ca_cert }}"
-            - "{{ __test_key }}"
 
         - name: Deploy rsyslog config on the target host
           vars:
             logging_pki: tls
             logging_pki_files:
-              - ca_cert_src: "{{ __test_ca_cert }}"
-                private_key_src: "{{ __test_key }}"
+              - private_key_src: "{{ __test_key }}"
             logging_outputs:
               - name: forwards_severity_and_facility
                 type: forwards

--- a/tests/tests_basics_forwards_cert_missing.yml
+++ b/tests/tests_basics_forwards_cert_missing.yml
@@ -3,7 +3,6 @@
 # [Configuration]
 # basics input (imjournal) -> forwards output (omfile)
 # logging_purge_confs: true
-# logging_pki: tls
 # logging_pki_files:
 #     private_key_src: "{{ __test_key }}" <-- local key file path to be copied from
 #     Note: ca_cert_src/ca_cert is missing.
@@ -20,7 +19,7 @@
   vars:
     __test_key_name: test-key.pem
     __test_key: /tmp/{{ __test_key_name }}
-    __expected_error: "Error: you specified logging_pki other than none or ptcp; you must specify logging_pki_files ca_cert_src and/or ca_cert in the playbook var section."
+    __expected_error: "Error: tls is enabled in forwards_severity_and_facility; you must specify logging_pki_files ca_cert_src and/or ca_cert in the playbook var section."
 
   tasks:
     - block:
@@ -33,7 +32,6 @@
 
         - name: Deploy rsyslog config on the target host
           vars:
-            logging_pki: tls
             logging_pki_files:
               - private_key_src: "{{ __test_key }}"
             logging_outputs:
@@ -43,6 +41,7 @@
                 severity: info
                 protocol: tcp
                 target: host.domain
+                pki: tls
                 port: 1514
             logging_inputs:
               - name: basic_input
@@ -60,10 +59,10 @@
 
       rescue:
         - debug:
-            msg: "Caught an expected error - {{ ansible_failed_result.msg }}"
+            msg: "Caught an expected error - {{ ansible_failed_result }}"
         - name: assert...
           assert:
-            that: "'{{ ansible_failed_result.msg }}' is match('{{ __expected_error }}')"
+            that: "'{{ ansible_failed_result.results.0.msg }}' is match('{{ __expected_error }}')"
 
     - name: default run for cleanup
       vars:

--- a/tests/tests_basics_forwards_implicit_files.yml
+++ b/tests/tests_basics_forwards_implicit_files.yml
@@ -102,6 +102,20 @@
       register: __result
       failed_when: not __result.stat.exists
 
-    - name: Grep severity_and_facility
-      command: /bin/grep 'local1.info action(name="forwards_severity_and_facility" type="omfwd" Target="host.domain" Port="1514" Protocol="tcp")' '{{ __test_forwards_conf }}'
+    - name: Generated a file to check severity_and_facility
+      copy:
+        dest: /tmp/__testfile__
+        content: |
+          # Ansible managed
+          ruleset(name="forwards_severity_and_facility") {
+              local1.info action(name="forwards_severity_and_facility"
+                  type="omfwd"
+                  Target="host.domain"
+                  Port="1514"
+                  Protocol="tcp"
+              )
+          }
+
+    - name: Check severity_and_facility
+      command: diff -B /tmp/__testfile__ '{{ __test_forwards_conf }}'
       changed_when: false

--- a/tests/tests_basics_forwards_implicit_files.yml
+++ b/tests/tests_basics_forwards_implicit_files.yml
@@ -37,15 +37,13 @@
             type: forwards
             facility: local1
             severity: info
-            protocol: tcp
             target: host.domain
-            port: 1514
+            tcp_port: 1514
           - name: forwards_facility_only
             type: forwards
             facility: local2
-            protocol: tcp
             target: host.domain
-            port: 2514
+            tcp_port: 2514
         logging_inputs:
           - name: basic_input0
             type: basics

--- a/tests/tests_combination.yml
+++ b/tests/tests_combination.yml
@@ -64,15 +64,13 @@
             type: forwards
             facility: local1
             severity: info
-            protocol: tcp
             target: host.domain
-            port: 1514
+            tcp_port: 1514
           - name: forwards_facility_only
             type: forwards
             facility: local2
-            protocol: tcp
             target: host.domain
-            port: 2514
+            tcp_port: 2514
         logging_inputs:
           - name: "{{ __test_tag }}"
             type: files

--- a/tests/tests_combination.yml
+++ b/tests/tests_combination.yml
@@ -133,15 +133,24 @@
       command: /bin/grep testMessage0000 '{{ __default_system_log }}'
       changed_when: false
 
-    - name: Check the forwarding config stat
-      stat:
-        path: "{{ __test_forwards_conf_s_f }}"
-      register: __result
-      failed_when: not __result.stat.exists
+    - name: Generated a file to check severity_and_facility
+      copy:
+        dest: /tmp/__testfile__
+        content: |
+          # Ansible managed
+          ruleset(name="forwards_severity_and_facility") {
+              local1.info action(name="forwards_severity_and_facility"
+                  type="omfwd"
+                  Target="host.domain"
+                  Port="1514"
+                  Protocol="tcp"
+              )
+          }
 
     - name: Check severity_and_facility
-      command: /bin/grep 'local1.info action(name="forwards_severity_and_facility" type="omfwd" Target="host.domain" Port="1514" Protocol="tcp")' '{{ __test_forwards_conf_s_f }}'
+      command: diff -B /tmp/__testfile__ '{{ __test_forwards_conf_s_f }}'
       changed_when: false
+
 
     - name: Check if the input files config exists
       stat:

--- a/tests/tests_combination2.yml
+++ b/tests/tests_combination2.yml
@@ -70,15 +70,13 @@
             type: forwards
             facility: local1
             severity: info
-            protocol: tcp
             target: host.domain
-            port: 1514
+            tcp_port: 1514
           - name: forwards_facility_only
             type: forwards
             facility: local2
-            protocol: tcp
             target: host.domain
-            port: 2514
+            tcp_port: 2514
         logging_inputs:
           - name: basic_input
             type: basics

--- a/tests/tests_combination2.yml
+++ b/tests/tests_combination2.yml
@@ -148,8 +148,22 @@
       register: __result
       failed_when: not __result.stat.exists
 
-    - name: Grep severity_and_facility
-      command: /bin/grep 'local1.info action(name="forwards_severity_and_facility" type="omfwd" Target="host.domain" Port="1514" Protocol="tcp")' '{{ __test_forwards_conf_s_f }}'
+    - name: Generated a file to check severity_and_facility
+      copy:
+        dest: /tmp/__testfile__
+        content: |
+          # Ansible managed
+          ruleset(name="forwards_severity_and_facility") {
+              local1.info action(name="forwards_severity_and_facility"
+                  type="omfwd"
+                  Target="host.domain"
+                  Port="1514"
+                  Protocol="tcp"
+              )
+          }
+
+    - name: Check severity_and_facility
+      command: diff -B /tmp/__testfile__ '{{ __test_forwards_conf_s_f }}'
       changed_when: false
 
     - name: Check the files config stat

--- a/tests/tests_combination_absent.yml
+++ b/tests/tests_combination_absent.yml
@@ -61,15 +61,13 @@
             type: forwards
             facility: local1
             severity: info
-            protocol: tcp
             target: host.domain
-            port: 1514
+            tcp_port: 1514
           - name: forwards_facility_only
             type: forwards
             facility: local2
-            protocol: tcp
             target: host.domain
-            port: 2514
+            tcp_port: 2514
         logging_inputs:
           - name: basic_input
             type: basics
@@ -141,16 +139,14 @@
             type: forwards
             facility: local1
             severity: info
-            protocol: tcp
             target: host.domain
-            port: 1514
+            tcp_port: 1514
             state: absent
           - name: forwards_facility_only
             type: forwards
             facility: local2
-            protocol: tcp
             target: host.domain
-            port: 2514
+            tcp_port: 2514
             state: absent
         logging_inputs:
           - name: basic_input

--- a/tests/tests_remote_default_remote.yml
+++ b/tests/tests_remote_default_remote.yml
@@ -11,9 +11,9 @@
 #    If not executed, the default rsyslog.conf size is larger than 3000 bytes.
 #    Thus, assert the size is less than 1000.
 # 2. Check file count in /etc/rsyslog.d.
-#    If logging role is executed, 8 config files are generated.
+#    If logging role is executed, 9 config files are generated.
 #    By setting logging_purge_confs, pre-existing config files are deleted.
-#    Thus, assert the the count is equal to 8.
+#    Thus, assert the the count is equal to 9.
 # 3. Install lsof
 # 3.1 Using lsof, check port 514 is open for TCP
 # 3.2 Using lsof, check port 514 is open for UDP
@@ -56,7 +56,7 @@
 
     - name: Check file counts in rsyslog.d
       assert:
-        that: rsyslog_d_file_count.matched == 8
+        that: rsyslog_d_file_count.matched == 9
 
     # Checking 'error' in stdout from systemctl status is for detecting the case in which rsyslog is running,
     # but some functionality is disabled due to some error, e.g., error: 'tls.cacert' file couldn't be accessed.

--- a/tests/tests_remote_default_remote.yml
+++ b/tests/tests_remote_default_remote.yml
@@ -15,8 +15,8 @@
 #    By setting logging_purge_confs, pre-existing config files are deleted.
 #    Thus, assert the the count is equal to 9.
 # 3. Install lsof
-# 3.1 Using lsof, check port 514 is open for TCP
-# 3.2 Using lsof, check port 514 is open for UDP
+# 3.1 Using lsof, check port 514 and 40001 is open for TCP
+# 3.2 Using lsof, check port 514 and 40002 is open for UDP
 #
 - name: Ensure inputs from the remote logging system passed to the local files outputs.
   hosts: all
@@ -30,12 +30,12 @@
           - name: remote_files_output
             type: remote_files
         logging_inputs:
-          - name: remote_udp_input
-            type: remote
-            udp_port: 514
           - name: remote_tcp_input
             type: remote
-            tcp_port: 514
+            tcp_ports: [514, 40001]
+          - name: remote_udp_input
+            type: remote
+            udp_ports: [514, 40002]
         logging_flows:
           - name: flow_0
             inputs: [remote_udp_input, remote_tcp_input]
@@ -80,14 +80,16 @@
     - debug:
         msg: "lsof returned {{ __result.stdout }}"
 
-    - name: Check port 514 is open for TCP
+    - name: Check port 514 and 40001 are open for TCP
       shell: |
         set -o pipefail
-        lsof -i -nP | grep rsyslogd | grep TCP | grep 514
+        lsof -i -nP | grep rsyslogd | grep TCP | grep {{ item }}
+      loop: [514, 40001]
       changed_when: false
 
-    - name: Check port 514 is open for UDP
+    - name: Check port 514 and 40002 are open for UDP
       shell: |
         set -o pipefail
-        lsof -i -nP | grep rsyslogd | grep UDP | grep 514
+        lsof -i -nP | grep rsyslogd | grep UDP | grep {{ item }}
+      loop: [514, 40002]
       changed_when: false

--- a/tests/tests_remote_remote.yml
+++ b/tests/tests_remote_remote.yml
@@ -15,8 +15,8 @@
 #    By setting logging_purge_confs, pre-existing config files are deleted.
 #    Thus, assert the the count is equal to 10.
 # 3. Install lsof
-# 3.1 Using lsof, check port 514 is open for TCP
-# 3.2 Using lsof, check port 514 is open for UDP
+# 3.1 Using lsof, check port 514 and 40001 are open for TCP
+# 3.2 Using lsof, check port 514 and 40002 are open for UDP
 #
 - name: Ensure that the role runs from inputs from the remote rsyslog to the local files outputs.
   hosts: all
@@ -45,12 +45,12 @@
             remote_sub_path: others/%HOSTNAME%/%PROGRAMNAME:::secpath-replace%.log
             facility: authpriv
         logging_inputs:
-          - name: remote_udp_input
-            type: remote
-            udp_port: 514
           - name: remote_tcp_input
             type: remote
-            tcp_port: 514
+            tcp_ports: [514, 40001]
+          - name: remote_udp_input
+            type: remote
+            udp_ports: [514, 40002]
         logging_flows:
           - name: flow_0
             inputs: [remote_udp_input, remote_tcp_input]
@@ -95,14 +95,16 @@
     - debug:
         msg: "lsof returned {{ __result.stdout }}"
 
-    - name: Check port 514 is open for TCP
+    - name: Check port 514 and 40001 is open for TCP
       shell: |
         set -o pipefail
-        lsof -i -nP | grep rsyslogd | grep TCP | grep 514
+        lsof -i -nP | grep rsyslogd | grep TCP | grep {{ item }}
+      loop: [514, 40001]
       changed_when: false
 
-    - name: Check port 514 is open for UDP
+    - name: Check port 514 and 40002 is open for UDP
       shell: |
         set -o pipefail
-        lsof -i -nP | grep rsyslogd | grep UDP | grep 514
+        lsof -i -nP | grep rsyslogd | grep UDP | grep {{ item }}
+      loop: [514, 40002]
       changed_when: false

--- a/tests/tests_remote_remote.yml
+++ b/tests/tests_remote_remote.yml
@@ -11,9 +11,9 @@
 #    If not executed, the default rsyslog.conf size is larger than 3000 bytes.
 #    Thus, assert the size is less than 1000.
 # 2. Check file count in /etc/rsyslog.d.
-#    If logging role is executed, 9 config files are generated.
+#    If logging role is executed, 10 config files are generated.
 #    By setting logging_purge_confs, pre-existing config files are deleted.
-#    Thus, assert the the count is equal to 9.
+#    Thus, assert the the count is equal to 10.
 # 3. Install lsof
 # 3.1 Using lsof, check port 514 is open for TCP
 # 3.2 Using lsof, check port 514 is open for UDP
@@ -71,7 +71,7 @@
 
     - name: Check file counts in rsyslog.d
       assert:
-        that: rsyslog_d_file_count.matched == 9
+        that: rsyslog_d_file_count.matched == 10
 
     # Checking 'error' in stdout from systemctl status is for detecting the case in which rsyslog is running,
     # but some functionality is disabled due to some error, e.g., error: 'tls.cacert' file couldn't be accessed.

--- a/tests/tests_server.yml
+++ b/tests/tests_server.yml
@@ -1,0 +1,110 @@
+# Test the server configuration containing tls tcp, plain tcp and udp connection
+#
+# [Configuration]
+# remote inputs configuration containing tls tcp, plain tcp and udp connection
+#
+# [Test scenario]
+# 0. Run logging role.
+# 1. Check the rsyslog.conf size and the file count in /etc/rsyslog.d.
+# 2. Check the configured ports are opened.
+#
+---
+- name: Test the server configuration containing tls tcp, plain tcp and udp connection
+  hosts: all
+  vars:
+    __test_ca_cert_name: test-ca.crt
+    __test_cert_name: test-cert.pem
+    __test_key_name: test-key.pem
+    __test_ca_cert: /tmp/{{ __test_ca_cert_name }}
+    __test_cert: /tmp/{{ __test_cert_name }}
+    __test_key: /tmp/{{ __test_key_name }}
+
+  tasks:
+    - name: Generate fake key/certs files
+      copy:
+        dest: "{{ item }}"
+        content:
+          This is a fake {{ item }}.
+      delegate_to: localhost
+      loop:
+        - "{{ __test_ca_cert }}"
+        - "{{ __test_cert }}"
+        - "{{ __test_key }}"
+
+    - name: Deploy rsyslog config on the target host
+      vars:
+        logging_pki: tls
+        logging_pki_files:
+          - ca_cert_src: "{{ __test_ca_cert }}"
+            cert_src: "{{ __test_cert }}"
+            private_key_src: "{{ __test_key }}"
+        logging_inputs:
+          - name: system_input
+            type: basics
+          - name: remote_tcp
+            type: remote
+            tcp_ports: [6514, 40000, 40001]
+            pki: tls
+            pki_authmode: x509/name
+            permitted_clients:
+              - '*.client.com'
+              - '*.example.com'
+          - name: remote_ptcp
+            type: remote
+            tcp_ports: [514, 40010, 40011]
+          - name: remote_udp
+            type: remote
+            udp_ports: [514, 40020]
+        logging_outputs:
+          - name: files_output
+            type: files
+        logging_flows:
+          - name: flows
+            inputs: [system_input, remote_tcp, remote_ptcp, remote_udp]
+            outputs: [files_output]
+      include_role:
+        name: linux-system-roles.logging
+
+    - include_tasks: set_rsyslog_variables.yml
+
+    # notify restart rsyslogd is executed at the end of this test task.
+    # thus we have to force to invoke handlers
+    - name: Force all notified handlers to run at this point, not waiting for normal sync points
+      meta: flush_handlers
+
+    - name: Check rsyslog.conf size
+      assert:
+        that: rsyslog_conf_stat.stat.size < 1000
+
+    - name: Check file counts in rsyslog.d
+      assert:
+        that: rsyslog_d_file_count.matched >= 12
+
+    - name: Install lsof
+      package:
+        name: lsof
+        state: present
+
+    - name: lsof outputs for rsyslogd
+      shell: |
+        set -o pipefail
+        lsof -i -nP | grep rsyslogd
+      register: __result
+      changed_when: false
+
+    - debug:
+        msg: "lsof returned {{ __result.stdout }}"
+
+    - name: Check port 514, 6514, 40010 and 40011 is open for TCP
+      shell: |
+        set -o pipefail
+        lsof -i -nP | grep rsyslogd | grep TCP | grep {{ item }}
+      loop: [514, 6514, 40010, 40011]
+      changed_when: false
+
+    - name: Check port 514 and 40020 is open for UDP
+      shell: |
+        set -o pipefail
+        lsof -i -nP | grep rsyslogd | grep UDP | grep {{ item }}
+      loop: [514, 40020]
+      changed_when: false

--- a/tests/tests_server.yml
+++ b/tests/tests_server.yml
@@ -33,7 +33,6 @@
 
     - name: Deploy rsyslog config on the target host
       vars:
-        logging_pki: tls
         logging_pki_files:
           - ca_cert_src: "{{ __test_ca_cert }}"
             cert_src: "{{ __test_cert }}"

--- a/tests/tests_server_conflict.yml
+++ b/tests/tests_server_conflict.yml
@@ -1,0 +1,79 @@
+# Test the server configuration containing conflicted tls inputs in the remote input
+#
+# [Configuration]
+# remote inputs - both remote_tcp_0 and remote_tcp_1 configure the tls connection.
+#
+# [Test scenario]
+# 0. Run logging role.
+# 1. An exception is to be captured and check the expected error message was returned or not.
+#
+---
+- name: Test the server configuration containing conflicted tls inputs in the remote input
+  hosts: all
+  vars:
+    __test_ca_cert_name: test-ca.crt
+    __test_cert_name: test-cert.pem
+    __test_key_name: test-key.pem
+    __test_ca_cert: /tmp/{{ __test_ca_cert_name }}
+    __test_cert: /tmp/{{ __test_cert_name }}
+    __test_key: /tmp/{{ __test_key_name }}
+    __expected_error: "Error: remote_tcp_0 and remote_tcp_1 conflict."
+
+  tasks:
+    - block:
+        - name: Generate fake key/certs files
+          copy:
+            dest: "{{ item }}"
+            content:
+              This is a fake {{ item }}.
+          delegate_to: localhost
+          loop:
+            - "{{ __test_ca_cert }}"
+            - "{{ __test_cert }}"
+            - "{{ __test_key }}"
+
+        - name: Deploy rsyslog config on the target host
+          vars:
+            logging_pki: tls
+            logging_pki_files:
+              - ca_cert_src: "{{ __test_ca_cert }}"
+                cert_src: "{{ __test_cert }}"
+                private_key_src: "{{ __test_key }}"
+            logging_inputs:
+              - name: system_input
+                type: basics
+              - name: remote_tcp_0
+                type: remote
+                tcp_ports: [6514, 40000, 40001]
+                pki: tls
+                pki_authmode: x509/name
+                permitted_clients:
+                  - '*.client.com'
+                  - '*.example.com'
+              - name: remote_tcp_1
+                type: remote
+                tcp_ports: [514, 40010, 40011]
+                pki: tls
+              - name: remote_udp
+                type: remote
+                udp_ports: [514, 40020]
+            logging_outputs:
+              - name: files_output
+                type: files
+            logging_flows:
+              - name: flows
+                inputs: [system_input, remote_tcp_0, remote_tcp_1, remote_udp]
+                outputs: [files_output]
+          include_role:
+            name: linux-system-roles.logging
+
+        - name: unreachable task
+          fail:
+            msg: UNREACH
+
+      rescue:
+        - debug:
+            msg: Caught an expected error - {{ ansible_failed_result }}
+        - assert:
+            that: item.msg is not defined or item.msg is defined and item.msg == __expected_error
+          loop: "{{ ansible_failed_result.results }}"

--- a/tests/tests_server_conflict.yml
+++ b/tests/tests_server_conflict.yml
@@ -34,7 +34,6 @@
 
         - name: Deploy rsyslog config on the target host
           vars:
-            logging_pki: tls
             logging_pki_files:
               - ca_cert_src: "{{ __test_ca_cert }}"
                 cert_src: "{{ __test_cert }}"


### PR DESCRIPTION
RHELPLAN-50082 / Bug 1861318 - [logging role] cannot setup machine with tls

The way configuring the TLS was in the old style. Converting the style to new.
In the conversion effort, following changes are made.
- eliminating the unused param tcp_tls_port from remote input.
- making sure to use __rsyslog_default_netstream_driver to distinguish
  tls tcp from plain tcp.
- using one namespace for multiple jinja vars in input_remote_module.j2.
- adjusting the forwards test scripts to the new style and the multilined format.