### PR TITLE
workaround travis CI docker version issue

### DIFF
--- a/.travis/runtox
+++ b/.travis/runtox
@@ -16,6 +16,24 @@ ME=$(basename $0)
 SCRIPTDIR=$(readlink -f $(dirname $0))
 BANNERSIZE=90
 
+# LSR_MOLECULE_DOCKER_VERSION is the version string to pass
+# to pip install - this is usually a comparison operator
+# followed by a version number e.g. '<4.3' but in reality
+# may be anything that pip allows to follow a package name
+# in an install specification
+if [ -z "${LSR_MOLECULE_DOCKER_VERSION:-}" ]; then
+  if type docker > /dev/null 2>&1; then
+    DOCKER_SERVER_API_VERSION=$(docker version --format '{{.Server.APIVersion}}')
+    case "$DOCKER_SERVER_API_VERSION" in
+    1.3[0-8]|1.[0-2]*) LSR_MOLECULE_DOCKER_VERSION='<4.3';;
+    *) LSR_MOLECULE_DOCKER_VERSION="";;
+    esac
+  else
+    LSR_MOLECULE_DOCKER_VERSION=""
+  fi
+fi
+export LSR_MOLECULE_DOCKER_VERSION
+
 . ${SCRIPTDIR}/utils.sh
 . ${SCRIPTDIR}/config.sh
 

--- a/tox.ini
+++ b/tox.ini
@@ -109,7 +109,7 @@ commands =
 changedir = {toxinidir}
 deps =
     {env:LSR_ANSIBLE_DEP:ansible}
-    docker
+    docker{env:LSR_MOLECULE_DOCKER_VERSION:}
     molecule<3
     selinux
     wcwidth==0.1.9;python_version=="3.6"


### PR DESCRIPTION
The pypi docker package was recently updated to 4.3.  This version
uses docker api version 1.39.  The docker daemon used by travis
CI uses docker api version 1.38.  We have to use a version of the
pypi docker package less than 4.3 with travis CI currently.
The .travis/runtox script is used to run `tox` in the travis CI
environment.  Change this script to look for the docker server api
version and set LSR_MOLECULE_DOCKER_VERSION appropriately so that
tox.ini will install the correct version of the pypi docker package.