### PR TITLE
Bug 1861318 - [logging role] cannot setup machine with tls

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,15 +113,15 @@ This is a schematic logging configuration to show log messages from input_nameA 
 
 - `remote` type - `remote` input supports receiving logs from the remote logging system over the network. This input type makes rsyslog a server.<br>
   **available options**
-  - `udp_ports`: List of UDP port numbers to listen. Default to `514`.
-  - `tcp_ports`: List of TCP port numbers to listen. Default to `514`.
+  - `udp_ports`: List of UDP port numbers to listen. If set, the `remote` input listens on the UDP ports. No defaults. If both `udp_ports` and `tcp_ports` are set in a `remote` input item, `udp_ports` is used and `tcp_ports` is dropped.
+  - `tcp_ports`: List of TCP port numbers to listen. If set, the `remote` input listens on the TCP ports. Default to `[514]`. If both `udp_ports` and `tcp_ports` are set in a `remote` input item, `udp_ports` is used and `tcp_ports` is dropped. If both `udp_ports` and `tcp_ports` are not set in a `remote` input item, `tcp_ports: [514]` is added to the item.
   - `tls`: Set to `true` to encrypt the connection using the default TLS implementation used by the provider. Default to `false`.
   - `pki_authmode`: Specifying the default network driver authentication mode. `x509/name`, `x509/fingerprint`, `anon` is accepted. Default to `x509/name`.
   - `permitted_clients`: List of hostnames, IP addresses, fingerprints(sha1), and wildcard DNS domains which will be allowed by the `logging` server to connect and send logs over TLS. Default to `['*.{{ logging_domain }}']`
 
-  There are 3 type of items in the remote type - udp, plain tcp and tls tcp. The udp type contains `udp_ports`; the plain tcp type contains `tcp_ports` but no `tls: true`; the tls tcp type contains tcp_ports as well as `tls: true`. Please note that it is not allowed for them to be conflicted. I.e., if there are 2 udp type items, it fails to deploy.
+  There are 3 types of items in the remote type - udp, plain tcp and tls tcp. The udp type configured using `udp_ports`; the plain tcp type is configured using `tcp_ports` without `tls` or with `tls: false`; the tls tcp type is configured using `tcp_ports` with `tls: true` at the same time. Please note there might be only one instance of each of the three types. E.g., if there are 2 `udp` type items, it fails to deploy.
 
-  Sample valid configuration
+  Valid configuration example
   ```
   - name: remote_udp
     type: remote
@@ -135,6 +135,23 @@ This is a schematic logging configuration to show log messages from input_nameA 
     tls: true
     pki_authmode: x509/name
     permitted_clients: ['*.example.com']
+  ```
+  Invalid configuration example 1; duplicated udp
+  ```
+  - name: remote_udp0
+    type: remote
+    udp_ports: [514]
+  - name: remote_udp1
+    type: remote
+    udp_ports: [1514]
+  ```
+  Invalid configuration example 2; duplicated tcp
+  ```
+  - name: remote_implicit_tcp
+    type: remote
+  - name: remote_tcp
+    type: remote
+    tcp_ports: [1514]
   ```
 
 #### Logging_outputs options

--- a/roles/rsyslog/templates/input_remote.j2
+++ b/roles/rsyslog/templates/input_remote.j2
@@ -1,41 +1,51 @@
+{# If both udp_ports and tcp_ports appear in the item, \
+   udp_ports are used in the rsyslog config and tcp_ports are dropped. \
+   If both udp_ports and tcp_ports are not configured, \
+   it is default to 'tcp_ports: [514]'. #}
 {% if item.udp_ports | d([]) %}
 # Log messages from remote hosts over UDP
 {%   set __logging_loop_index = loop.index %}
 input(name="{{ item.name }}" type="imudp" port=["{{ item.udp_ports | join('","') }}"])
 {{ lookup('template', 'input_template.j2') }}
-{% endif %}
-{% set rsyslog_flows = logging_flows | d([ {"name": "default_flow", "inputs": [ item.name ], "outputs": ["default_files"]} ], true) %}
-{% set outdict = {} %}
-{% for flow in rsyslog_flows %}
-{%   if flow.inputs | intersect([ item.name ]) %}
-{%     for oname in flow.outputs %}
-{%       set _ = outdict.__setitem__(oname, outdict.get(oname,[])|union([ item.name ])) %}
-{%     endfor %}
+{% else %}
+{%   if not item.tcp_ports | d([]) %}
+{%     set item_tcp_ports = ["514"] %}
+{%   else %}
+{%     set item_tcp_ports = item.tcp_ports %}
 {%   endif %}
-{% endfor %}
-{% for tport in item.tcp_ports | d([]) %}
-{%   set __logging_loop_index = loop.index %}
-{%   if not item.tls | d(false) | bool %}
+{%   set rsyslog_flows = logging_flows | d([ {"name": "default_flow", "inputs": [ item.name ], "outputs": ["default_files"]} ], true) %}
+{%   set outdict = {} %}
+{%   for flow in rsyslog_flows %}
+{%     if flow.inputs | intersect([ item.name ]) %}
+{%       for oname in flow.outputs %}
+{%         set _ = outdict.__setitem__(oname, outdict.get(oname,[])|union([ item.name ])) %}
+{%       endfor %}
+{%     endif %}
+{%   endfor %}
+{%   for tport in item_tcp_ports %}
+{%     set __logging_loop_index = loop.index %}
+{%     if not item.tls | d(false) | bool %}
 # Log messages from remote hosts over plain TCP
 input(name="{{ item.name }}_{{ __logging_loop_index }}" type="imptcp" port="{{ tport }}")
-{%   else %}
+{%     else %}
 # Log messages from remote hosts over TLS
 input(name="{{ item.name }}_{{ __logging_loop_index }}" type="imtcp" port="{{ tport }}")
-{%   endif %}
-{%   for output in rsyslog_outputs %}
-{%     if outdict[output.name] | d(false) %}
+{%     endif %}
+{%     for output in rsyslog_outputs %}
+{%       if outdict[output.name] | d(false) %}
 if
-{%       for inputname in outdict[output.name] %}
-{%         if inputname == item.name %}
-{%           if not loop.first %}
+{%         for inputname in outdict[output.name] %}
+{%           if inputname == item.name %}
+{%             if not loop.first %}
   or
-{%           endif %}
+{%             endif %}
   ($inputname == "{{ item.name }}_{{ __logging_loop_index }}" )
-{%         endif %}
-{%       endfor %}
+{%           endif %}
+{%         endfor %}
   then {
     call {{ output.name }}
 }
-{%     endif %}
+{%       endif %}
+{%     endfor %}
 {%   endfor %}
-{% endfor %}
+{% endif %}

--- a/roles/rsyslog/templates/input_remote_module.j2
+++ b/roles/rsyslog/templates/input_remote_module.j2
@@ -1,9 +1,13 @@
-{% if item.udp_ports is defined %}
+{# If both udp_ports and tcp_ports appear in the item, \
+   udp_ports are used in the rsyslog config and tcp_ports are dropped. \
+   If both udp_ports and tcp_ports are not configured, \
+   it is default to 'tcp_ports: [514]'. #}
+{% if item.udp_ports | d([]) %}
 # Read messages sent over UDP
 module(load="imudp" threads="{{ logging_udp_threads }}"
        TimeRequery="{{ logging_udp_system_time_requery }}"
        BatchSize="{{ logging_udp_batch_size }}")
-{% elif item.tcp_ports is defined %}
+{% else %}
 {%   if not item.tls | d(false) | bool %}
 # Read messages sent over plain TCP
 module(load="imptcp" threads="{{ logging_tcp_threads }}")
@@ -12,7 +16,8 @@ module(load="imptcp" threads="{{ logging_tcp_threads }}")
 module(load="imtcp"
        StreamDriver.Name="{{ __rsyslog_tls_netstream_driver }}"
        StreamDriver.Mode="1"
-       StreamDriver.AuthMode="{{ item.pki_authmode | d(__rsyslog_default_pki_authmode) }}"
+       StreamDriver.AuthMode="{{ item.pki_authmode |
+	                             d(__rsyslog_default_pki_authmode) }}"
 {%     if item.pki_authmode | d() != 'anon' %}
 {%       if item.permitted_clients | d() %}
        PermittedPeer=["{{ item.permitted_clients | join('","') }}"]


### PR DESCRIPTION
In the server configuration (remote input), the description of udp_ports
and tcp_ports was not accurate. Added the followings
- If both are set, udp_ports is used and tcp_ports is dropped.
- If both are not set, "tcp_ports: [514]" is added.
- I.e., udp_ports do not have a default value; tcp_ports do "[514]".

The templates input_remote.j2 and input_remote_module.j2 are updated
based on the description.