### PR TITLE
Replacing selectattr('tls', 'true'|'false') with selectattr('tls', '==', true|false)

### DIFF
--- a/roles/rsyslog/tasks/inputs/remote/main.yml
+++ b/roles/rsyslog/tasks/inputs/remote/main.yml
@@ -18,9 +18,9 @@
     __logging_remote_ptcp: "{{ __logging_remote_tcp |
                                selectattr('tls', 'undefined') | list }} +
                             {{ __logging_remote_tls |
-                               selectattr('tls', 'false') | list }}"
+                               selectattr('tls', '==', false) | list }}"
     __logging_remote_tlstcp: "{{ __logging_remote_tls |
-                                 selectattr('tls', 'true') | list }}"
+                                 selectattr('tls', '==', true) | list }}"
 
 - name: Install/Update remote input packages and generate configuration files in /etc/rsyslog.d
   vars:

--- a/roles/rsyslog/tasks/main.yml
+++ b/roles/rsyslog/tasks/main.yml
@@ -210,11 +210,11 @@
       vars:
         __logging_forwards_tls: "{{ logging_outputs | selectattr('type', '==', 'forwards') |
                                   selectattr('tls', 'defined') |
-                                  selectattr('tls', 'true') | list }}"
+                                  selectattr('tls', '==', true) | list }}"
         __logging_remote_tls: "{{ logging_inputs | selectattr('type', '==', 'remote') |
                                   selectattr('tcp_ports', 'defined') |
                                   selectattr('tls', 'defined') |
-                                  selectattr('tls', 'true') | list }}"
+                                  selectattr('tls', '==', true) | list }}"
 
       when:
         - __rsyslog_enabled | bool


### PR DESCRIPTION
Note: In the jinja2 doc:
true(value) and false(value) are "New in version 2.11."
Plus, `eq` is not supported in Jinja 2.7.2.