### PR TITLE
Fixing the file counting code in the tests.

### DIFF
--- a/tests/set_rsyslog_variables.yml
+++ b/tests/set_rsyslog_variables.yml
@@ -6,5 +6,5 @@
 - name: Get file counts in /etc/rsyslog.d
   find:
     paths: /etc/rsyslog.d
-    patterns: '*.conf,*.template,*.remote,*.rulebase'
+    patterns: '[0-9][0-9]-*.conf,*.template,*.remote,*.rulebase'
   register: rsyslog_d_file_count


### PR DESCRIPTION
The logging test playbooks checks the generated rsyslog config file
count first to capture the failure at the early stage. The count
could be influenced by the other applications which put its config
file in /etc/rsyslog.d. The extra count was considered, but it
was not strict enough to reduce the error.

Since the config file name generated by the logging role starts
with '[0-9][0-9]-', thus adding it to the find patterns to make
the generated file count more accurate.
Note: Most additional config file does not start with '[0-9][0-9]-',
but there is an exception 21-cloudinit.conf.