### PR TITLE
Test playbooks - Adding 1 second pause between the logger and its result checking.

### DIFF
--- a/tests/tests_basics_files.yml
+++ b/tests/tests_basics_files.yml
@@ -74,4 +74,8 @@
 
     - name: Check the test log message in {{ __default_system_log }}
       command: /bin/grep testMessage0000 {{ __default_system_log }}
+      register: __result
+      until: __result is success
+      retries: 5
+      delay: 1
       changed_when: false

--- a/tests/tests_basics_files2.yml
+++ b/tests/tests_basics_files2.yml
@@ -99,4 +99,8 @@
 
     - name: Check the test log message in {{ __default_system_log }}
       command: /bin/grep testMessage0000 "{{ __default_system_log }}"
+      register: __result
+      until: __result is success
+      retries: 5
+      delay: 1
       changed_when: false

--- a/tests/tests_basics_files_forwards.yml
+++ b/tests/tests_basics_files_forwards.yml
@@ -105,6 +105,10 @@
 
     - name: Check the test log message in {{ __default_system_log }}
       command: /bin/grep testMessage0000 '{{ __default_system_log }}'
+      register: __result
+      until: __result is success
+      retries: 5
+      delay: 1
       changed_when: false
 
     - name: Check if the forwarding config exists

--- a/tests/tests_basics_files_log_dir.yml
+++ b/tests/tests_basics_files_log_dir.yml
@@ -78,6 +78,10 @@
 
     - name: Check the files output config that the path is {{ logging_system_log_dir }}/messages
       command: /bin/grep '\*.info;mail.none;authpriv.none;cron.none.*{{ logging_system_log_dir }}/messages' {{ __test_files_conf }}
+      register: __result
+      until: __result is success
+      retries: 5
+      delay: 1
       changed_when: false
 
     - name: Check the test log message in {{ logging_system_log_dir }}/messages

--- a/tests/tests_basics_forwards_implicit_files.yml
+++ b/tests/tests_basics_forwards_implicit_files.yml
@@ -92,6 +92,10 @@
 
     - name: Check if the test message is in {{ __default_system_log }}
       command: /bin/grep testMessage0000 '{{ __default_system_log }}'
+      register: __result
+      until: __result is success
+      retries: 5
+      delay: 1
       changed_when: false
 
     - name: Get the forwarding config stat

--- a/tests/tests_combination.yml
+++ b/tests/tests_combination.yml
@@ -129,6 +129,10 @@
 
     - name: Check the test log message in {{ __default_system_log }}
       command: /bin/grep testMessage0000 '{{ __default_system_log }}'
+      register: __result
+      until: __result is success
+      retries: 5
+      delay: 1
       changed_when: false
 
     - name: Generated a file to check severity_and_facility

--- a/tests/tests_combination2.yml
+++ b/tests/tests_combination2.yml
@@ -138,6 +138,10 @@
 
     - name: Check the test log message in {{ __default_system_log }}
       command: /bin/grep testMessage0000 '{{ __default_system_log }}'
+      register: __result
+      until: __result is success
+      retries: 5
+      delay: 1
       changed_when: false
 
     - name: Check the forwarding config stat

--- a/tests/tests_imuxsock_files.yml
+++ b/tests/tests_imuxsock_files.yml
@@ -76,4 +76,8 @@
 
     - name: Check the test log message in {{ __default_system_log }}
       command: /bin/grep testMessage0000 "{{ __default_system_log }}"
+      register: __result
+      until: __result is success
+      retries: 5
+      delay: 1
       changed_when: false


### PR DESCRIPTION
In the code to check the log message is successfully logged or not in the /var/log/messages file, adding "until: __result.rc == 0" and waiting up to 5 seconds.
