### PR TITLE
Fixing a logic bug in elasticsearch output template.

### DIFF
--- a/roles/rsyslog/templates/output_elasticsearch.j2
+++ b/roles/rsyslog/templates/output_elasticsearch.j2
@@ -44,7 +44,7 @@ ruleset(name="{{ item.name }}") {
             bulkid="{{ item.bulkid | d("id_template") }}"
             dynbulkid="{{ item.dynbulkid | d('on') }}"
             allowUnsignedCerts="{{ item.allowUnsignedCerts | d("off") }}"
-{% if not item.retryfailures | d(true) %}
+{% if item.retryfailures | d(true) %}
 {%   if item.retryruleset | d() | length > 0 %}
             retryfailures="on"
             retryruleset="{{ item.retryruleset }}"
@@ -56,8 +56,6 @@ ruleset(name="{{ item.name }}") {
             retryfailures="off"
 {% endif %}
             usehttps="{{ item.usehttps | default("on") }}"
-
-
 {% if (item.tls is defined) | ternary(item.tls, item.use_cert | d(true)) %}
 {%   if item.ca_cert is defined %}
 {%     set __cacert = item.ca_cert %}

--- a/tests/tests_files_elasticsearch_use_local_cert.yml
+++ b/tests/tests_files_elasticsearch_use_local_cert.yml
@@ -44,6 +44,7 @@
     __test_ca_cert: /tmp/es-ca.crt
     __test_cert: /tmp/es-cert.pem
     __test_key: /tmp/es-key.pem
+    __test_el: elasticsearch_output
 
   tasks:
     - name: Generate fake key/certs files.
@@ -60,13 +61,13 @@
     - name: deploy config to send to elasticsearch
       vars:
         logging_outputs:
-          - name: elasticsearch_output
+          - name: "{{ __test_el }}"
             type: elasticsearch
             server_host: logging-es
             server_port: 9200
             index_prefix: project.
             input_type: ovirt
-            retryfailures: false
+            retryfailures: on
             ca_cert_src: "{{ __test_ca_cert }}"
             cert_src: "{{ __test_cert }}"
             private_key_src: "{{ __test_key }}"
@@ -77,7 +78,7 @@
         logging_flows:
           - name: flow_0
             inputs: [files_input]
-            outputs: [elasticsearch_output, elasticsearch_output_ops]
+            outputs: "[{{ __test_el }}]"
       include_role:
         name: linux-system-roles.logging
 
@@ -119,3 +120,12 @@
         - mycert: "{{ __test_cert }}"
         - myprivkey: "{{ __test_key }}"
       changed_when: false
+
+    - name: Check retryfailures in {{ __test_outputfiles_conf }}
+      command: /bin/grep 'retryfailures="on"' {{ __test_outputfiles_conf }}
+      changed_when: false
+
+    - name: Check retryruleset in {{ __test_outputfiles_conf }}
+      command: /bin/grep 'retryruleset="{{ __test_el }}"' {{ __test_outputfiles_conf }}
+      changed_when: false
+


### PR DESCRIPTION
When evaluated, the retryfailures value was denied by "not", which
should not have been. Removing the "not" and adding a test case to
tests_files_elasticsearch_use_local_cert.yml.