### PR TITLE
use tox for ansible-lint instead of molecule

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,7 +1,10 @@
 ---
 skip_list:
 - '106'
+- '204'
 - '208'
+- '301'  # Commands should not change things if nothing needs doing
+- '303'  # systemctl used in place of systemd module
 - '306'
 - '403'
 - '502'

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -36,7 +36,7 @@ jobs:
           toxenvs="py${toxpyver}"
           case "$toxpyver" in
           27) toxenvs="${toxenvs},coveralls,flake8,pylint,custom" ;;
-          36) toxenvs="${toxenvs},coveralls,black,yamllint,shellcheck,custom,collection" ;;
+          36) toxenvs="${toxenvs},coveralls,black,yamllint,ansible-lint,shellcheck,custom,collection" ;;
           37) toxenvs="${toxenvs},coveralls,custom" ;;
           38) toxenvs="${toxenvs},coveralls,custom" ;;
           esac

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -8,6 +8,7 @@ lint:
   name: yamllint
   options:
     config-file: .yamllint.yml
+  enabled: false
 platforms:
   - name: centos-7
     image: docker.io/linuxsystemroles/centos-7
@@ -19,6 +20,7 @@ provisioner:
   log: true
   lint:
     name: ansible-lint
+    enabled: false
     options:
       x: ["204"]
   playbooks:
@@ -36,3 +38,4 @@ verifier:
   name: testinfra
   lint:
     name: flake8
+    enabled: false


### PR DESCRIPTION
Deprecate the use of molecule for linting.  Use tox for ansible-lint.
The next step will be to remove the ansible-lint dependency from
the molecule environments.