### PR TITLE
support jinja 2.7

### DIFF
--- a/roles/rsyslog/tasks/inputs/remote/main.yml
+++ b/roles/rsyslog/tasks/inputs/remote/main.yml
@@ -8,7 +8,7 @@
       when:
         - item | length > 1
   vars:
-    __logging_remote: "{{ logging_inputs | selectattr('type', '==', 'remote') | list }}"
+    __logging_remote: "{{ logging_inputs | selectattr('type', 'match', '^remote$') | list }}"
     __logging_remote_udp: "{{ __logging_remote |
                               selectattr('udp_ports', 'defined') | list }}"
     __logging_remote_tcp: "{{ __logging_remote |
@@ -17,10 +17,8 @@
                               selectattr('tls', 'defined') | list }}"
     __logging_remote_ptcp: "{{ __logging_remote_tcp |
                                selectattr('tls', 'undefined') | list }} +
-                            {{ __logging_remote_tls |
-                               selectattr('tls', '==', false) | list }}"
-    __logging_remote_tlstcp: "{{ __logging_remote_tls |
-                                 selectattr('tls', '==', true) | list }}"
+                            {{ __logging_remote_tls | rejectattr('tls') | list }}"
+    __logging_remote_tlstcp: "{{ __logging_remote_tls | selectattr('tls') | list }}"
 
 - name: Install/Update remote input packages and generate configuration files in /etc/rsyslog.d
   vars:

--- a/roles/rsyslog/tasks/main.yml
+++ b/roles/rsyslog/tasks/main.yml
@@ -217,13 +217,13 @@
           notify: restart rsyslogd
 
       vars:
-        __logging_forwards_tls: "{{ logging_outputs | selectattr('type', '==', 'forwards') |
+        __logging_forwards_tls: "{{ logging_outputs | selectattr('type', 'match', '^forwards$') |
                                   selectattr('tls', 'defined') |
-                                  selectattr('tls', '==', true) | list }}"
-        __logging_remote_tls: "{{ logging_inputs | selectattr('type', '==', 'remote') |
+                                  selectattr('tls') | list }}"
+        __logging_remote_tls: "{{ logging_inputs | selectattr('type', 'match', '^remote$') |
                                   selectattr('tcp_ports', 'defined') |
                                   selectattr('tls', 'defined') |
-                                  selectattr('tls', '==', true) | list }}"
+                                  selectattr('tls') | list }}"
 
       when:
         - __rsyslog_enabled | bool

--- a/roles/rsyslog/templates/global.j2
+++ b/roles/rsyslog/templates/global.j2
@@ -1,28 +1,30 @@
-{% set ns = namespace(ca_cert_path = '', cert_path = '', key_path = '') %}
+{% set ca_cert_path = '' %}
+{% set cert_path = '' %}
+{% set key_path = '' %}
 {% if logging_pki_files.0.ca_cert_src | d() or logging_pki_files.0.ca_cert | d() %}
 {%   set __ca_cert_file = logging_pki_files.0.ca_cert_src | d(__rsyslog_default_pki_ca_cert_name) | basename %}
-{%   set ns.ca_cert_path = logging_pki_files.0.ca_cert |
-                           d(__rsyslog_default_pki_path + __rsyslog_default_pki_cert_dir + __ca_cert_file) %}
+{%   set ca_cert_path = logging_pki_files.0.ca_cert |
+                        d(__rsyslog_default_pki_path + __rsyslog_default_pki_cert_dir + __ca_cert_file) %}
 {% endif %}
 {% if logging_pki_files.0.cert_src | d() or logging_pki_files.0.cert | d() %}
 {%   set __cert_file = logging_pki_files.0.cert_src | d(__rsyslog_default_pki_cert_name) | basename %}
-{%   set ns.cert_path = logging_pki_files.0.cert |
-                        d(__rsyslog_default_pki_path + __rsyslog_default_pki_cert_dir + __cert_file) %}
+{%   set cert_path = logging_pki_files.0.cert |
+                     d(__rsyslog_default_pki_path + __rsyslog_default_pki_cert_dir + __cert_file) %}
 {% endif %}
 {% if logging_pki_files.0.private_key_src | d() or logging_pki_files.0.private_key | d() %}
 {%   set __key_file = logging_pki_files.0.private_key_src | d(__rsyslog_default_pki_key_name) | basename %}
-{%   set ns.key_path = logging_pki_files.0.private_key |
-                       d(__rsyslog_default_pki_path + __rsyslog_default_pki_key_dir + __key_file) %}
+{%   set key_path = logging_pki_files.0.private_key |
+                    d(__rsyslog_default_pki_path + __rsyslog_default_pki_key_dir + __key_file) %}
 {% endif %}
 global(
   workDirectory="{{ rsyslog_work_dir }}"
-{% if ns.ca_cert_path != '' %}
-  defaultNetstreamDriverCAFile="{{ ns.ca_cert_path }}"
-{%   if ns.cert_path != '' %}
-  defaultNetstreamDriverCertFile="{{ ns.cert_path }}"
+{% if ca_cert_path != '' %}
+  defaultNetstreamDriverCAFile="{{ ca_cert_path }}"
+{%   if cert_path != '' %}
+  defaultNetstreamDriverCertFile="{{ cert_path }}"
 {%   endif %}
-{%   if ns.key_path != '' %}
-  defaultNetstreamDriverKeyFile="{{ ns.key_path }}"
+{%   if key_path != '' %}
+  defaultNetstreamDriverKeyFile="{{ key_path }}"
 {%   endif %}
 {% endif %}
 {% if rsyslog_max_message_size is defined %}

--- a/roles/rsyslog/vars/inputs/ovirt/main.yml
+++ b/roles/rsyslog/vars/inputs/ovirt/main.yml
@@ -32,7 +32,7 @@ rsyslog_conf_ovirt_local_modules:
     sections:
 
       - options: |-
-          {% if logging_inputs | selectattr('name', 'defined') | selectattr('type', 'defined') | selectattr('type', '==', 'basics') | list | length == 0 %}
+          {% if logging_inputs | selectattr('name', 'defined') | selectattr('type', 'defined') | selectattr('type', 'match', '^basics$') | list | length == 0 %}
           # Log messages sent to local UNIX socket with use=off'
           module(load="imuxsock" SysSock.Use="off")
           {% endif %}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,11 +4,13 @@
 
     - name: Set rsyslog_output_elasticsearch for the omelasticsearch output
       set_fact:
-        rsyslog_output_elasticsearch: "{{ logging_outputs | selectattr('name', 'defined') | selectattr('type', 'defined') | selectattr('type', '==', 'elasticsearch') | selectattr('server_host', 'defined') | list }}"
+        rsyslog_output_elasticsearch: "{{ logging_outputs | selectattr('name', 'defined') | selectattr('type', 'defined') |
+          selectattr('type', 'match', '^elasticsearch$') | selectattr('server_host', 'defined') | list }}"
 
     - name: Set rsyslog_output_files for the omfile outputs
       set_fact:
-        rsyslog_output_files: "{{ logging_outputs | selectattr('name', 'defined') | selectattr('type', 'defined') | selectattr('type', '==', 'files') | list }}"
+        rsyslog_output_files: "{{ logging_outputs | selectattr('name', 'defined') | selectattr('type', 'defined') |
+          selectattr('type', 'match', '^files$') | list }}"
 
     - name: Set files output if rsyslog_output_files is empty and logging_inputs is not empty
       set_fact:
@@ -19,19 +21,23 @@
 
     - name: Set rsyslog_output_forwards for the omfwd output
       set_fact:
-        rsyslog_output_forwards: "{{ logging_outputs | selectattr('name', 'defined') | selectattr('type', 'defined') | selectattr('target', 'defined') | selectattr('type', '==', 'forwards') | list }}"
+        rsyslog_output_forwards: "{{ logging_outputs | selectattr('name', 'defined') | selectattr('type', 'defined') |
+          selectattr('target', 'defined') | selectattr('type', 'match', '^forwards$') | list }}"
 
     - name: Set rsyslog_output_remote_files for the omfwd output for the remote input
       set_fact:
-        rsyslog_output_remote_files: "{{ logging_outputs | selectattr('name', 'defined') | selectattr('type', 'defined') | selectattr('type', '==', 'remote_files') | list }}"
+        rsyslog_output_remote_files: "{{ logging_outputs | selectattr('name', 'defined') | selectattr('type', 'defined') |
+          selectattr('type', 'match', '^remote_files$') | list }}"
 
     - name: Set rsyslog_output_relp for the relp output
       set_fact:
-        rsyslog_output_relp: "{{ logging_outputs | selectattr('name', 'defined') | selectattr('type', 'defined') | selectattr('type', '==', 'relp') | selectattr('server_host', 'defined') | list }}"
+        rsyslog_output_relp: "{{ logging_outputs | selectattr('name', 'defined') | selectattr('type', 'defined') |
+          selectattr('type', 'match', '^relp$') | selectattr('server_host', 'defined') | list }}"
 
     - name: Set rsyslog_input_relp for the relp input
       set_fact:
-        rsyslog_input_relp: "{{ logging_inputs | selectattr('name', 'defined') | selectattr('type', 'defined') | selectattr('type', '==', 'relp') | list }}"
+        rsyslog_input_relp: "{{ logging_inputs | selectattr('name', 'defined') | selectattr('type', 'defined') |
+          selectattr('type', 'match', '^relp$') | list }}"
 
     - name: Set rsyslog_outputs
       set_fact:

--- a/tests/tests_basics_files.yml
+++ b/tests/tests_basics_files.yml
@@ -179,11 +179,14 @@
             msg: UNREACH
       vars:
         __expected_error: "Error: ['bogus_basic_input'] includes undefined logging_inputs item."
+        __expected_error2: "Error: [u'bogus_basic_input'] includes undefined logging_inputs item."
       rescue:
         - debug:
-            msg: Caught an expected error - {{ ansible_failed_result }}
+            msg: |
+              Caught an expected error - {{ ansible_failed_result }}
         - assert:
-            that: ansible_failed_result.results.0.msg == __expected_error
+            that: ansible_failed_result.results.0.msg == __expected_error or
+                  ansible_failed_result.results.0.msg == __expected_error2
 
     - name: END TEST CASE 2; Clean up the deployed config
       vars:


### PR DESCRIPTION
Do not use the case_sensitive argument to the unique filter
For doing selectattr with string comparison, use `match` with
an argument like `^STRING$` instead of `==` or `equalto` with
`STRING`.
For doing selectattr with boolean values, you don't need to
provide a test - `selectattr('boolvar')` is the same as
`selectattr('boolvar', '==', true)`.  For `false` comparison,
use `rejectattr('boolvar')` which is the same as
selectattr('boolvar', '==', false)`
Do not use `namespace` as it is only needed with loops, not `if`