### PR TITLE
Bug fixes in relp_input and relp_output

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,8 +252,8 @@ This is a schematic logging configuration to show log messages from input_nameA 
 - `relp` type - `relp` output sends logs to the remote logging system over the network using relp.<br>
   **available options**
   - `port`: Port number Relp is listening to. Default to `20514`.
-  - `server_host`: Host name the remote logging system is running on. **Required**.
-  - `server_port`: Port number the remote logging system is listening to. Default to `20514`.
+  - `target`: Host name the remote logging system is running on. **Required**.
+  - `port`: Port number the remote logging system is listening to. Default to `20514`.
   - `tls`: If true, encrypt the connection with TLS. You must provide key/certificates and triplets {`ca_cert`, `cert`, `private_key`} and/or {`ca_cert_src`, `cert_src`, `private_key_src`}. Default to `true`.
   - `ca_cert`: Path to CA cert to configure Relp with tls. Default to `logging_config_dir/basename of ca_cert_src`.
   - `cert`: Path to cert to configure Relp with tls.  Default to `logging_config_dir/basename of cert_src`.
@@ -698,7 +698,7 @@ Deploying `basics input` reading logs from systemd journal and `relp output` to 
     logging_outputs:
       - name: relp_client
         type: relp
-        server_host: logging.server.com
+        target: logging.server.com
         port: 20514
         tls: true
         ca_cert_src: /path/to/ca.pem

--- a/roles/rsyslog/templates/input_relp.j2
+++ b/roles/rsyslog/templates/input_relp.j2
@@ -49,7 +49,7 @@ if
 {%         if not loop.first %}
   or
 {%         endif %}
-  ($inputname == "{{ item.name }}_{{ loop.index }}" )
+  ($inputname == "{{ item.name }}" )
 {%       endif %}
 {%     endfor %}
   then {

--- a/roles/rsyslog/templates/output_relp.j2
+++ b/roles/rsyslog/templates/output_relp.j2
@@ -1,8 +1,8 @@
 ruleset(name="{{ item.name }}") {
     action(name="{{ item.name }}"
            type="omrelp"
-           target="{{ item.server_host }}"
-           port="{{ item.server_port | d(20514) | int }}"
+           target="{{ item.target }}"
+           port="{{ item.port | d(20514) | int }}"
 {% if item.tls | default(true) %}
 {%   if item.ca_cert is defined %}
 {%     set __cacert = item.ca_cert %}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,7 +32,7 @@
     - name: Set rsyslog_output_relp for the relp output
       set_fact:
         rsyslog_output_relp: "{{ logging_outputs | selectattr('name', 'defined') | selectattr('type', 'defined') |
-          selectattr('type', 'match', '^relp$') | selectattr('server_host', 'defined') | list }}"
+          selectattr('type', 'match', '^relp$') | selectattr('target', 'defined') | list }}"
 
     - name: Set rsyslog_input_relp for the relp input
       set_fact:

--- a/tests/tests_relp.yml
+++ b/tests/tests_relp.yml
@@ -165,7 +165,7 @@
         logging_outputs:
           - name: relp_client0
             type: relp
-            server_host: localhost
+            target: localhost
             port: 6514
             tls: true
             ca_cert: "{{ __test_ca_cert }}"
@@ -177,8 +177,8 @@
               - '*.example.com'
           - name: relp_client1
             type: relp
-            server_host: localhost
-            port: 20514
+            target: localhost
+            port: 7514
             tls: true
             ca_cert: "{{ __test_ca_cert }}"
             cert: "{{ __test_cert }}"
@@ -209,6 +209,11 @@
         __check_systemctl_status: false
       include_tasks: tasks/check_daemon_config_files.yml
 
+    - name: Check the port in relp_client1
+      shell: grep "7514" "{{ __test_relp_client1 }}" | wc -l
+      register: __result
+      failed_when: __result.stdout != "1"
+
     - name: END TEST CASE 1; Clean up the deployed config
       vars:
         logging_enabled: false
@@ -219,7 +224,7 @@
         logging_outputs:
           - name: relp_client0
             type: relp
-            server_host: localhost
+            target: localhost
             port: 6514
             tls: true
             ca_cert: "{{ __test_ca_cert }}"
@@ -232,8 +237,8 @@
             state: absent
           - name: relp_client1
             type: relp
-            server_host: localhost
-            port: 20514
+            target: localhost
+            port: 7514
             tls: true
             ca_cert: "{{ __test_ca_cert }}"
             cert: "{{ __test_cert }}"

--- a/tests/tests_relp.yml
+++ b/tests/tests_relp.yml
@@ -53,10 +53,14 @@
         logging_outputs:
           - name: files_output
             type: files
+          - name: forwards_output
+            type: forwards
+            target: host.domain
+            tcp_port: 1514
         logging_flows:
           - name: flows
             inputs: [system_input, relp_server0, relp_server1]
-            outputs: [files_output]
+            outputs: [files_output, forwards_output]
       include_role:
         name: linux-system-roles.logging
 
@@ -96,6 +100,18 @@
         lsof -i -nP | grep rsyslogd | grep TCP | grep {{ item }}
       loop: [6514, 20514]
       changed_when: false
+
+    - name: Check the flows in relp_server0 - 0
+      shell: grep "$inputname == \"relp_server0\"" "{{ __test_relp_server0 }}" | wc -l
+      register: __result
+      failed_when: __result.stdout != "2"
+
+    - name: Check the flows in relp_server0 - 1
+      shell: |-
+        grep -A 2 "$inputname == \"relp_server0\"" "{{ __test_relp_server0 }}" |
+        grep "call files_output" | wc -l
+      register: __result
+      failed_when: __result.stdout != "1"
 
     - name: END TEST CASE 0; Clean up the deployed config
       vars:


### PR DESCRIPTION
This PR contains 2 commits:
1) Bug fix in relp_input - an unwanted loop index was added as suffix
    
    There was a bug in roles/rsyslog/templates/input_relp.j2, in which
    $inputname was compared with a name with extra _{{ loop.index }} to
    determine the output. It made the relp input never delivered to the
    output.
    
    Test case is added to TEST CASE 0 in tests_relp.yml.

2) Bug fix in relp_output - there was inconsistencies in the parameters.
    
    To specify the server host and server port, relp required "server_host"
    and "server_port", while the forwards output does "target" and "port".
    To eliminate the inconsistency, adjusting the relp parameters to the
    forwards output's parameters.
    
    Test case is added to TEST CASE 1 in tests_relp.yml.