### PR TITLE
Bug fixes found or introduced in the previous commit "Bug fix in relp_output - there was inconsistencies in the parameters."

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,6 @@ This is a schematic logging configuration to show log messages from input_nameA 
 
 - `relp` type - `relp` output sends logs to the remote logging system over the network using relp.<br>
   **available options**
-  - `port`: Port number Relp is listening to. Default to `20514`.
   - `target`: Host name the remote logging system is running on. **Required**.
   - `port`: Port number the remote logging system is listening to. Default to `20514`.
   - `tls`: If true, encrypt the connection with TLS. You must provide key/certificates and triplets {`ca_cert`, `cert`, `private_key`} and/or {`ca_cert_src`, `cert_src`, `private_key_src`}. Default to `true`.

--- a/roles/rsyslog/templates/input_ovirt.j2
+++ b/roles/rsyslog/templates/input_ovirt.j2
@@ -4,7 +4,7 @@
 {% if __rsyslog_ovirt_subtype == "collectd" %}
 {%   set __rsyslog_collectd_port = item.ovirt_collectd_port | d(44514) %}
 {%   set __rsyslog_elasticsearch_index_prefix = item.ovirt_elasticsearch_index_prefix | d('project.ovirt-metrics') %}
-input (name="{{ item.name }}" type="imtcp" port="{{ __rsyslog_collectd_port }}")
+input(name="{{ item.name }}" type="imtcp" port="{{ __rsyslog_collectd_port }}")
 if $inputname == "{{ item.name }}" then {
     set $!original_raw_message = $msg;
     action(name="collectd_mmjsonparse" type="mmjsonparse" cookie="") # parse entire message as json

--- a/roles/rsyslog/templates/input_relp.j2
+++ b/roles/rsyslog/templates/input_relp.j2
@@ -49,7 +49,7 @@ if
 {%         if not loop.first %}
   or
 {%         endif %}
-  ($inputname == "{{ item.name }}" )
+  ($inputname == "{{ item.name }}")
 {%       endif %}
 {%     endfor %}
   then {

--- a/roles/rsyslog/templates/input_remote.j2
+++ b/roles/rsyslog/templates/input_remote.j2
@@ -39,7 +39,7 @@ if
 {%             if not loop.first %}
   or
 {%             endif %}
-  ($inputname == "{{ item.name }}_{{ __logging_loop_index }}" )
+  ($inputname == "{{ item.name }}_{{ __logging_loop_index }}")
 {%           endif %}
 {%         endfor %}
   then {

--- a/roles/rsyslog/templates/input_template.j2
+++ b/roles/rsyslog/templates/input_template.j2
@@ -18,7 +18,7 @@ if
 {%         if item.type == "basics" %}
   ($inputname == "imjournal" or $inputname == "imuxsock")
 {%         elif item.type == "remote" %}
-  ($inputname == "{{ item.name }}" )
+  ($inputname == "{{ item.name }}")
 {%         else %}
   ($syslogtag == "{{ item.name }}")
 {%         endif %}

--- a/tests/tests_ovirt_elasticsearch.yml
+++ b/tests/tests_ovirt_elasticsearch.yml
@@ -102,7 +102,7 @@
       failed_when: __result.stat.exists
 
     - name: Check ovirt_collectd_port is "{{ __test_collectd_port }}"
-      command: /bin/grep 'input (name="{{ __test_collectd_name }}" type="imtcp" port="{{ __test_collectd_port }}"' {{ __test_ovirt_collectd_conf }}
+      command: /bin/grep 'input(name="{{ __test_collectd_name }}" type="imtcp" port="{{ __test_collectd_port }}"' {{ __test_ovirt_collectd_conf }}
       changed_when: false
 
     - name: Check index_prefix is "{{ __test_metrics_index }}" in "{{ __test_ovirt_collectd_conf }}"
@@ -281,7 +281,7 @@
       failed_when: __result.stat.exists
 
     - name: Check ovirt_collectd_port is "{{ __test_collectd_port }}"
-      command: /bin/grep 'input (name="{{ __test_collectd_name }}" type="imtcp" port="{{ __test_collectd_port }}"' {{ __test_ovirt_collectd_conf }}
+      command: /bin/grep 'input(name="{{ __test_collectd_name }}" type="imtcp" port="{{ __test_collectd_port }}"' {{ __test_ovirt_collectd_conf }}
       changed_when: false
 
     - name: Check index_prefix is "{{ __test_metrics_index }}" in "{{ __test_ovirt_collectd_conf }}"


### PR DESCRIPTION
README - Removing a duplicated "port" in the relp output parameter.
- It was introduce in the previous commit cc9af13e7560f975279771c99c8acae7766435f9

Fixing whitespace inconsistencies in the templates.
- input_ovirt.j2,tests_ovirt_elasticsearch.yml - removing an extra whitespace between 'input' and '('.
- input_relp.j2,input_remote.j2,input_template.j2 - removing an extra whitespace before ')'.
