### PR TITLE
Issue: cert and key files should be deployed in the /etc/pki/tls folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,9 +132,9 @@ This is a schematic logging configuration to show log messages from input_nameA 
   **available options**
   - `port`: Port number Relp is listening to. Default to `20514`. See also [Port and SELinux](#port-and-selinux).
   - `tls`: If true, encrypt the connection with TLS. You must provide key/certificates and triplets {`ca_cert`, `cert`, `private_key`} and/or {`ca_cert_src`, `cert_src`, `private_key_src`}. Default to `true`.
-  - `ca_cert`: Path to CA cert to configure Relp with tls. Default to `logging_config_dir/basename of ca_cert_src`.
-  - `cert`: Path to cert to configure Relp with tls.  Default to `logging_config_dir/basename of cert_src`.
-  - `private_key`: Path to key to configure Relp with tls.  Default to `logging_config_dir/basename of private_key_src`.
+  - `ca_cert`: Path to CA cert to configure Relp with tls. Default to `/etc/pki/tls/certs/basename of ca_cert_src`.
+  - `cert`: Path to cert to configure Relp with tls. Default to `/etc/pki/tls/certs/basename of cert_src`.
+  - `private_key`: Path to key to configure Relp with tls. Default to `/etc/pki/tls/private/basename of private_key_src`.
   - `ca_cert_src`: Local CA cert file path which is copied to the target host. If `ca_cert` is specified, it is copied to the location. Otherwise, to logging_config_dir.
   - `cert_src`: Local cert file path which is copied to the target host. If `cert` is specified, it is copied to the location. Otherwise, to logging_config_dir.
   - `private_key_src`: Local key file path which is copied to the target host. If `private_key` is specified, it is copied to the location. Otherwise, to logging_config_dir.
@@ -201,9 +201,9 @@ This is a schematic logging configuration to show log messages from input_nameA 
   - `retryfailures`: Specifying whether retries or not in case of failure. Allowed value is `true` or `false`.  Default to `true`.
   - `tls`: If true, encrypt the connection with TLS. You must provide key/certificates and triplets {`ca_cert`, `cert`, `private_key`} and/or {`ca_cert_src`, `cert_src`, `private_key_src`}. Default to `true`.
   - `use_cert`: [DEPRECATED] If true, encrypt the connection with TLS. You must provide key/certificates and triplets {`ca_cert`, `cert`, `private_key`} and/or {`ca_cert_src`, `cert_src`, `private_key_src`}. Default to `true`. Option `use_cert` is deprecated in favor of `tls` and `use_cert` will be removed in the next minor release.
-  - `ca_cert`: Path to CA cert for Elasticsearch. Default to `logging_config_dir/basename of ca_cert_src`.
-  - `cert`: Path to cert to connect to Elasticsearch.  Default to `logging_config_dir/basename of cert_src`.
-  - `private_key`: Path to key to connect to Elasticsearch.  Default to `logging_config_dir/basename of private_key_src`.
+  - `ca_cert`: Path to CA cert for Elasticsearch. Default to `/etc/pki/tls/certs/basename of ca_cert_src`.
+  - `cert`: Path to cert to connect to Elasticsearch. Default to `/etc/pki/tls/certs/basename of cert_src`.
+  - `private_key`: Path to key to connect to Elasticsearch. Default to `/etc/pki/tls/private/basename of private_key_src`.
   - `ca_cert_src`: Local CA cert file path which is copied to the target host. If `ca_cert` is specified, it is copied to the location. Otherwise, to logging_config_dir.
   - `cert_src`: Local cert file path which is copied to the target host. If `cert` is specified, it is copied to the location. Otherwise, to logging_config_dir.
   - `private_key_src`: Local key file path which is copied to the target host. If `private_key` is specified, it is copied to the location. Otherwise, to logging_config_dir.
@@ -254,9 +254,9 @@ This is a schematic logging configuration to show log messages from input_nameA 
   - `target`: Host name the remote logging system is running on. **Required**.
   - `port`: Port number the remote logging system is listening to. Default to `20514`.
   - `tls`: If true, encrypt the connection with TLS. You must provide key/certificates and triplets {`ca_cert`, `cert`, `private_key`} and/or {`ca_cert_src`, `cert_src`, `private_key_src`}. Default to `true`.
-  - `ca_cert`: Path to CA cert to configure Relp with tls. Default to `logging_config_dir/basename of ca_cert_src`.
-  - `cert`: Path to cert to configure Relp with tls.  Default to `logging_config_dir/basename of cert_src`.
-  - `private_key`: Path to key to configure Relp with tls.  Default to `logging_config_dir/basename of private_key_src`.
+  - `ca_cert`: Path to CA cert to configure Relp with tls. Default to `/etc/pki/tls/certs/basename of ca_cert_src`.
+  - `cert`: Path to cert to configure Relp with tls. Default to `/etc/pki/tls/certs/basename of cert_src`.
+  - `private_key`: Path to key to configure Relp with tls. Default to `/etc/pki/tls/private/basename of private_key_src`.
   - `ca_cert_src`: Local CA cert file path which is copied to the target host. If `ca_cert` is specified, it is copied to the location. Otherwise, to logging_config_dir.
   - `cert_src`: Local cert file path which is copied to the target host. If `cert` is specified, it is copied to the location. Otherwise, to logging_config_dir.
   - `private_key_src`: Local key file path which is copied to the target host. If `private_key` is specified, it is copied to the location. Otherwise, to logging_config_dir.

--- a/roles/rsyslog/tasks/set_certs.yml
+++ b/roles/rsyslog/tasks/set_certs.yml
@@ -4,7 +4,7 @@
     - name: Copy ca_cert on the control host to the specified path on the target host
       copy:
         src: '{{ item.ca_cert_src }}'
-        dest: '{{ item.ca_cert | d(__rsyslog_config_dir) }}'
+        dest: '{{ item.ca_cert | d(__rsyslog_default_pki_path + __rsyslog_default_pki_cert_dir) }}'
       with_items:
         - '{{ __rsyslog_cert_subject }}'
       when: item.ca_cert_src | d()
@@ -12,7 +12,7 @@
     - name: Copy cert on the control host to the specified path on the target host
       copy:
         src: '{{ item.cert_src }}'
-        dest: '{{ item.cert | d(__rsyslog_config_dir) }}'
+        dest: '{{ item.cert | d(__rsyslog_default_pki_path + __rsyslog_default_pki_cert_dir) }}'
       with_items:
         - '{{ __rsyslog_cert_subject }}'
       when: item.cert_src | d()
@@ -20,7 +20,7 @@
     - name: Copy key on the control host to the specified path on the target host
       copy:
         src: '{{ item.private_key_src }}'
-        dest: '{{ item.private_key | d(__rsyslog_config_dir) }}'
+        dest: '{{ item.private_key | d(__rsyslog_default_pki_path + __rsyslog_default_pki_cert_dir) }}'
       with_items:
         - '{{ __rsyslog_cert_subject }}'
       when: item.private_key_src | d()

--- a/roles/rsyslog/templates/input_relp.j2
+++ b/roles/rsyslog/templates/input_relp.j2
@@ -6,23 +6,23 @@ input(name="{{ item.name }}"
 {%   if item.ca_cert is defined %}
 {%     set __cacert = item.ca_cert %}
 {%   elif item.ca_cert_src is defined %}
-{%     set __cacert = __rsyslog_config_dir + '/' + item.ca_cert_src | basename %}
+{%     set __cacert = __rsyslog_default_pki_path + __rsyslog_default_pki_cert_dir + item.ca_cert_src | basename %}
 {%   else %}
-{%     set __cacert = __rsyslog_config_dir + '/relp-ca.crt' %}
+{%     set __cacert = __rsyslog_default_pki_path + __rsyslog_default_pki_cert_dir + 'relp-ca.crt' %}
 {%   endif %}
 {%   if item.cert is defined %}
 {%     set __mycert = item.cert %}
 {%   elif item.cert_src is defined %}
-{%     set __mycert = __rsyslog_config_dir + '/' + item.cert_src | basename %}
+{%     set __mycert = __rsyslog_default_pki_path + __rsyslog_default_pki_cert_dir + item.cert_src | basename %}
 {%   else %}
-{%     set __mycert = __rsyslog_config_dir + '/relp-cert.pem' %}
+{%     set __mycert = __rsyslog_default_pki_path + __rsyslog_default_pki_cert_dir + 'relp-cert.pem' %}
 {%   endif %}
 {%   if item.private_key is defined %}
 {%     set __myprivkey = item.private_key %}
 {%   elif item.private_key_src is defined %}
-{%     set __myprivkey = __rsyslog_config_dir + '/' + item.private_key_src | basename %}
+{%     set __myprivkey = __rsyslog_default_pki_path + __rsyslog_default_pki_key_dir + item.private_key_src | basename %}
 {%   else %}
-{%     set __myprivkey = __rsyslog_config_dir + '/relp-key.pem' %}
+{%     set __myprivkey = __rsyslog_default_pki_path + __rsyslog_default_pki_key_dir + 'relp-key.pem' %}
 {%   endif %}
       tls="on"
       tls.cacert="{{ __cacert }}"

--- a/roles/rsyslog/templates/output_elasticsearch.j2
+++ b/roles/rsyslog/templates/output_elasticsearch.j2
@@ -59,23 +59,23 @@ ruleset(name="{{ item.name }}") {
 {%   if item.ca_cert is defined %}
 {%     set __cacert = item.ca_cert %}
 {%   elif item.ca_cert_src is defined %}
-{%     set __cacert = __rsyslog_config_dir + '/' + item.ca_cert_src | basename %}
+{%     set __cacert = __rsyslog_default_pki_path + __rsyslog_default_pki_cert_dir + item.ca_cert_src | basename %}
 {%   else %}
-{%     set __cacert = __rsyslog_config_dir + '/es-ca.crt' %}
+{%     set __cacert = __rsyslog_default_pki_path + __rsyslog_default_pki_cert_dir + 'es-ca.crt' %}
 {%   endif %}
 {%   if item.cert is defined %}
 {%     set __mycert = item.cert %}
 {%   elif item.cert_src is defined %}
-{%     set __mycert = __rsyslog_config_dir + '/' + item.cert_src | basename %}
+{%     set __mycert = __rsyslog_default_pki_path + __rsyslog_default_pki_cert_dir + item.cert_src | basename %}
 {%   else %}
-{%     set __mycert = __rsyslog_config_dir + '/es-cert.pem' %}
+{%     set __mycert = __rsyslog_default_pki_path + __rsyslog_default_pki_cert_dir + 'es-cert.pem' %}
 {%   endif %}
 {%   if item.private_key is defined %}
 {%     set __myprivkey = item.private_key %}
 {%   elif item.private_key_src is defined %}
-{%     set __myprivkey = __rsyslog_config_dir + '/' + item.private_key_src | basename %}
+{%     set __myprivkey = __rsyslog_default_pki_path + __rsyslog_default_pki_key_dir + item.private_key_src | basename %}
 {%   else %}
-{%     set __myprivkey = __rsyslog_config_dir + '/es-key.pem' %}
+{%     set __myprivkey = __rsyslog_default_pki_path + __rsyslog_default_pki_key_dir + 'es-key.pem' %}
 {%   endif %}
             tls.cacert="{{ __cacert }}"
             tls.mycert="{{ __mycert }}"

--- a/roles/rsyslog/templates/output_relp.j2
+++ b/roles/rsyslog/templates/output_relp.j2
@@ -7,23 +7,23 @@ ruleset(name="{{ item.name }}") {
 {%   if item.ca_cert is defined %}
 {%     set __cacert = item.ca_cert %}
 {%   elif item.ca_cert_src is defined %}
-{%     set __cacert = __rsyslog_config_dir + '/' + item.ca_cert_src | basename %}
+{%     set __cacert = __rsyslog_default_pki_path + __rsyslog_default_pki_cert_dir + item.ca_cert_src | basename %}
 {%   else %}
-{%     set __cacert = __rsyslog_config_dir + '/relp-ca.crt' %}
+{%     set __cacert = __rsyslog_default_pki_path + __rsyslog_default_pki_cert_dir + 'relp-ca.crt' %}
 {%   endif %}
 {%   if item.cert is defined %}
 {%     set __mycert = item.cert %}
 {%   elif item.cert_src is defined %}
-{%     set __mycert = __rsyslog_config_dir + '/' + item.cert_src | basename %}
+{%     set __mycert = __rsyslog_default_pki_path + __rsyslog_default_pki_cert_dir + item.cert_src | basename %}
 {%   else %}
-{%     set __mycert = __rsyslog_config_dir + '/relp-cert.pem' %}
+{%     set __mycert = __rsyslog_default_pki_path + __rsyslog_default_pki_cert_dir + 'relp-cert.pem' %}
 {%   endif %}
 {%   if item.private_key is defined %}
 {%     set __myprivkey = item.private_key %}
 {%   elif item.private_key_src is defined %}
-{%     set __myprivkey = __rsyslog_config_dir + '/' + item.private_key_src | basename %}
+{%     set __myprivkey = __rsyslog_default_pki_path + __rsyslog_default_pki_key_dir + item.private_key_src | basename %}
 {%   else %}
-{%     set __myprivkey = __rsyslog_config_dir + '/relp-key.pem' %}
+{%     set __myprivkey = __rsyslog_default_pki_path + __rsyslog_default_pki_key_dir + 'relp-key.pem' %}
 {%   endif %}
            tls="on"
            tls.cacert="{{ __cacert }}"

--- a/tests/tests_files_elasticsearch.yml
+++ b/tests/tests_files_elasticsearch.yml
@@ -84,12 +84,15 @@
       stat:
         path: "/etc/rsyslog.d/{{ __test_key | basename }}"
 
-    - name: Check key/certs in {{ __test_outputfiles_conf }}
-      command: /bin/grep 'tls.{{ item.key }}="\/etc\/rsyslog.d\/{{ item.value | basename }}"' {{ __test_outputfiles_conf }}
+    - name: Check certs in {{ __test_outputfiles_conf }}
+      command: /bin/grep 'tls.{{ item.key }}="/etc/pki/tls/certs/{{ item.value | basename }}"' {{ __test_outputfiles_conf }}
       with_dict:
         - cacert: "{{ __test_ca_cert }}"
         - mycert: "{{ __test_cert }}"
-        - myprivkey: "{{ __test_key }}"
+      changed_when: false
+
+    - name: Check key in {{ __test_outputfiles_conf }}
+      command: /bin/grep 'tls.myprivkey="/etc/pki/tls/private/{{ __test_key | basename }}"' {{ __test_outputfiles_conf }}
       changed_when: false
 
     - name: Check retryfailures in {{ __test_outputfiles_conf }}
@@ -131,9 +134,9 @@
     - name: clean up fake pki files
       file: path="{{ item }}" state=absent
       loop:
-        - /etc/rsyslog.d/es-key.pem
-        - /etc/rsyslog.d/es-cert.pem
-        - /etc/rsyslog.d/es-ca.crt
+        - /etc/pki/tls/private/es-key.pem
+        - /etc/pki/tls/certs/es-cert.pem
+        - /etc/pki/tls/certs/es-ca.crt
 
     # TEST CASE 1
     - name: TEST CASE 1; Elasticsearch config - local certs are copied to the target host with the specified path.

--- a/tests/tests_relp.yml
+++ b/tests/tests_relp.yml
@@ -113,6 +113,36 @@
       register: __result
       failed_when: __result.stdout != "1"
 
+    - name: Check the ca cert in relp_server0 - 0
+      shell: |-
+        grep 'tls.cacert="/etc/pki/tls/certs/test-ca.crt"' "{{ __test_relp_server0 }}" | wc -l
+      register: __result
+      failed_when: __result.stdout != "1"
+
+    - name: Check the ca cert in relp_server0 - 1
+      stat:
+        path: /etc/pki/tls/certs/test-ca.crt
+
+    - name: Check the cert in relp_server0 - 0
+      shell: |-
+        grep 'tls.mycert="/etc/pki/tls/certs/test-cert.pem"' "{{ __test_relp_server0 }}" | wc -l
+      register: __result
+      failed_when: __result.stdout != "1"
+
+    - name: Check the cert in relp_server0 - 1
+      stat:
+        path: /etc/pki/tls/certs/test-cert.pem
+
+    - name: Check the private key in relp_server0 - 0
+      shell: |-
+        grep 'tls.myprivkey="/etc/pki/tls/private/test-key.pem"' "{{ __test_relp_server0 }}" | wc -l
+      register: __result
+      failed_when: __result.stdout != "1"
+
+    - name: Check the private key in relp_server0 - 1
+      stat:
+        path: /etc/pki/tls/private/test-key.pem
+
     - name: END TEST CASE 0; Clean up the deployed config
       vars:
         logging_enabled: false
@@ -213,6 +243,36 @@
       shell: grep "7514" "{{ __test_relp_client1 }}" | wc -l
       register: __result
       failed_when: __result.stdout != "1"
+
+    - name: Check the ca cert in relp_client0 - 0
+      shell: |-
+        grep 'tls.cacert="/etc/pki/tls/certs/test-ca.crt"' "{{ __test_relp_client0 }}" | wc -l
+      register: __result
+      failed_when: __result.stdout != "1"
+
+    - name: Check the ca cert in relp_client0 - 1
+      stat:
+        path: /etc/pki/tls/certs/test-ca.crt
+
+    - name: Check the cert in relp_client0 - 0
+      shell: |-
+        grep 'tls.mycert="/etc/pki/tls/certs/test-cert.pem"' "{{ __test_relp_client0 }}" | wc -l
+      register: __result
+      failed_when: __result.stdout != "1"
+
+    - name: Check the cert in relp_client0 - 1
+      stat:
+        path: /etc/pki/tls/certs/test-cert.pem
+
+    - name: Check the private key in relp_client0 - 0
+      shell: |-
+        grep 'tls.myprivkey="/etc/pki/tls/private/test-key.pem"' "{{ __test_relp_client0 }}" | wc -l
+      register: __result
+      failed_when: __result.stdout != "1"
+
+    - name: Check the private key in relp_client0 - 1
+      stat:
+        path: /etc/pki/tls/private/test-key.pem
 
     - name: END TEST CASE 1; Clean up the deployed config
       vars:


### PR DESCRIPTION
When ca_cert_src, cert_src, and private_key_src are specified without the
corresponding target locations ca_cert, cert, and private_key, the files
are copied to /etc/rsyslog.d for the elasticsearch output and the relp
input/output. On the other hand, logging_pki_files copies to /etc/pki/tls.

The inconsistent behaviour should confuse the users. Since relp is new,
and we are releasing the next version as a major update (with major_version++),
it is a good timing to adjust it.

README and test cases are updated.

https://github.com/linux-system-roles/logging/issues/205