### PR TITLE
use tox-lsr 2.2.0

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -3,7 +3,7 @@ name: tox
 on:  # yamllint disable-line rule:truthy
   - pull_request
 env:
-  TOX_LSR: "git+https://github.com/linux-system-roles/tox-lsr@2.1.2"
+  TOX_LSR: "git+https://github.com/linux-system-roles/tox-lsr@2.2.0"
   LSR_ANSIBLES: 'ansible==2.8.* ansible==2.9.*'
   LSR_MSCENARIOS: default
   # LSR_EXTRA_PACKAGES: libdbus-1-dev


### PR DESCRIPTION
Upgrade to tox-lsr 2.2.0 to pick up fix for improving collection
testing to get rid of black.