### PR TITLE
Bug 1927943 - Logging - Integrating ELK with RHV-4.4 fails as RHVH is…

### DIFF
--- a/roles/rsyslog/tasks/main.yml
+++ b/roles/rsyslog/tasks/main.yml
@@ -13,7 +13,9 @@
 
 - name: Install/Update required packages
   package:
-    name: "{{ __rsyslog_base_packages }} + {{ __rsyslog_tls_packages }} + {{ rsyslog_extra_packages | flatten }}"
+    name: "{{ __rsyslog_base_packages }} +
+      {{ __rsyslog_tls_packages if (logging_pki_files | d([]) | length > 0) else [] }} +
+      {{ rsyslog_extra_packages | flatten }}"
     state: latest
   when:
     - __rsyslog_enabled | bool

--- a/tests/tasks/check_packages.yml
+++ b/tests/tasks/check_packages.yml
@@ -1,0 +1,41 @@
+- name: Gather the package facts
+  package_facts:
+    manager: auto
+
+- name: Check expected packages are installed
+  assert:
+    that: "{{ item in ansible_facts.packages }}"
+  loop: "{{ __expected }}"
+
+- name: Get not installed list
+  set_fact:
+    __not_installed: "{{ __all_rsyslog_packages | difference(__expected) }}"
+  vars:
+    __all_rsyslog_packages:
+      - ca-certificates
+      - librelp
+      - rsyslog-crypto
+      - rsyslog-elasticsearch
+      - rsyslog-gnutls
+      - rsyslog-gssapi
+      - rsyslog-hiredis
+      - rsyslog-kafka
+      - rsyslog-libdbi
+      - rsyslog-mmaudit
+      - rsyslog-mmjsonparse
+      - rsyslog-mmkubernetes
+      - rsyslog-mmnormalize
+      - rsyslog-mmsnmptrapd
+      - rsyslog-mongodb
+      - rsyslog-mysql
+      - rsyslog-omamqp1
+      - rsyslog-pgsql
+      - rsyslog-rabbitmq
+      - rsyslog-relp
+      - rsyslog-snmp
+      - rsyslog-udpspoof
+
+- name: Check packages that should not be are not installed
+  assert:
+    that: "{{ item not in ansible_facts.packages }}"
+  loop: "{{ __not_installed }}"

--- a/tests/tests_basics_files.yml
+++ b/tests/tests_basics_files.yml
@@ -39,6 +39,13 @@
         __check_systemctl_status: true
       include_tasks: tasks/check_daemon_config_files.yml
 
+    - name: Ensure installed packages
+      vars:
+        __expected:
+          - rsyslog
+          - ca-certificates
+      include_tasks: tasks/check_packages.yml
+
     - name: Grep output to messages line
       command: /bin/grep '\*.info;mail.none;authpriv.none;cron.none.*{{ __default_system_log }}' '{{ __test_default_files_conf }}'
       changed_when: false
@@ -98,6 +105,13 @@
           - "{{ __test_files_conf0 }}"
         __check_systemctl_status: true
       include_tasks: tasks/check_daemon_config_files.yml
+
+    - name: Ensure installed packages
+      vars:
+        __expected:
+          - rsyslog
+          - ca-certificates
+      include_tasks: tasks/check_packages.yml
 
     - name: Ensure logger message is logged in a file
       vars:
@@ -282,6 +296,13 @@
           - "{{ __test_forwards_conf }}"
         __check_systemctl_status: true
       include_tasks: tasks/check_daemon_config_files.yml
+
+    - name: Ensure installed packages
+      vars:
+        __expected:
+          - rsyslog
+          - ca-certificates
+      include_tasks: tasks/check_packages.yml
 
     - name: Check the filter
       command: /bin/grep '\*.info;authpriv.none;auth.none;cron.none;mail.none.*{{ __default_system_log }}' '{{ __test_files_conf0 }}'

--- a/tests/tests_basics_forwards.yml
+++ b/tests/tests_basics_forwards.yml
@@ -94,6 +94,13 @@
         __check_systemctl_status: true
       include_tasks: tasks/check_daemon_config_files.yml
 
+    - name: Ensure installed packages
+      vars:
+        __expected:
+          - rsyslog
+          - ca-certificates
+      include_tasks: tasks/check_packages.yml
+
     - name: Generated a file to check severity_and_facility
       copy:
         dest: /tmp/__testfile__
@@ -328,6 +335,14 @@
         __check_systemctl_status: true
       include_tasks: tasks/check_daemon_config_files.yml
 
+    - name: Ensure installed packages
+      vars:
+        __expected:
+          - rsyslog
+          - rsyslog-gnutls
+          - ca-certificates
+      include_tasks: tasks/check_packages.yml
+
     - name: Generated a file to check severity_and_facility
       copy:
         dest: /tmp/__testfile__
@@ -393,6 +408,11 @@
       loop:
         - "/etc/pki/tls/certs/{{ __test_ca_cert_name }}"
 
+    - name: Uninstall rsyslog-gnutls
+      package:
+        name: ["rsyslog-gnutls"]
+        state: absent
+
     # TEST CASE 2
     - name: TEST CASE 2; Test the configuration, basics input and a forwards output with logging_pki_files
       vars:
@@ -433,6 +453,14 @@
           - "{{ __test_files_conf }}"
         __check_systemctl_status: true
       include_tasks: tasks/check_daemon_config_files.yml
+
+    - name: Ensure installed packages
+      vars:
+        __expected:
+          - rsyslog
+          - rsyslog-gnutls
+          - ca-certificates
+      include_tasks: tasks/check_packages.yml
 
     - name: Generated a file to check severity_and_facility
       copy:
@@ -577,3 +605,8 @@
         - "{{ __test_key }}"
         - /tmp/__testfile__
       delegate_to: localhost
+
+    - name: Uninstall rsyslog-gnutls
+      package:
+        name: ["rsyslog-gnutls"]
+        state: absent

--- a/tests/tests_combination.yml
+++ b/tests/tests_combination.yml
@@ -82,6 +82,13 @@
         __check_systemctl_status: true
       include_tasks: tasks/check_daemon_config_files.yml
 
+    - name: Ensure installed packages
+      vars:
+        __expected:
+          - rsyslog
+          - ca-certificates
+      include_tasks: tasks/check_packages.yml
+
     - name: Check if the files config exists
       stat:
         path: "{{ __test_files_conf }}"
@@ -254,6 +261,13 @@
         __check_systemctl_status: true
       include_tasks: tasks/check_daemon_config_files.yml
 
+    - name: Ensure installed packages
+      vars:
+        __expected:
+          - rsyslog
+          - ca-certificates
+      include_tasks: tasks/check_packages.yml
+
     - name: Check the files config stat
       stat:
         path: "{{ __test_files_conf }}"
@@ -422,6 +436,13 @@
         __check_systemctl_status: true
       include_tasks: tasks/check_daemon_config_files.yml
 
+    - name: Ensure installed packages
+      vars:
+        __expected:
+          - rsyslog
+          - ca-certificates
+      include_tasks: tasks/check_packages.yml
+
     - name: Generate test config file to be overridden
       copy:
         dest: "{{ __test_basics_conf }}"
@@ -498,6 +519,13 @@
           - "{{ __test_basics_conf }}"
         __check_systemctl_status: true
       include_tasks: tasks/check_daemon_config_files.yml
+
+    - name: Ensure installed packages
+      vars:
+        __expected:
+          - rsyslog
+          - ca-certificates
+      include_tasks: tasks/check_packages.yml
 
     - name: Check {{ __test_basics_conf }} was updated
       command: '/bin/grep "# GENERATED BASICS CONFIG FILE" {{ __test_basics_conf }}'

--- a/tests/tests_default.yml
+++ b/tests/tests_default.yml
@@ -8,3 +8,10 @@
     - name: default run (NOOP)
       include_role:
         name: linux-system-roles.logging
+
+    - name: Ensure installed packages
+      vars:
+        __expected:
+          - rsyslog
+          - ca-certificates
+      include_tasks: tasks/check_packages.yml

--- a/tests/tests_enabled.yml
+++ b/tests/tests_enabled.yml
@@ -36,3 +36,10 @@
         __conf_files: []
         __check_systemctl_status: true
       include_tasks: tasks/check_daemon_config_files.yml
+
+    - name: Ensure installed packages
+      vars:
+        __expected:
+          - rsyslog
+          - ca-certificates
+      include_tasks: tasks/check_packages.yml

--- a/tests/tests_files_elasticsearch.yml
+++ b/tests/tests_files_elasticsearch.yml
@@ -68,6 +68,14 @@
         __check_systemctl_status: true
       include_tasks: tasks/check_daemon_config_files.yml
 
+    - name: Ensure installed packages
+      vars:
+        __expected:
+          - rsyslog
+          - ca-certificates
+          - rsyslog-elasticsearch
+      include_tasks: tasks/check_packages.yml
+
     - name: Check if the output files config exists
       stat:
         path: "{{ __test_outputfiles_conf }}"
@@ -138,6 +146,11 @@
         - /etc/pki/tls/certs/es-cert.pem
         - /etc/pki/tls/certs/es-ca.crt
 
+    - name: Uninstall rsyslog-elasticsearch
+      package:
+        name: ["rsyslog-elasticsearch"]
+        state: absent
+
     # TEST CASE 1
     - name: TEST CASE 1; Elasticsearch config - local certs are copied to the target host with the specified path.
       vars:
@@ -180,6 +193,22 @@
           - "{{ __test_outputfiles_conf }}"
         __check_systemctl_status: true
       include_tasks: tasks/check_daemon_config_files.yml
+
+    - name: Ensure installed packages
+      vars:
+        __expected:
+          - rsyslog
+          - ca-certificates
+          - rsyslog-elasticsearch
+      include_tasks: tasks/check_packages.yml
+
+    - name: Ensure installed packages
+      vars:
+        __expected:
+          - rsyslog
+          - ca-certificates
+          - rsyslog-elasticsearch
+      include_tasks: tasks/check_packages.yml
 
     - name: Check if the output files config exists
       stat:
@@ -454,3 +483,8 @@
     # thus we have to force to invoke handlers
     - name: Force all notified handlers to run at this point, not waiting for normal sync points
       meta: flush_handlers
+
+    - name: Uninstall rsyslog-elasticsearch
+      package:
+        name: ["rsyslog-elasticsearch"]
+        state: absent

--- a/tests/tests_files_files.yml
+++ b/tests/tests_files_files.yml
@@ -83,6 +83,13 @@
         __check_systemctl_status: true
       include_tasks: tasks/check_daemon_config_files.yml
 
+    - name: Ensure installed packages
+      vars:
+        __expected:
+          - rsyslog
+          - ca-certificates
+      include_tasks: tasks/check_packages.yml
+
     - name: Check if the input files config does not exist
       stat:
         path: "{{ __test_inputfiles_conf2 }}"

--- a/tests/tests_imuxsock_files.yml
+++ b/tests/tests_imuxsock_files.yml
@@ -52,6 +52,13 @@
         __check_systemctl_status: true
       include_tasks: tasks/check_daemon_config_files.yml
 
+    - name: Ensure installed packages
+      vars:
+        __expected:
+          - rsyslog
+          - ca-certificates
+      include_tasks: tasks/check_packages.yml
+
     - name: Check output to messages line
       command: /bin/grep '\*.info;mail.none;authpriv.none;cron.none.*{{ __default_system_log }}' '{{ __test_files_conf }}'
       changed_when: false

--- a/tests/tests_ovirt_elasticsearch.yml
+++ b/tests/tests_ovirt_elasticsearch.yml
@@ -85,6 +85,19 @@
         __check_systemctl_status: false
       include_tasks: tasks/check_daemon_config_files.yml
 
+    - name: Ensure installed packages
+      vars:
+        __expected:
+          - rsyslog
+          - ca-certificates
+          - rsyslog-elasticsearch
+          - rsyslog-mmnormalize
+          - rsyslog-mmjsonparse
+          - libfastjson
+          - liblognorm
+          - libestr
+      include_tasks: tasks/check_packages.yml
+
     - name: Check "{{ __test_ovirt_collectd_conf }}, {{ __test_ovirt_engine_conf }}, {{ __test_ovirt_vdsm_conf }}"
       stat:
         path: "{{ item }}"
@@ -178,6 +191,17 @@
     - name: Force all notified handlers to run at this point, not waiting for normal sync points
       meta: flush_handlers
 
+    - name: Uninstall rsyslog-elasticsearch,mmjsonparse,mmnormalize,libestr,libfastjson,liblognorm
+      package:
+        name:
+          - rsyslog-elasticsearch
+          - rsyslog-mmjsonparse
+          - rsyslog-mmnormalize
+          - libestr
+          - libfastjson
+          - liblognorm
+        state: absent
+
     - name: TEST CASE 1; Ensure advanced ovirt configuration works
       vars:
         logging_outputs:
@@ -263,6 +287,19 @@
           - "{{ __test_ovirt_vdsm_conf }}"
         __check_systemctl_status: false
       include_tasks: tasks/check_daemon_config_files.yml
+
+    - name: Ensure installed packages
+      vars:
+        __expected:
+          - rsyslog
+          - ca-certificates
+          - rsyslog-elasticsearch
+          - rsyslog-mmnormalize
+          - rsyslog-mmjsonparse
+          - libfastjson
+          - liblognorm
+          - libestr
+      include_tasks: tasks/check_packages.yml
 
     - name: Check "{{ __test_ovirt_collectd_conf }}, {{ __test_ovirt_engine_conf }}, {{ __test_ovirt_vdsm_conf }}"
       stat:
@@ -395,3 +432,14 @@
     # thus we have to force to invoke handlers
     - name: Force all notified handlers to run at this point, not waiting for normal sync points
       meta: flush_handlers
+
+    - name: Uninstall rsyslog-elasticsearch,mmjsonparse,mmnormalize,libestr,libfastjson,liblognorm
+      package:
+        name:
+          - rsyslog-elasticsearch
+          - rsyslog-mmjsonparse
+          - rsyslog-mmnormalize
+          - libfastjson
+          - liblognorm
+          - libestr
+        state: absent

--- a/tests/tests_relp.yml
+++ b/tests/tests_relp.yml
@@ -77,6 +77,15 @@
         __check_systemctl_status: true
       include_tasks: tasks/check_daemon_config_files.yml
 
+    - name: Ensure installed packages
+      vars:
+        __expected:
+          - rsyslog
+          - ca-certificates
+          - rsyslog-relp
+          - librelp
+      include_tasks: tasks/check_packages.yml
+
     - name: Install lsof
       package:
         name: lsof
@@ -196,6 +205,11 @@
     - name: Force all notified handlers to run at this point, not waiting for normal sync points
       meta: flush_handlers
 
+    - name: Uninstall relp
+      package:
+        name: ["rsyslog-relp", "librelp"]
+        state: absent
+
     # TEST CASE 1
     - name: TEST CASE 1; Test the client configuration using tls relp
       vars:
@@ -246,6 +260,15 @@
           - "{{ __test_relp_client1 }}"
         __check_systemctl_status: false
       include_tasks: tasks/check_daemon_config_files.yml
+
+    - name: Ensure installed packages
+      vars:
+        __expected:
+          - rsyslog
+          - ca-certificates
+          - rsyslog-relp
+          - librelp
+      include_tasks: tasks/check_packages.yml
 
     - name: Check the port in relp_client1
       shell: grep "7514" "{{ __test_relp_client1 }}" | wc -l
@@ -345,3 +368,8 @@
         - "{{ __test_key }}"
         - "{{ __test_cert_csr }}"
         - "{{ __test_cert }}"
+
+    - name: Uninstall relp
+      package:
+        name: ["rsyslog-relp", "librelp"]
+        state: absent

--- a/tests/tests_remote.yml
+++ b/tests/tests_remote.yml
@@ -45,6 +45,13 @@
         __check_systemctl_status: true
       include_tasks: tasks/check_daemon_config_files.yml
 
+    - name: Ensure installed packages
+      vars:
+        __expected:
+          - rsyslog
+          - ca-certificates
+      include_tasks: tasks/check_packages.yml
+
     # Checking 'error' in stdout from systemctl status is for detecting the case in which rsyslog is running,
     # but some functionality is disabled due to some error, e.g., error: 'tls.cacert' file couldn't be accessed.
     - name: Check rsyslog errors
@@ -156,6 +163,13 @@
           - "{{ __test_output_remote1 }}"
         __check_systemctl_status: true
       include_tasks: tasks/check_daemon_config_files.yml
+
+    - name: Ensure installed packages
+      vars:
+        __expected:
+          - rsyslog
+          - ca-certificates
+      include_tasks: tasks/check_packages.yml
 
     - name: Install lsof
       package:

--- a/tests/tests_server.yml
+++ b/tests/tests_server.yml
@@ -81,6 +81,14 @@
         __check_systemctl_status: true
       include_tasks: tasks/check_daemon_config_files.yml
 
+    - name: Ensure installed packages
+      vars:
+        __expected:
+          - rsyslog
+          - ca-certificates
+          - rsyslog-gnutls
+      include_tasks: tasks/check_packages.yml
+
     - name: Install lsof
       package:
         name: lsof
@@ -230,3 +238,8 @@
       rescue:
         - debug:
             msg: Caught an expected error - {{ ansible_failed_result }}
+
+    - name: Uninstall rsyslog-gnutls
+      package:
+        name: ["rsyslog-gnutls"]
+        state: absent


### PR DESCRIPTION
… missing 'rsyslog-gnutls' package.

rsyslog-gnutls is needed when the global tls is configured with the
variable logging_pki_files. When the package module is called for
rsyslog-gnutls, this pr adds a check for logging_pki-files and only
when it is configured, rsyslog-gnutls is installed.

Also, a check is added to every test case that the necessary and
sufficient packages are installed.