### PR TITLE
A bug fix brought in in commit da399b95287ea1623ca844c91e3368372b2e60…

### DIFF
--- a/roles/rsyslog/tasks/set_certs.yml
+++ b/roles/rsyslog/tasks/set_certs.yml
@@ -20,7 +20,7 @@
     - name: Copy key on the control host to the specified path on the target host
       copy:
         src: '{{ item.private_key_src }}'
-        dest: '{{ item.private_key | d(__rsyslog_default_pki_path + __rsyslog_default_pki_cert_dir) }}'
+        dest: '{{ item.private_key | d(__rsyslog_default_pki_path + __rsyslog_default_pki_key_dir) }}'
       with_items:
         - '{{ __rsyslog_cert_subject }}'
       when: item.private_key_src | d()


### PR DESCRIPTION
…c9 (tls)

Issue: cert and key files should be deployed in the /etc/pki/tls folder
https://github.com/linux-system-roles/logging/issues/205

The default private key path should be /etc/pki/tls/private, but it was
set to /etc/pki/tls/certs.