### PR TITLE
CI: Add support for RHEL-9

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -14,5 +14,6 @@ galaxy_info:
       versions:
         - 7
         - 8
+        - 9
 
 allow_duplicates: true

--- a/roles/rsyslog/meta/main.yml
+++ b/roles/rsyslog/meta/main.yml
@@ -14,5 +14,6 @@ galaxy_info:
       versions:
         - 7
         - 8
+        - 9
 
 allow_duplicates: true


### PR DESCRIPTION
From now the `rhel-8-y` status is the latest unreleased RHEL-8 and the `rhel-x` status is pre-released RHEL-9.