### PR TITLE
Instead of the archive module, use "tar" command for backup.

### DIFF
--- a/roles/rsyslog/tasks/main.yml
+++ b/roles/rsyslog/tasks/main.yml
@@ -64,28 +64,31 @@
         path: '{{ __rsyslog_work_dir }}'
         mode: '0700'
 
-    # Creating a backup dir for rsyslog.d
-    - name: Set backup dir name
-      set_fact:
-        rsyslog_backup_dir: '{{ rsyslog_backup_dir |
-          d("/tmp") }}/rsyslog.d-{{ ansible_date_time.iso8601_basic_short }}'
-
-    - name: Create a backup dir
-      file:
-        state: directory
-        path: '{{ rsyslog_backup_dir }}'
-        mode: '0700'
-      changed_when: false
-
     # Back up the pre-existing rsyslog config files in the backup dir,
     # then removing the files/dirs in rsyslog.d.
-    - name: Archive the contents of {{ __rsyslog_config_dir }} to the backup dir
-      archive:
-        path: ["{{ __rsyslog_config_dir }}", /etc/rsyslog.conf]
-        dest: "{{ rsyslog_backup_dir }}/backup.tgz"
-        remove: '{{ true if __rsyslog_purge_original_conf | bool else false }}'
-        mode: '0600'
-      changed_when: false
+    - block:
+        - name: Create a backup dir
+          file:
+            state: directory
+            path: '{{ __rsyslog_backup_dir }}'
+            mode: '0700'
+          changed_when: false
+
+        - name: Archive the contents of {{ __rsyslog_config_dir }} to
+            the backup dir
+          command: >
+            tar -cvzf "{{ __rsyslog_backup_dir }}/backup.tgz"
+                /etc/rsyslog.conf "{{ __rsyslog_config_dir }}"
+          changed_when: false
+
+        - name: Purge original conf
+          file:
+            state: absent
+            path: "{{ __rsyslog_config_dir }}/*"
+          when: __rsyslog_purge_original_conf | bool | d(false)
+      vars:
+        __rsyslog_backup_dir: '{{ rsyslog_backup_dir |
+          d("/tmp") }}/rsyslog.d-{{ ansible_date_time.iso8601_basic_short }}'
 
     - name: "Create logging directory if it does not exist or
       the ownership and/or modes are different."

--- a/tests/tests_basics_files.yml
+++ b/tests/tests_basics_files.yml
@@ -173,7 +173,6 @@
         - name: "TEST CASE 2; Test the configuration, which flow
           contains a undefined input bogus_basic_input"
           vars:
-            logging_purge_confs: true
             logging_outputs:
               - name: files_output0
                 type: files
@@ -273,6 +272,7 @@
     - name: "TEST CASE 3; Ensure that the role runs with parameters
       from imjournal input to two omfile and two omfwd outputs"
       vars:
+        logging_purge_confs: true
         logging_outputs:
           - name: files_output0
             type: files


### PR DESCRIPTION
Note: having the module 'archive' makes the logging role fail with
an error "couldn't resolve module/action 'archive'." if executed
with ansible-navigator.

Stop using set_fact to set rsyslog_backup_dir in roles/rsyslog/tasks/main.yml
to fix a bug that the backup dir could have repeated
rsyslog.d-{{ ansible_date_time.iso8601_basic_short }}
sub-directories if the logging role is executed multiple times.

Move "logging_purge_confs: true" to TEST CASE 3 in tests_basic_files.yml.