### PR TITLE
Add a support for list value to server_host in the elasticsearch output

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,11 +216,11 @@ Available options:
 `elasticsearch` output supports sending logs to Elasticsearch. It is available only when the input is `ovirt`. Assuming Elasticsearch is already configured and running.
 
 Available options:
-- `server_host`: Host name Elasticsearch is running on. **Required**.
+- `server_host`: Host name Elasticsearch is running on. The value is a single host or list of hosts. **Required**.
 - `server_port`: Port number Elasticsearch is listening to. Default to `9200`.
 - `index_prefix`: Elasticsearch index prefix the particular log will be indexed to. **Required**.
 - `input_type`: Specifying the input type. Currently only type `ovirt` is supported. Default to `ovirt`.
-- `retryfailures`: Specifying whether retries or not in case of failure. Allowed value is `true` or `false`.  Default to `true`.
+- `retryfailures`: Specifying whether retries or not in case of failure. Allowed value is `true` or `false`. Default to `true`.
 - `tls`: If true, encrypt the connection with TLS. You must provide key/certificates and triplets {`ca_cert`, `cert`, `private_key`} and/or {`ca_cert_src`, `cert_src`, `private_key_src`}. Default to `true`.
 - `use_cert`: [DEPRECATED] If true, encrypt the connection with TLS. You must provide key/certificates and triplets {`ca_cert`, `cert`, `private_key`} and/or {`ca_cert_src`, `cert_src`, `private_key_src`}. Default to `true`. Option `use_cert` is deprecated in favor of `tls` and `use_cert` will be removed in the next minor release.
 - `ca_cert`: Path to CA cert for Elasticsearch. Default to `/etc/pki/tls/certs/basename of ca_cert_src`.

--- a/roles/rsyslog/templates/output_elasticsearch.j2
+++ b/roles/rsyslog/templates/output_elasticsearch.j2
@@ -33,7 +33,13 @@ ruleset(name="{{ item.name }}") {
         action(
             type="omelasticsearch"
             name="{{ item.name }}"
-            server="{{ item.server_host | d('logging-es') }}"
+{% if item.server_host is string %}
+            server="{{ item.server_host }}"
+{% elif item.server_host is sequence %}
+            server={{ item.server_host }}
+{% else %}
+            server="logging-es"
+{% endif %}
             serverport="{{ item.server_port | d(9200) | int }}"
             template="{{ item.template | d("es_template") }}"
             searchIndex="{{ item.searchIndex | d("index_template") }}"

--- a/tests/tests_ovirt_elasticsearch.yml
+++ b/tests/tests_ovirt_elasticsearch.yml
@@ -166,6 +166,14 @@
         {{ __test_ovirt_vdsm_conf }}
       changed_when: false
 
+    - name: Check server param in "{{ __test_es_conf }}"
+      command: /bin/grep 'server="logging-es"' {{ __test_es_conf }}
+      changed_when: false
+
+    - name: Check server param in "{{ __test_es_ops_conf }}"
+      command: /bin/grep 'server="logging-es-ops"' {{ __test_es_ops_conf }}
+      changed_when: false
+
     - name: END TEST CASE 0; Ensure basic ovirt configuration works
       vars:
         logging_enabled: false
@@ -239,7 +247,7 @@
             type: file
           - name: elasticsearch_output
             type: elasticsearch
-            server_host: logging-es
+            server_host: [logging-es0, logging-es1]
             server_port: 9200
             index_prefix: project.
             input_type: ovirt
@@ -248,7 +256,9 @@
             private_key: "/etc/rsyslog.d/es-key.pem"
           - name: elasticsearch_output_ops
             type: elasticsearch
-            server_host: logging-es-ops
+            server_host:
+              - logging-es-ops0
+              - logging-es-ops1
             server_port: 9200
             index_prefix: .operations.
             input_type: ovirt
@@ -415,6 +425,17 @@
         - "retryfailures=.off."
       changed_when: false
 
+    - name: Check server param in "{{ __test_es_conf }}"
+      command: >-
+        /bin/grep "server=\['logging-es0', 'logging-es1'\]" {{ __test_es_conf }}
+      changed_when: false
+
+    - name: Check server param in "{{ __test_es_ops_conf }}"
+      command: >-
+        /bin/grep "server=\['logging-es-ops0', 'logging-es-ops1'\]"
+                  {{ __test_es_ops_conf }}
+      changed_when: false
+
     - name: END TEST CASE 1; Ensure basic ovirt configuration works
       vars:
         logging_enabled: false
@@ -424,7 +445,7 @@
             state: absent
           - name: elasticsearch_output
             type: elasticsearch
-            server_host: logging-es
+            server_host: [logging-es0, logging-es1]
             server_port: 9200
             index_prefix: project.
             input_type: ovirt
@@ -434,7 +455,9 @@
             state: absent
           - name: elasticsearch_output_ops
             type: elasticsearch
-            server_host: logging-es-ops
+            server_host:
+              - logging-es-ops0
+              - logging-es-ops1
             server_port: 9200
             index_prefix: .operations.
             input_type: ovirt


### PR DESCRIPTION
RFE from oVirt:
elasticsearch now allows the server to be a list of servers:
https://www.rsyslog.com/doc/v8-stable/configuration/modules/omelasticsearch.html#server
Is this variable adjusted in Logging repo to be an array?

- `server_host`: Host name Elasticsearch is running on. The value
  is a single host or list of hosts. **Required**.