### PR TITLE
create_tests_certs: Ensure python3-cryptography exists in RedHat/CentOS-8 and newer

### DIFF
--- a/tests/tasks/create_tests_certs.yml
+++ b/tests/tasks/create_tests_certs.yml
@@ -1,4 +1,4 @@
-- name: Install python2-cryptography
+- name: Ensure python2-cryptography exists in RedHat/CentOS-7
   package:
     name:
       - python2-cryptography
@@ -7,6 +7,16 @@
     - ansible_facts["distribution"] == "CentOS" or
       ansible_facts["distribution"] == "RedHat"
     - ansible_facts["distribution_major_version"] == "7"
+
+- name: Ensure python3-cryptography exists in RedHat/CentOS-8 and newer
+  package:
+    name:
+      - python3-cryptography
+    state: present
+  when:
+    - ansible_facts["distribution"] == "CentOS" or
+      ansible_facts["distribution"] == "RedHat"
+    - ansible_facts["distribution_major_version"] >= "8"
 
 - name: Generate a CA key
   openssl_privatekey:


### PR DESCRIPTION
Test cases that requires the TLS configuration failed due to the missing
the python3-cryptography package. The package is not installed by
default. This patch ensures it is installed.

bz1989962