### PR TITLE
[FIX] "Purge original conf" task

### DIFF
--- a/roles/rsyslog/tasks/main.yml
+++ b/roles/rsyslog/tasks/main.yml
@@ -85,11 +85,6 @@
           shell: |-
             set -euo pipefail
             /bin/rm -rf {{ __rsyslog_config_dir }}/*
-        # 'file' module "state=absent" does not work with "path=/some/dir/*" (wildcard)
-        # 'file' module should support "state=empty" see: https://github.com/ansible/ansible/issues/18910
-        #  file:
-        #    state: empty
-        #    path: "{{ __rsyslog_config_dir }}"
           when: __rsyslog_purge_original_conf | bool | d(false)
       vars:
         __rsyslog_backup_dir: '{{ rsyslog_backup_dir |

--- a/roles/rsyslog/tasks/main.yml
+++ b/roles/rsyslog/tasks/main.yml
@@ -82,9 +82,12 @@
           changed_when: false
 
         - name: Purge original conf
-          file:
-            state: absent
-            path: "{{ __rsyslog_config_dir }}/*"
+          shell: "/bin/rm -rf {{ __rsyslog_config_dir }}/*"
+        # 'file' module "state=absent" does not work with "path=/some/dir/*" (wildcard)
+        # 'file' module should support "state=empty" see: https://github.com/ansible/ansible/issues/18910
+        #  file:
+        #    state: empty
+        #    path: "{{ __rsyslog_config_dir }}"
           when: __rsyslog_purge_original_conf | bool | d(false)
       vars:
         __rsyslog_backup_dir: '{{ rsyslog_backup_dir |

--- a/roles/rsyslog/tasks/main.yml
+++ b/roles/rsyslog/tasks/main.yml
@@ -82,12 +82,7 @@
           changed_when: false
 
         - name: Purge original conf
-          shell: "/bin/rm -rf {{ __rsyslog_config_dir }}/*"
-        # 'file' module "state=absent" does not work with "path=/some/dir/*" (wildcard)
-        # 'file' module should support "state=empty" see: https://github.com/ansible/ansible/issues/18910
-        #  file:
-        #    state: empty
-        #    path: "{{ __rsyslog_config_dir }}"
+          shell: set -euo pipefail; /bin/rm -rf {{ __rsyslog_config_dir }}/*
           when: __rsyslog_purge_original_conf | bool | d(false)
       vars:
         __rsyslog_backup_dir: '{{ rsyslog_backup_dir |


### PR DESCRIPTION
`file` module `state=absent` does not work with `path=/some/dir/*` (wildcard)
`file` module should support `state=empty` see: https://github.com/ansible/ansible/issues/18910
`state=empty` is needed here - and should be used later