### PR TITLE
python2 renders server_host list incorrectly

### DIFF
--- a/roles/rsyslog/templates/output_elasticsearch.j2
+++ b/roles/rsyslog/templates/output_elasticsearch.j2
@@ -36,7 +36,7 @@ ruleset(name="{{ item.name }}") {
 {% if item.server_host is string %}
             server="{{ item.server_host }}"
 {% elif item.server_host is sequence %}
-            server={{ item.server_host }}
+            server=[{% for srv in item.server_host %}"{{ srv }}"{{ '' if loop.last else ', ' }}{% endfor %}]
 {% else %}
             server="logging-es"
 {% endif %}

--- a/tests/tests_ovirt_elasticsearch.yml
+++ b/tests/tests_ovirt_elasticsearch.yml
@@ -427,12 +427,13 @@
 
     - name: Check server param in "{{ __test_es_conf }}"
       command: >-
-        /bin/grep "server=\['logging-es0', 'logging-es1'\]" {{ __test_es_conf }}
+        /bin/grep "server=\[\"logging-es0\", \"logging-es1\"\]"
+                  {{ __test_es_conf }}
       changed_when: false
 
     - name: Check server param in "{{ __test_es_ops_conf }}"
       command: >-
-        /bin/grep "server=\['logging-es-ops0', 'logging-es-ops1'\]"
+        /bin/grep "server=\[\"logging-es-ops0\", \"logging-es-ops1\"\]"
                   {{ __test_es_ops_conf }}
       changed_when: false
 


### PR DESCRIPTION
On python2 (el7) when server_host is a list, this:
```
          server={{ item.server_host }}
```
gets rendered as this:
```
          server=[u'logging-es0', u'logging-es1']
```
I think we should not rely on the python/jinja2 list to string
conversion being exactly the same format as the rsyslog string list format.