### PR TITLE
do not warn about unarchive or leading slashes

### DIFF
--- a/roles/rsyslog/tasks/main.yml
+++ b/roles/rsyslog/tasks/main.yml
@@ -77,8 +77,10 @@
         - name: Archive the contents of {{ __rsyslog_config_dir }} to
             the backup dir
           command: >
-            tar -cvzf "{{ __rsyslog_backup_dir }}/backup.tgz"
+            tar -cvzPf "{{ __rsyslog_backup_dir }}/backup.tgz"
                 /etc/rsyslog.conf "{{ __rsyslog_config_dir }}"
+          args:
+            warn: false  # suppress 'unarchive' warning
           changed_when: false
 
         - name: Purge original conf


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1984182
Use the `args.warn: false` to omit the warning about using
`unarchive` instead of the `tar` command.
Use the `tar` `-P` flag to omit the warning about trimming
leading slashes `/` from the paths.