### PR TITLE
WIP: [FIX] "Purge original conf" task

### DIFF
--- a/roles/rsyslog/handlers/main.yml
+++ b/roles/rsyslog/handlers/main.yml
@@ -3,6 +3,10 @@
   service:
     name: rsyslog
     state: restarted
+  ignore_errors: true
+
+- name: restart rsyslogd
+  command: journalctl -u rsyslog
 
 - name: stop rsyslogd
   service:

--- a/roles/rsyslog/tasks/main.yml
+++ b/roles/rsyslog/tasks/main.yml
@@ -88,9 +88,9 @@
           when: not __backup_stat.stat.exists
 
         - name: Purge original conf
-          file:
-            state: absent
-            path: "{{ __rsyslog_config_dir }}/*"
+          shell: |-
+            set -euo pipefail
+            /bin/rm -rfv {{ __rsyslog_config_dir }}/*
           when: __rsyslog_purge_original_conf | bool | d(false)
 
         - block:


### PR DESCRIPTION
`file` module `state=absent` does not work with `path=/some/dir/*` (wildcard)
`file` module should support `state=empty` see: https://github.com/ansible/ansible/issues/18910
`state=empty` is needed here - and should be used later
Use rm -rfv so that the files being removed will be shown