### PR TITLE
baseosci - fix logging tests

### DIFF
--- a/tests/tests_basics_files.yml
+++ b/tests/tests_basics_files.yml
@@ -2,7 +2,6 @@
 - name: "Ensure that the role runs with parameters for
   basics input and files output"
   hosts: all
-  become: true
   vars:
     __test_default_files_conf: /etc/rsyslog.d/30-output-files-default_files.conf
     __test_files_conf0: /etc/rsyslog.d/30-output-files-files_output0.conf

--- a/tests/tests_basics_forwards.yml
+++ b/tests/tests_basics_forwards.yml
@@ -2,7 +2,6 @@
 - name: "Ensure that the role runs with parameters for basics input
   and forwards output"
   hosts: all
-  become: true
   vars:
     __test_files_conf: >-
       /etc/rsyslog.d/30-output-files-default_files.conf

--- a/tests/tests_combination.yml
+++ b/tests/tests_combination.yml
@@ -2,7 +2,6 @@
 - name: "Combination test - test for (2 types of inputs) x
   (2 types of outputs) combination"
   hosts: all
-  become: true
   vars:
     __test_files_conf: /etc/rsyslog.d/30-output-files-files_test0.conf
     __test_forwards_conf_s_f: >-

--- a/tests/tests_default.yml
+++ b/tests/tests_default.yml
@@ -2,7 +2,6 @@
 #
 - name: Ensure that the role runs with default parameters
   hosts: all
-  become: true
 
   tasks:
     - name: default run (NOOP)

--- a/tests/tests_enabled.yml
+++ b/tests/tests_enabled.yml
@@ -19,7 +19,6 @@
 #
 - name: Ensure that the role runs with default parameters
   hosts: all
-  become: true
 
   tasks:
     - name: default run

--- a/tests/tests_files_elasticsearch.yml
+++ b/tests/tests_files_elasticsearch.yml
@@ -2,7 +2,6 @@
 - name: "Ensure that the role runs with parameters from
   imfile to two elasticsearch outputs"
   hosts: all
-  become: true
   vars:
     __test_inputfiles_dir: /var/log/inputdirectory
     __test_inputfiles_conf: >-

--- a/tests/tests_files_files.yml
+++ b/tests/tests_files_files.yml
@@ -27,7 +27,6 @@
 - name: "Ensure that the role runs with parameters from two files inputs
   to two files outputs"
   hosts: all
-  become: true
   vars:
     __test_inputfiles_dir0: /var/log/inputdirectory0
     __test_inputfiles_dir1: /var/log/inputdirectory1

--- a/tests/tests_imuxsock_files.yml
+++ b/tests/tests_imuxsock_files.yml
@@ -29,7 +29,6 @@
 - name: "Ensure that the role runs with parameters with the simplest
   configuration using imuxsock instead of imjournal"
   hosts: all
-  become: true
   vars:
     __test_files_conf: /etc/rsyslog.d/30-output-files-default_files.conf
     __default_system_log: /var/log/messages

--- a/tests/tests_ovirt_elasticsearch.yml
+++ b/tests/tests_ovirt_elasticsearch.yml
@@ -2,7 +2,6 @@
 - name: "Ensure that the role runs with parameters from ovirt to
   two elasticsearch outputs and local files output"
   hosts: all
-  become: true
   vars:
     __test_ovirt_collectd_conf: >-
       /etc/rsyslog.d/90-input-ovirt-ovirt_collectd_input.conf

--- a/tests/tests_relp.yml
+++ b/tests/tests_relp.yml
@@ -175,8 +175,7 @@
       shell: >-
         set -euo pipefail;
         grep
-        "tls.permittedpeer=\[\"\*.$( _domain=$(hostname -d); _domain=${_domain:-"{{ logging_domain }}"}; echo $_domain )\"\]"
-        "{{ __test_relp_server1 }}" | wc -l
+        "tls.permittedpeer=\[\"\*.{{ logging_domain }}\"\]" "{{ __test_relp_server1 }}" | wc -l
       register: __result
       changed_when: false
       failed_when: __result.stdout != "1"
@@ -346,8 +345,7 @@
       shell: >-
         set -euo pipefail;
         grep
-        "tls.permittedpeer=\[\"\*.$( _domain=$(hostname -d); _domain=${_domain:-"{{ logging_domain }}"}; echo $_domain )\"\]" "{{ __test_relp_client1 }}"
-        | wc -l
+        "tls.permittedpeer=\[\"\*.{{ logging_domain }}\"\]" "{{ __test_relp_client1 }}" | wc -l
       register: __result
       changed_when: false
       failed_when: __result.stdout != "1"

--- a/tests/tests_remote.yml
+++ b/tests/tests_remote.yml
@@ -2,7 +2,6 @@
 - name: "Ensure inputs from the remote logging system passed
   to the local files outputs."
   hosts: all
-  become: true
   vars:
     __test_input_remote_tcp: >-
       /etc/rsyslog.d/11-input-remote-remote_tcp_input.conf

--- a/tests/tests_version.yml
+++ b/tests/tests_version.yml
@@ -8,7 +8,6 @@
 #
 - name: Ensure internal var __rsyslog_version is set correctly
   hosts: all
-  become: true
   vars:
     __rsyslog_version: "0.0.0"
 


### PR DESCRIPTION
- Removing "become: true" from test scripts.
- Fixed the expected value of the test_relp tls.permittedpeer value.
Ref: 93313