### PR TITLE
Update copy tasks conditions with tls true

### DIFF
--- a/roles/rsyslog/tasks/set_certs.yml
+++ b/roles/rsyslog/tasks/set_certs.yml
@@ -11,7 +11,9 @@
         mode: '0444'
       with_items:
         - '{{ __rsyslog_cert_subject }}'
-      when: item.ca_cert_src | d()
+      when: 
+        - item.ca_cert_src | d()
+        - (item.tls is defined) | ternary(item.tls, item.use_cert | d(true))
 
     - name: "Copy cert on the control host to the specified path
       on the target host"
@@ -22,7 +24,9 @@
         mode: '0444'
       with_items:
         - '{{ __rsyslog_cert_subject }}'
-      when: item.cert_src | d()
+      when: 
+        - item.cert_src | d()
+        - (item.tls is defined) | ternary(item.tls, item.use_cert | d(true))
 
     - name: "Copy key on the control host to the specified path
       on the target host"
@@ -33,7 +37,9 @@
         mode: '0400'
       with_items:
         - '{{ __rsyslog_cert_subject }}'
-      when: item.private_key_src | d()
+      when: 
+        - item.private_key_src | d()
+        - (item.tls is defined) | ternary(item.tls, item.use_cert | d(true))
 
     - name: Check certs - tls is true, but triplets are not given
       fail:

--- a/roles/rsyslog/tasks/set_certs.yml
+++ b/roles/rsyslog/tasks/set_certs.yml
@@ -11,7 +11,7 @@
         mode: '0444'
       with_items:
         - '{{ __rsyslog_cert_subject }}'
-      when: 
+      when:
         - item.ca_cert_src | d()
         - (item.tls is defined) | ternary(item.tls, item.use_cert | d(true))
 
@@ -24,7 +24,7 @@
         mode: '0444'
       with_items:
         - '{{ __rsyslog_cert_subject }}'
-      when: 
+      when:
         - item.cert_src | d()
         - (item.tls is defined) | ternary(item.tls, item.use_cert | d(true))
 
@@ -37,7 +37,7 @@
         mode: '0400'
       with_items:
         - '{{ __rsyslog_cert_subject }}'
-      when: 
+      when:
         - item.private_key_src | d()
         - (item.tls is defined) | ternary(item.tls, item.use_cert | d(true))
 


### PR DESCRIPTION
Playbook fails when certificates are not used.
This patch adds condition for the copy tasks to perform only when tls is set to true.

Bug-Url: https://bugzilla.redhat.com/1994580
