### PR TITLE
Allowing the case, tls is false and key/certs vars are configured.

### DIFF
--- a/roles/rsyslog/tasks/set_certs.yml
+++ b/roles/rsyslog/tasks/set_certs.yml
@@ -51,8 +51,8 @@
       when: item.tls is defined | ternary(item.tls, item.use_cert | d(true))
 
     - name: Check certs - key/certs data are provided, but tls is false
-      fail:
-        msg: "Error: you specified tls: false and also specified one or
+      debug:
+        msg: "WARNING: you specified tls: false and also specified one or
           more cert/key files in the configuration named {{ item.name }}"
       with_items:
         - '{{ __rsyslog_cert_subject }}'

--- a/tests/tests_files_elasticsearch.yml
+++ b/tests/tests_files_elasticsearch.yml
@@ -19,9 +19,6 @@
       specify all 3 of ca_cert, cert, private_key, or all 3 of
       ca_cert_src, cert_src, private_key_src, or set tls:
       false in the configuration named elasticsearch_output"
-    __expected_err2: "Error: you specified tls: false and also
-      specified one or more cert/key files in the configuration
-      named elasticsearch_output"
 
   tasks:
     - name: "local certs are copied to the target host with
@@ -91,17 +88,13 @@
       stat:
         path: "{{ __test_outputfiles_conf }}"
 
-    - name: Check if the copied ca cert file exists
+    - name: Check if the copied key/certs files exist
       stat:
-        path: "/etc/rsyslog.d/{{ __test_ca_cert | basename }}"
-
-    - name: Check if the copied cert file exists
-      stat:
-        path: "/etc/rsyslog.d/{{ __test_cert | basename }}"
-
-    - name: Check if the copied key file exists
-      stat:
-        path: "/etc/rsyslog.d/{{ __test_key | basename }}"
+        path: "{{ item }}"
+      loop:
+        - "/etc/rsyslog.d/{{ __test_ca_cert | basename }}"
+        - "/etc/rsyslog.d/{{ __test_cert | basename }}"
+        - "/etc/rsyslog.d/{{ __test_key | basename }}"
 
     - name: Check certs in {{ __test_outputfiles_conf }}
       command: >-
@@ -223,29 +216,17 @@
           - rsyslog-elasticsearch
       include_tasks: tasks/check_packages.yml
 
-    - name: Ensure installed packages
-      vars:
-        __expected:
-          - rsyslog
-          - ca-certificates
-          - rsyslog-elasticsearch
-      include_tasks: tasks/check_packages.yml
-
     - name: Check if the output files config exists
       stat:
         path: "{{ __test_outputfiles_conf }}"
 
-    - name: Check if the copied ca cert file exists
+    - name: Check if the copied key/certs files exist
       stat:
-        path: "{{ __test_ca_cert_target }}"
-
-    - name: Check if the copied cert file exists
-      stat:
-        path: "{{ __test_cert_target }}"
-
-    - name: Check if the copied key file exists
-      stat:
-        path: "{{ __test_key_target }}"
+        path: "{{ item }}"
+      loop:
+        - "{{ __test_ca_cert_target }}"
+        - "{{ __test_cert_target }}"
+        - "{{ __test_key_target }}"
 
     - name: Check key/certs in {{ __test_outputfiles_conf }}
       command: >-
@@ -297,8 +278,115 @@
         - "{{ __test_key_target }}"
 
     # TEST CASE 2
+    - name: "TEST CASE 2; Elasticsearch config -
+      local certs are not copied to the target host as tls is false"
+      vars:
+        logging_outputs:
+          - name: elasticsearch_output
+            type: elasticsearch
+            server_host: logging-es
+            server_port: 9200
+            index_prefix: project.
+            input_type: ovirt
+            retryfailures: false
+            tls: false
+            ca_cert_src: "{{ __test_ca_cert }}"
+            cert_src: "{{ __test_cert }}"
+            private_key_src: "{{ __test_key }}"
+        logging_inputs:
+          - name: files_input
+            type: files
+            input_log_path: "{{ __test_inputfiles_dir }}/*.log"
+        logging_flows:
+          - name: flow_0
+            inputs: [files_input]
+            outputs: [elasticsearch_output]
+      include_role:
+        name: linux-system-roles.logging
+
+    # notify restart rsyslogd is executed at the end of this test task.
+    # thus we have to force to invoke handlers
+    - name: "Force all notified handlers to run at this point,
+      not waiting for normal sync points"
+      meta: flush_handlers
+
+    - name: Ensure config file size and counts
+      vars:
+        __conf_count: 9
+        __conf_size: less
+        __conf_files:
+          - "{{ __test_inputfiles_conf }}"
+          - "{{ __test_outputfiles_conf }}"
+        __check_systemctl_status: true
+      include_tasks: tasks/check_daemon_config_files.yml
+
+    - name: Ensure installed packages
+      vars:
+        __expected:
+          - rsyslog
+          - ca-certificates
+          - rsyslog-elasticsearch
+      include_tasks: tasks/check_packages.yml
+
+    - name: Check if the output files config exists
+      stat:
+        path: "{{ __test_outputfiles_conf }}"
+
+    - name: Check if the copied key/certs files do not exist
+      stat:
+        path: "{{ item }}"
+      register: __result
+      failed_when: __result.stat.exists
+      loop:
+        - "{{ __test_ca_cert_target }}"
+        - "{{ __test_cert_target }}"
+        - "{{ __test_key_target }}"
+
+    - name: Check key/certs not in {{ __test_outputfiles_conf }}
+      command: >-
+        /bin/grep 'tls.{{ item.key }}="{{ item.value }}"'
+        {{ __test_outputfiles_conf }}
+      with_dict:
+        - cacert: "{{ __test_ca_cert_target }}"
+        - mycert: "{{ __test_cert_target }}"
+        - myprivkey: "{{ __test_key_target }}"
+      register: __result
+      changed_when: false
+      failed_when: __result.rc != 1
+
+    - name: END TEST CASE 2; Clean up the deployed config
+      vars:
+        logging_enabled: false
+        logging_outputs:
+          - name: elasticsearch_output
+            type: elasticsearch
+            server_host: logging-es
+            server_port: 9200
+            index_prefix: project.
+            input_type: ovirt
+            retryfailures: false
+            tls: false
+            ca_cert_src: "{{ __test_ca_cert }}"
+            cert_src: "{{ __test_cert }}"
+            private_key_src: "{{ __test_key }}"
+            state: absent
+        logging_inputs:
+          - name: files_input
+            type: files
+            input_log_path: "{{ __test_inputfiles_dir }}/*.log"
+            state: absent
+      include_role:
+        name: linux-system-roles.logging
+
+    # notify restart rsyslogd is executed at the end of this test task.
+    # thus we have to force to invoke handlers
+    - name: "Force all notified handlers to run at this point,
+      not waiting for normal sync points"
+      meta: flush_handlers
+
+    # TEST CASE 3
     - block:
-        - name: "TEST CASE 2; Error case for Elasticsearch config -
+        - name: "TEST CASE 3; Error case for Elasticsearch config -
           cert and ca_cert_src are missing"
           vars:
             logging_outputs:
@@ -336,7 +424,7 @@
           assert:
             that: ansible_failed_result.results.0.msg is match(__expected_err1)
 
-    - name: END TEST CASE 2; Clean up the deployed config
+    - name: END TEST CASE 3; Clean up the deployed config
       vars:
         logging_enabled: false
         logging_outputs:
@@ -366,90 +454,7 @@
     - name: clean up fake pki files
       file: path="{{ item }}" state=absent
       loop:
-        - /etc/rsyslog.d/es-cert.pem
-        - /etc/rsyslog.d/key.pem
-
-    # TEST CASE 3
-    - block:
-        - name: "TEST CASE 3; Error case for Elasticsearch config -
-          although cert paths are specified, tls is false"
-          vars:
-            logging_outputs:
-              - name: elasticsearch_output
-                type: elasticsearch
-                server_host: logging-es
-                server_port: 9200
-                index_prefix: project.
-                input_type: ovirt
-                retryfailures: false
-                tls: false
-                ca_cert: /etc/rsyslog.d/ca_cert.crt
-                cert: /etc/rsyslog.d/cert.pem
-                private_key: /etc/rsyslog.d/key.pem
-                ca_cert_src: "{{ __test_ca_cert }}"
-                cert_src: "{{ __test_cert }}"
-                private_key_src: "{{ __test_key }}"
-            logging_inputs:
-              - name: files_input
-                type: files
-                input_log_path: "{{ __test_inputfiles_dir }}/*.log"
-            logging_flows:
-              - name: flow_0
-                inputs: [files_input]
-                outputs: [elasticsearch_output, elasticsearch_output_ops]
-          include_role:
-            name: linux-system-roles.logging
-
-        - name: unreachable task
-          fail:
-            msg: UNREACH
-
-      rescue:
-        - debug:
-            msg: "Caught an expected error -
-              {{ ansible_failed_result.results }}"
-        - name: assert...
-          assert:
-            that: ansible_failed_result.results.0.msg is match(__expected_err2)
-
-    - name: END TEST CASE 3; Clean up the deployed config
-      vars:
-        logging_enabled: false
-        logging_outputs:
-          - name: elasticsearch_output
-            type: elasticsearch
-            server_host: logging-es
-            server_port: 9200
-            index_prefix: project.
-            input_type: ovirt
-            retryfailures: false
-            tls: true
-            ca_cert: /etc/rsyslog.d/ca_cert.crt
-            cert: /etc/rsyslog.d/cert.pem
-            private_key: /etc/rsyslog.d/key.pem
-            ca_cert_src: "{{ __test_ca_cert }}"
-            cert_src: "{{ __test_cert }}"
-            private_key_src: "{{ __test_key }}"
-            state: absent
-        logging_inputs:
-          - name: files_input
-            type: files
-            input_log_path: "{{ __test_inputfiles_dir }}/*.log"
-            state: absent
-      include_role:
-        name: linux-system-roles.logging
-
-    # notify restart rsyslogd is executed at the end of this test task.
-    # thus we have to force to invoke handlers
-    - name: "Force all notified handlers to run at this point,
-      not waiting for normal sync points"
-      meta: flush_handlers
-
-    - name: clean up fake pki files
-      file: path="{{ item }}" state=absent
-      loop:
         - /etc/rsyslog.d/ca_cert.crt
-        - /etc/rsyslog.d/cert.pem
         - /etc/rsyslog.d/key.pem
 
     # TEST CASE 4


### PR DESCRIPTION
- The case used to fail in the checking task with emitting an error.
  The error is transformed to a warning.
- For the test case, TEST CASE 2 in tests_files_elasticsearch.yml
  is added.

In addition, some minor bugs in tests_files_elasticsearch.yml are
fixed.

ref: bz1994580