### PR TITLE
Use the openssl command-line interface instead of the openssl module

### DIFF
--- a/tests/tasks/create_tests_certs.yml
+++ b/tests/tasks/create_tests_certs.yml
@@ -1,61 +1,60 @@
-- name: Install python-cryptography
+---
+- name: Ensure openssl exists
   package:
     name:
-      - python-cryptography
+      - openssl
     state: present
-  when:
-    - ansible_facts["distribution"] == "CentOS" or
-      ansible_facts["distribution"] == "RedHat"
-    - ansible_facts["distribution_major_version"] == "7"
 
-- name: Install python3-cryptography
-  package:
-    name:
-      - python3-cryptography
-    state: present
-  when:
-    - not (ansible_facts["distribution"] == "CentOS" or
-      ansible_facts["distribution"] == "RedHat") or
-      ansible_facts["distribution_major_version"] | int > 7
+- name: Ensure /etc/pki/CA exists
+  file:
+    path: /etc/pki/CA
+    state: directory
+    mode: 0755
 
-- name: Generate a CA key
-  openssl_privatekey:
-    path: "{{ __test_ca_key }}"
-    type: RSA
+- name: Ensure /etc/pki/CA exists
+  file:
+    path: /etc/pki/CA/certs
+    state: directory
+    mode: 0755
 
-- name: Generate a CA Certificate Signing Request
-  openssl_csr:
-    path: "{{ __test_ca_cert_csr }}"
-    privatekey_path: "{{ __test_ca_key }}"
-    common_name: test-ca.system-roles.fedora.org
+- name: Ensure /etc/pki/CA exists
+  file:
+    path: /etc/pki/CA/private
+    state: directory
+    mode: 0755
 
-- name: Generate a self signed CA cert using the CA key
-  openssl_certificate:
-    path: "{{ __test_ca_cert }}"
-    privatekey_path: "{{ __test_ca_key }}"
-    csr_path: "{{ __test_ca_cert_csr }}"
-    provider: selfsigned
+- name: Generate a self signed CA cert and the CA key
+  command: >-
+    openssl req -x509 -newkey rsa:2048 -nodes
+    -keyout "{{ __test_ca_key }}" -out "{{ __test_ca_cert }}"
+    -subj "/CN=test-ca/OU=system-roles/DC=fedora/DC=org"
+  changed_when: false
+
+- name: Verify CA cert
+  command: >-
+    openssl x509 -text -in "{{ __test_ca_cert }}" -noout
+  changed_when: false
 
 - name: Generate a server/client key
-  openssl_privatekey:
-    path: "{{ __test_key }}"
-    type: RSA
+  command: openssl genrsa -out "{{ __test_key }}"
+  changed_when: false
 
 - name: Generate a server Certificate Signing Request
-  openssl_csr:
-    path: "{{ __test_cert_csr }}"
-    privatekey_path: "{{ __test_key }}"
-    country_name: US
-    organization_name: Fedora
-    email_address: logging@fedora.org
-    common_name: logging.fedora.org
+  command: >-
+    openssl req -new -key "{{ __test_key }}"
+    -out "{{ __test_cert_csr }}"
+    -subj "/C=US/O=Fedora/DC=fedora/CN=logging.fedora.org"
+  changed_when: false
 
 - name: "Generate a server/client cert using the key,
   and signed by the self signed CA"
-  openssl_certificate:
-    path: "{{ __test_cert }}"
-    privatekey_path: "{{ __test_key }}"
-    csr_path: "{{ __test_cert_csr }}"
-    ownca_path: "{{ __test_ca_cert }}"
-    ownca_privatekey_path: "{{ __test_ca_key }}"
-    provider: ownca
+  command: >-
+    openssl x509 -req -in "{{ __test_cert_csr }}"
+    -CA "{{ __test_ca_cert }}" -CAkey "{{ __test_ca_key }}"
+    -CAcreateserial -out "{{ __test_cert }}"
+  changed_when: false
+
+- name: Verify the server/client cert
+  command: >-
+    openssl x509 -text -in "{{ __test_cert }}" -noout
+  changed_when: false

--- a/tests/tests_relp.yml
+++ b/tests/tests_relp.yml
@@ -3,17 +3,21 @@
   hosts: all
   vars:
     __test_ca_key_name: test-ca-key.pem
-    __test_ca_csr: test-ca.csr
     __test_ca_cert_name: test-ca.crt
     __test_key_name: test-key.pem
     __test_csr_name: test-cert.csr
     __test_cert_name: test-cert.pem
-    __test_ca_key: "/etc/pki/tls/private/{{ __test_ca_key_name }}"
-    __test_ca_cert_csr: "/etc/rsyslog.d/{{ __test_ca_csr }}"
-    __test_ca_cert: "/etc/pki/tls/certs/{{ __test_ca_cert_name }}"
-    __test_key: "/etc/pki/tls/private/{{ __test_key_name }}"
-    __test_cert_csr: "/etc/rsyslog.d/{{ __test_csr_name }}"
-    __test_cert: "/etc/pki/tls/certs/{{ __test_cert_name }}"
+    __test_ca_path: /etc/pki/CA
+    __test_ca_key_path: "{{ __test_ca_path }}/private"
+    __test_ca_cert_path: "{{ __test_ca_path }}/certs"
+    __test_key_path: /etc/pki/tls/private
+    __test_cert_path: /etc/pki/tls/certs
+    __test_csr_path: /etc/rsyslog.d
+    __test_ca_key: "{{ __test_ca_key_path }}/{{ __test_ca_key_name }}"
+    __test_ca_cert: "{{ __test_ca_cert_path }}/{{ __test_ca_cert_name }}"
+    __test_key: "{{ __test_key_path }}/{{ __test_key_name }}"
+    __test_cert_csr: "{{ __test_csr_path }}/{{ __test_csr_name }}"
+    __test_cert: "{{ __test_cert_path }}/{{ __test_cert_name }}"
     __test_relp_server0: /etc/rsyslog.d/11-input-relp-relp_server0.conf
     __test_relp_server1: /etc/rsyslog.d/11-input-relp-relp_server1.conf
     __test_relp_client0: /etc/rsyslog.d/31-output-relp-relp_client0.conf
@@ -130,38 +134,38 @@
     - name: Check the ca cert in relp_server0 - 0
       shell: |-
         set -euo pipefail
-        grep 'tls.cacert="/etc/pki/tls/certs/test-ca.crt"' "{{ __test_relp_server0 }}" | wc -l
+        grep 'tls.cacert="{{ __test_ca_cert }}"' "{{ __test_relp_server0 }}" | wc -l
       register: __result
       changed_when: false
       failed_when: __result.stdout != "1"
 
     - name: Check the ca cert in relp_server0 - 1
       stat:
-        path: /etc/pki/tls/certs/test-ca.crt
+        path: "{{ __test_ca_cert }}"
 
     - name: Check the cert in relp_server0 - 0
       shell: |-
         set -euo pipefail
-        grep 'tls.mycert="/etc/pki/tls/certs/test-cert.pem"' "{{ __test_relp_server0 }}" | wc -l
+        grep 'tls.mycert="{{ __test_cert }}"' "{{ __test_relp_server0 }}" | wc -l
       register: __result
       changed_when: false
       failed_when: __result.stdout != "1"
 
     - name: Check the cert in relp_server0 - 1
       stat:
-        path: /etc/pki/tls/certs/test-cert.pem
+        path: "{{ __test_cert }}"
 
     - name: Check the private key in relp_server0 - 0
       shell: |-
         set -euo pipefail
-        grep 'tls.myprivkey="/etc/pki/tls/private/test-key.pem"' "{{ __test_relp_server0 }}" | wc -l
+        grep 'tls.myprivkey="{{ __test_key }}"' "{{ __test_relp_server0 }}" | wc -l
       register: __result
       changed_when: false
       failed_when: __result.stdout != "1"
 
     - name: Check the private key in relp_server0 - 1
       stat:
-        path: /etc/pki/tls/private/test-key.pem
+        path: "{{ __test_key }}"
 
     - name: Check tls.permittedpeer in relp_server0
       shell: |-
@@ -300,38 +304,38 @@
     - name: Check the ca cert in relp_client0 - 0
       shell: |-
         set -euo pipefail
-        grep 'tls.cacert="/etc/pki/tls/certs/test-ca.crt"' "{{ __test_relp_client0 }}" | wc -l
+        grep 'tls.cacert="{{ __test_ca_cert }}"' "{{ __test_relp_client0 }}" | wc -l
       register: __result
       changed_when: false
       failed_when: __result.stdout != "1"
 
     - name: Check the ca cert in relp_client0 - 1
       stat:
-        path: /etc/pki/tls/certs/test-ca.crt
+        path: "{{ __test_ca_cert }}"
 
     - name: Check the cert in relp_client0 - 0
       shell: |-
         set -euo pipefail
-        grep 'tls.mycert="/etc/pki/tls/certs/test-cert.pem"' "{{ __test_relp_client0 }}" | wc -l
+        grep 'tls.mycert="{{ __test_cert }}"' "{{ __test_relp_client0 }}" | wc -l
       register: __result
       changed_when: false
       failed_when: __result.stdout != "1"
 
     - name: Check the cert in relp_client0 - 1
       stat:
-        path: /etc/pki/tls/certs/test-cert.pem
+        path: "{{ __test_cert }}"
 
     - name: Check the private key in relp_client0 - 0
       shell: |-
         set -euo pipefail
-        grep 'tls.myprivkey="/etc/pki/tls/private/test-key.pem"' "{{ __test_relp_client0 }}" | wc -l
+        grep 'tls.myprivkey="{{ __test_key }}"' "{{ __test_relp_client0 }}" | wc -l
       register: __result
       changed_when: false
       failed_when: __result.stdout != "1"
 
     - name: Check the private key in relp_client0 - 1
       stat:
-        path: /etc/pki/tls/private/test-key.pem
+        path: "{{ __test_key }}"
 
     - name: Check tls.permittedpeer in relp_client0
       shell: |-
@@ -395,7 +399,6 @@
       file: path="{{ item }}" state=absent
       loop:
         - "{{ __test_ca_key }}"
-        - "{{ __test_ca_cert_csr }}"
         - "{{ __test_ca_cert }}"
         - "{{ __test_key }}"
         - "{{ __test_cert_csr }}"

--- a/tests/tests_server.yml
+++ b/tests/tests_server.yml
@@ -18,12 +18,18 @@
     __test_key_name: test-key.pem
     __test_csr_name: test-cert.csr
     __test_cert_name: test-cert.pem
-    __test_ca_key: "/etc/pki/tls/private/{{ __test_ca_key_name }}"
-    __test_ca_cert_csr: "/etc/rsyslog.d/{{ __test_ca_csr }}"
-    __test_ca_cert: "/etc/pki/tls/certs/{{ __test_ca_cert_name }}"
-    __test_key: "/etc/pki/tls/private/{{ __test_key_name }}"
-    __test_cert_csr: "/etc/rsyslog.d/{{ __test_csr_name }}"
-    __test_cert: "/etc/pki/tls/certs/{{ __test_cert_name }}"
+    __test_ca_path: /etc/pki/CA
+    __test_ca_key_path: "{{ __test_ca_path }}/private"
+    __test_ca_cert_path: "{{ __test_ca_path }}/certs"
+    __test_key_path: /etc/pki/tls/private
+    __test_cert_path: /etc/pki/tls/certs
+    __test_csr_path: /etc/rsyslog.d
+    __test_ca_key: "{{ __test_ca_key_path }}/{{ __test_ca_key_name }}"
+    __test_ca_cert_csr: "{{ __test_csr_path }}/{{ __test_ca_csr }}"
+    __test_ca_cert: "{{ __test_ca_cert_path }}/{{ __test_ca_cert_name }}"
+    __test_key: "{{ __test_key_path }}/{{ __test_key_name }}"
+    __test_cert_csr: "{{ __test_csr_path }}/{{ __test_csr_name }}"
+    __test_cert: "{{ __test_cert_path }}/{{ __test_cert_name }}"
     __test_server_ptcp: /etc/rsyslog.d/11-input-remote-remote_ptcp.conf
     __test_server_tcp: /etc/rsyslog.d/11-input-remote-remote_tcp.conf
     __test_server_udp: /etc/rsyslog.d/11-input-remote-remote_udp.conf


### PR DESCRIPTION
in the test helper task tests/tasks/create_tests_certs.yml.

This is to avoid using the non ansible-core module.