### PR TITLE
Add uid and pwd parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,9 @@ Available options:
 - `ca_cert_src`: Local CA cert file path which is copied to the target host. If `ca_cert` is specified, it is copied to the location. Otherwise, to logging_config_dir.
 - `cert_src`: Local cert file path which is copied to the target host. If `cert` is specified, it is copied to the location. Otherwise, to logging_config_dir.
 - `private_key_src`: Local key file path which is copied to the target host. If `private_key` is specified, it is copied to the location. Otherwise, to logging_config_dir.
+- `uid`: If basic HTTP authentication is deployed, the user name is specified with this key.
+
+logging_elasticsearch_password: If basic HTTP authentication is deployed, the password is specified with this global variable. Please be careful that this `logging_elasticsearch_password` is a global variable to be placed at the same level as `logging_output`, `logging_input`, and `logging_flows` are. Another things to be aware of are this `logging_elasticsearch_password` is shared among all the elasticsearch outputs. That is, the elasticsearch servers should share one password if there are multiple of servers. Plus, the uid and password are configured if both of them are found in the playbook. For instance, if there are multiple elasticsearch outputs and one of them is missing the `uid` key, then the configured output does not have the uid and password.
 
 #### files type
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -72,3 +72,8 @@ logging_pki_files: []
 #
 # The default DNS domain used to accept remote incoming logs from remote hosts.
 logging_domain: '{{ ansible_domain if ansible_domain else ansible_hostname }}'
+
+# logging_elasticsearch_password
+#
+# Password to pass to the elasticsearch output
+logging_elasticsearch_password: ""

--- a/roles/rsyslog/tasks/deploy_nolog.yml
+++ b/roles/rsyslog/tasks/deploy_nolog.yml
@@ -1,0 +1,58 @@
+---
+# SPDX-License-Identifier: GPL-3.0-only
+
+# If the input/output has a possibility to reveal some sensitive data,
+# include this deploy_nolog.yml file.
+# See tasks/outputs/elasticsearch/main.yml for an examle.
+
+- name: Install/Update required packages
+  package:
+    name: "{{ __rsyslog_packages }}"
+    state: present
+  when:
+    - __rsyslog_packages | length > 0
+    - not rsyslog_in_image | bool
+  notify: restart rsyslogd
+
+- name: Generate role configuration files in rsyslog.d with no_log
+  template:
+    src: 'rules.conf.j2'
+    dest: '{{ inner_item.path |
+      d(__rsyslog_config_dir) }}/{{ inner_item.filename | d((inner_item.weight
+      if inner_item.weight | d() else
+      rsyslog_weight_map[inner_item.type | d("rules")]) +
+      "-" + (inner_item.name | d("rules")) + "." +
+      (inner_item.suffix | d("conf"))) }}'
+    owner: '{{ inner_item.owner | d("root") }}'
+    group: '{{ inner_item.group | d("root") }}'
+    mode: '{{ inner_item.mode  | d("0644") }}'
+  loop: '{{ __rsyslog_rules | flatten }}'
+  loop_control:
+    loop_var: inner_item
+  no_log: true
+  when:
+    - __rsyslog_enabled | bool
+    - inner_item.state is undefined or inner_item.state != 'absent'
+    - inner_item.filename | d() or inner_item.name | d()
+    - inner_item.options | d() or inner_item.sections | d()
+  notify: restart rsyslogd
+
+- name: Remove role config files from rsyslog.d with no_log
+  file:
+    path: '{{ inner_item.path |
+      d(__rsyslog_config_dir) }}/{{ inner_item.filename | d((inner_item.weight
+      if inner_item.weight | d() else
+      rsyslog_weight_map[inner_item.type | d("rules")]) +
+      "-" + (inner_item.name | d("rules")) + "." +
+      (inner_item.suffix | d("conf"))) }}'
+    state: absent
+  loop: '{{ __rsyslog_rules | flatten }}'
+  loop_control:
+    loop_var: inner_item
+  no_log: true
+  when:
+    - (not __rsyslog_enabled | bool) or
+      (inner_item.state | d('present') == 'absent')
+    - inner_item.filename | d() or inner_item.name | d()
+    - inner_item.options | d() or inner_item.sections | d()
+  notify: restart rsyslogd

--- a/roles/rsyslog/tasks/outputs/elasticsearch/main.yml
+++ b/roles/rsyslog/tasks/outputs/elasticsearch/main.yml
@@ -24,6 +24,32 @@
         state: "{{ item.state | d('present') }}"
         sections:
           - options: "{{ lookup('template', 'output_elasticsearch.j2') }}"
+        mode: "0600"
+        owner: "root"
+        group: "root"
   include_tasks:
     file: "{{ role_path }}/tasks/deploy.yml"
   loop: '{{ rsyslog_output_elasticsearch }}'
+  when: (logging_elasticsearch_password is not defined) or
+        (logging_elasticsearch_password | length == 0)
+
+- name: "Create elasticsearch output configuration files in
+  /etc/rsyslog.d (no_log)"
+  vars:
+    __rsyslog_packages: []
+    __rsyslog_rules:
+      - name: "output-elasticsearch-{{ item.name }}"
+        type: "output"
+        weight: "31"
+        state: "{{ item.state | d('present') }}"
+        sections:
+          - options: "{{ lookup('template', 'output_elasticsearch.j2') }}"
+        mode: "0600"
+        owner: "root"
+        group: "root"
+  include_tasks:
+    file: "{{ role_path }}/tasks/deploy_nolog.yml"
+  loop: '{{ rsyslog_output_elasticsearch }}'
+  when:
+    - logging_elasticsearch_password is defined
+    - logging_elasticsearch_password | length > 0

--- a/roles/rsyslog/templates/output_elasticsearch.j2
+++ b/roles/rsyslog/templates/output_elasticsearch.j2
@@ -87,6 +87,10 @@ ruleset(name="{{ item.name }}") {
             tls.mycert="{{ __mycert }}"
             tls.myprivkey="{{ __myprivkey }}"
 {% endif %}
+{% if logging_elasticsearch_password | length > 0 and item.uid is defined and item.uid | length > 0 %}
+            uid="{{ item.uid }}"
+            pwd="{{ logging_elasticsearch_password }}"
+{% endif %}
         )
     }
 }

--- a/tests/tests_ovirt_elasticsearch.yml
+++ b/tests/tests_ovirt_elasticsearch.yml
@@ -26,6 +26,7 @@
   tasks:
     - name: TEST CASE 0; Ensure basic ovirt default configuration works
       vars:
+        logging_elasticsearch_password: password0
         logging_outputs:
           - name: default_files
             type: file
@@ -39,6 +40,7 @@
             ca_cert: "/etc/rsyslog.d/es-ca.crt"
             cert: "/etc/rsyslog.d/es-cert.pem"
             private_key: "/etc/rsyslog.d/es-key.pem"
+            uid: testuser0
           - name: elasticsearch_output_ops
             type: elasticsearch
             server_host: logging-es-ops
@@ -173,9 +175,20 @@
       command: /bin/grep 'server="logging-es-ops"' {{ __test_es_ops_conf }}
       changed_when: false
 
+    - name: Check password is in "{{ __test_es_conf }}"
+      command: /bin/grep 'pwd="password0"'  {{ __test_es_conf }}
+      changed_when: false
+
+    - name: Check pwd= is not in "{{ __test_es_ops_conf }}"
+      command: /bin/grep "pwd="  {{ __test_es_ops_conf }}
+      register: __result
+      changed_when: false
+      failed_when: __result.rc != 1
+
     - name: END TEST CASE 0; Ensure basic ovirt configuration works
       vars:
         logging_enabled: false
+        logging_elasticsearch_password: password0
         logging_outputs:
           - name: default_files
             type: file
@@ -191,6 +204,7 @@
             cert: "/etc/rsyslog.d/es-cert.pem"
             private_key: "/etc/rsyslog.d/es-key.pem"
             state: absent
+            uid: testuser0
           - name: elasticsearch_output_ops
             type: elasticsearch
             server_host: logging-es-ops
@@ -253,6 +267,7 @@
             ca_cert: "/etc/rsyslog.d/es-ca.crt"
             cert: "/etc/rsyslog.d/es-cert.pem"
             private_key: "/etc/rsyslog.d/es-key.pem"
+            uid: testuser0
           - name: elasticsearch_output_ops
             type: elasticsearch
             server_host:
@@ -453,6 +468,7 @@
             cert: "/etc/rsyslog.d/es-cert.pem"
             private_key: "/etc/rsyslog.d/es-key.pem"
             state: absent
+            uid: testuser0
           - name: elasticsearch_output_ops
             type: elasticsearch
             server_host:


### PR DESCRIPTION
We want to expose the uid and pwd parameters in our role,
to allow basic auth on the elasticsearch server.

The metrics update can be seen here: https://gerrit.ovirt.org/#/c/ovirt-engine-metrics/+/116098/

Bug-Url: https://bugzilla.redhat.com/1990490

Signed-off-by: Aviv Litman <alitman@redhat.com>