### PR TITLE
Add logging_restore_confs variable to restore backup.

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,8 @@ These variables are set in the same level of the `logging_inputs`, `logging_outp
 - `logging_mark`: Mark message periodically by immark, if set to `true`. Default to `false`.
 - `logging_mark_interval`: Interval for `logging_mark` in seconds. Default to `3600`.
 - `logging_purge_confs`: `true` or `false`. If set to `true`, files in /etc/rsyslog.d are purged.
+- `logging_backup_dir`: Path to specify the directory to store backup file which contains pre-logging system role run. The backup is used when `logging_restore_confs` is set to `true`.
+- `logging_restore_confs`: `true` or `false`. If set to `true`, config files in the backup file are restored. This variable is to be used in the cleaning up.
 - `logging_system_log_dir`: Directory where the local log output files are placed. Default to `/var/log`.
 
 ### Update and Delete

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,6 +17,15 @@ logging_flows: []
 # If logging_purge_confs is set to true, existing config files will be purged.
 logging_purge_confs: false
 
+# Variable to specify the directory to store backup file which contains pre-
+# logging system role run. The backup is used when logging_restore_confs is
+# set to true.
+# Default to '/var/lib/rsyslog' for rsyslog.
+logging_backup_dir: ""
+
+# If logging_restore_confs is set to true, backed up config files are restored.
+logging_restore_confs: false
+
 # Variable to specify the directory to put the local output files to store logs.
 logging_system_log_dir: /var/log
 

--- a/roles/rsyslog/tasks/main.yml
+++ b/roles/rsyslog/tasks/main.yml
@@ -74,25 +74,42 @@
             state: directory
             path: '{{ __rsyslog_backup_dir }}'
             mode: '0700'
-          changed_when: false
 
-        - name: Archive the contents of {{ __rsyslog_config_dir }} to
-            the backup dir
+        - name: Get backup file stat
+          stat:
+            path: "{{ __rsyslog_backup_dir }}/backup.tgz"
+          register: __backup_stat
+
+        - name: Archive the original contents of {{ __rsyslog_config_dir }}
+            to the backup dir
           command: >
             tar -cvzPf "{{ __rsyslog_backup_dir }}/backup.tgz"
-                /etc/rsyslog.conf "{{ __rsyslog_config_dir }}"
-          args:
-            warn: false  # suppress 'unarchive' warning
-          changed_when: false
+              /etc/rsyslog.conf "{{ __rsyslog_config_dir }}"
+          when: not __backup_stat.stat.exists
 
         - name: Purge original conf
           file:
             state: absent
             path: "{{ __rsyslog_config_dir }}/*"
           when: __rsyslog_purge_original_conf | bool | d(false)
+
+        - block:
+            - name: Get backup file stat
+              stat:
+                path: "{{ __rsyslog_backup_dir }}/backup.tgz"
+              register: __backup_stat
+
+            - name: Restore original conf
+              command: >
+                tar -xvzPf "{{ __rsyslog_backup_dir }}/backup.tgz"
+              when: __backup_stat.stat.exists
+          when:
+            - __rsyslog_restore_original_conf | bool | d(false)
+
       vars:
-        __rsyslog_backup_dir: '{{ rsyslog_backup_dir |
-          d("/tmp") }}/rsyslog.d-{{ ansible_date_time.iso8601_basic_short }}'
+        __rsyslog_backup_dir: '{{ logging_backup_dir
+                               if logging_backup_dir|length > 0
+                               else "/var/lib/rsyslog" }}'
 
     - name: "Create logging directory if it does not exist or
       the ownership and/or modes are different."

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -96,6 +96,7 @@
   vars:
     __rsyslog_enabled: "{{ logging_enabled }}"
     __rsyslog_purge_original_conf: "{{ logging_purge_confs }}"
+    __rsyslog_restore_original_conf: "{{ logging_restore_confs }}"
     __rsyslog_system_log_dir: "{{ logging_system_log_dir }}"
   include_role:
     name: "{{ role_path }}/roles/rsyslog"

--- a/tests/tests_basics_files.yml
+++ b/tests/tests_basics_files.yml
@@ -386,6 +386,7 @@
 
     - name: END TEST CASE 3; Clean up the deployed config
       vars:
+        logging_restore_confs: true
         logging_enabled: false
         logging_outputs:
           - name: files_output0


### PR DESCRIPTION
When `logging_purge_confs` is set to `true` and the configuration is cleaned up at the end of the test (e.g., tests_basics_files.yml), the rsyslog configuration on the target nodes are destroyed and rsyslog service fails to restart as shown in this ansible.log.
https://dl.fedoraproject.org/pub/alt/linuxsystemroles/logs/linux-system-roles-logging-pull-linux-system-roles_logging-240-618f22e-rhel-8-y-20220105-174527/artifacts/ansible.log

To mitigate the issue, I'd like to propose to add `logging_restore_confs` variable to restore the conf files from backup if it is set to `true`. In the addition, I'm switching the default backup location from /tmp to /var/tmp to keep the backup in a bit safer place.