### PR TITLE
Initialize tests_enabled.yml by setting "logging_purge_confs: true"

### DIFF
--- a/tests/tests_enabled.yml
+++ b/tests/tests_enabled.yml
@@ -22,6 +22,8 @@
 
   tasks:
     - name: default run
+      vars:
+        logging_purge_confs: true
       include_role:
         name: linux-system-roles.logging
 


### PR DESCRIPTION
This is part of the effort to allow CI tests run in the serialized
manner on one VM for shortening the duration of the CI tests. The
test case tests_enabled.yml expects the rsyslog configuration file
in the original state from the rsyslog rpm package.