### PR TITLE
Fix failures reported by "tox -e qemu_option -- --remove-cloud-init ..."

### DIFF
--- a/tests/tests_basics_files.yml
+++ b/tests/tests_basics_files.yml
@@ -76,15 +76,7 @@
 
     - name: END TEST CASE 0; Clean up the deployed config
       vars:
-        logging_enabled: false
-        logging_inputs:
-          - name: basic_input
-            type: basics
-            state: absent
-        logging_outputs:
-          - name: default_files
-            type: files
-            state: absent
+        logging_purge_confs: true
       include_role:
         name: linux-system-roles.logging
 
@@ -156,20 +148,7 @@
 
     - name: END TEST CASE 1; Clean up the deployed config
       vars:
-        logging_enabled: false
-        logging_system_log_dir: "{{ __logging_system_log_dir }}"
-        logging_outputs:
-          - name: files_output0
-            type: files
-            state: absent
-        logging_inputs:
-          - name: basic_input
-            type: basics
-            state: absent
-        logging_flows:
-          - name: flows0
-            inputs: [basic_input]
-            outputs: [files_output]
+        logging_purge_confs: true
       include_role:
         name: linux-system-roles.logging
 
@@ -239,37 +218,7 @@
 
     - name: END TEST CASE 2; Clean up the deployed config
       vars:
-        logging_enabled: false
-        logging_outputs:
-          - name: files_output0
-            type: files
-            facility: authpriv,auth
-            path: /var/log/secure
-            state: absent
-          - name: files_output1
-            type: files
-            severity: info
-            exclude:
-              - authpriv.none
-              - auth.none
-              - cron.none
-              - mail.none
-            path: "{{ __default_system_log }}"
-            state: absent
-          - name: files_output2
-            type: files
-            severity: emerg
-            path: :omusrmsg:*
-            state: absent
-          - name: files_output3
-            type: files
-            facility: local7
-            path: /var/log/boot.log
-            state: absent
-        logging_inputs:
-          - name: basic_input
-            type: basics
-            state: absent
+        logging_purge_confs: true
       include_role:
         name: linux-system-roles.logging
 
@@ -386,40 +335,7 @@
 
     - name: END TEST CASE 3; Clean up the deployed config
       vars:
-        logging_enabled: false
-        logging_outputs:
-          - name: files_output0
-            type: files
-            severity: info
-            exclude:
-              - authpriv.none
-              - auth.none
-              - cron.none
-              - mail.none
-            path: "{{ __default_system_log }}"
-            state: absent
-          - name: files_output1
-            type: files
-            facility: authpriv,auth
-            path: /var/log/secure
-            state: absent
-          - name: forwards_severity_and_facility
-            type: forwards
-            facility: local1
-            severity: info
-            target: host.domain
-            tcp_port: 1514
-            state: absent
-          - name: forwards_facility_only
-            type: forwards
-            facility: local2
-            target: host.domain
-            tcp_port: 2514
-            state: absent
-        logging_inputs:
-          - name: basic_input0
-            type: basics
-            state: absent
+        logging_purge_confs: true
       include_role:
         name: linux-system-roles.logging
 

--- a/tests/tests_basics_forwards.yml
+++ b/tests/tests_basics_forwards.yml
@@ -92,7 +92,7 @@
 
     - name: Ensure config file size and counts
       vars:
-        __conf_count: 12
+        __conf_count: 11
         __conf_size: less
         __conf_files:
           - "{{ __test_forward_conf_s_f }}"
@@ -267,51 +267,7 @@
 
     - name: END TEST CASE 0; Clean up the deployed config
       vars:
-        logging_enabled: false
-        logging_outputs:
-          - name: forwards_severity_and_facility
-            type: forwards
-            facility: local1
-            severity: info
-            target: host.domain
-            tcp_port: 1514
-            state: absent
-          - name: forwards_facility_only
-            type: forwards
-            facility: local2
-            target: host.domain
-            tcp_port: 2514
-            state: absent
-          - name: forwards_severity_only
-            type: forwards
-            severity: err
-            target: host.domain
-            tcp_port: 3514
-            state: absent
-          - name: forwards_no_severity_and_facility
-            type: forwards
-            target: host.domain
-            tcp_port: 4514
-            state: absent
-          - name: forwards_no_severity_and_facility_udp
-            type: forwards
-            target: host.domain
-            udp_port: 6514
-            state: absent
-          - name: forwards_no_severity_and_facility_protocol_port
-            type: forwards
-            target: host.domain
-            state: absent
-          - name: forwards_no_severity_and_facility_protocol_port_target
-            type: forwards
-            state: absent
-          - target: no_name.localdomain
-            type: forwards
-            state: absent
-        logging_inputs:
-          - name: basic_input
-            type: basics
-            state: absent
+        logging_purge_confs: true
       include_role:
         name: linux-system-roles.logging
 
@@ -422,25 +378,7 @@
 
     - name: END TEST CASE 1; Clean up the deployed config
       vars:
-        logging_enabled: false
-        logging_pki_files:
-          - ca_cert_src: "{{ __test_ca_cert }}"
-            state: absent
-        logging_outputs:
-          - name: forwards_severity_and_facility
-            type: forwards
-            facility: local1
-            severity: info
-            target: host.domain
-            tcp_port: 1514
-            tls: true
-            pki_authmode: anon
-            permitted_server: '*.example.com'
-            state: absent
-        logging_inputs:
-          - name: basic_input
-            type: basics
-            state: absent
+        logging_purge_confs: true
       include_role:
         name: linux-system-roles.logging
 
@@ -569,27 +507,7 @@
 
     - name: END TEST CASE 2; Clean up the deployed config
       vars:
-        logging_enabled: false
         logging_purge_confs: true
-        logging_pki_files:
-          - ca_cert_src: "{{ __test_ca_cert }}"
-            cert_src: "{{ __test_cert }}"
-            private_key_src: "{{ __test_key }}"
-            state: absent
-        logging_outputs:
-          - name: forwards_severity_and_facility
-            type: forwards
-            facility: local1
-            severity: info
-            target: host.domain
-            tcp_port: 1514
-            tls: true
-            permitted_server: '*.example.com'
-            state: absent
-        logging_inputs:
-          - name: basic_input
-            type: basics
-            state: absent
       include_role:
         name: linux-system-roles.logging
 
@@ -653,22 +571,15 @@
 
     - name: END TEST CASE 3; Clean up the deployed config
       vars:
-        logging_enabled: false
-        logging_outputs:
-          - name: forwards_severity_and_facility
-            type: forwards
-            facility: local1
-            severity: info
-            target: host.domain
-            tls: true
-            tcp_port: 1514
-            state: absent
-        logging_inputs:
-          - name: basic_input
-            type: basics
-            state: absent
+        logging_purge_confs: true
       include_role:
         name: linux-system-roles.logging
+
+    # notify restart rsyslogd is executed at the end of this test task.
+    # thus we have to force to invoke handlers
+    - name: "Force all notified handlers to run at this point,
+      not waiting for normal sync points"
+      meta: flush_handlers
 
     - name: clean up fake pki files
       file: path="{{ item }}" state=absent

--- a/tests/tests_combination.yml
+++ b/tests/tests_combination.yml
@@ -169,49 +169,7 @@
 
     - name: END TEST CASE 0; Clean up the deployed config
       vars:
-        logging_enabled: false
-        logging_outputs:
-          - name: files_test0
-            type: files
-            severity: info
-            exclude:
-              - authpriv.none
-              - auth.none
-              - cron.none
-              - mail.none
-            path: "{{ __default_system_log }}"
-            state: absent
-          - name: files_test1
-            type: files
-            facility: authpriv,auth
-            path: /var/log/secure
-            state: absent
-          - name: forwards_severity_and_facility
-            type: forwards
-            facility: local1
-            severity: info
-            target: host.domain
-            tcp_port: 1514
-            state: absent
-          - name: forwards_facility_only
-            type: forwards
-            facility: local2
-            target: host.domain
-            tcp_port: 2514
-            state: absent
-        logging_inputs:
-          - name: "{{ __test_tag }}"
-            type: files
-            input_log_path: "{{ __test_inputfiles_dir }}/*.log"
-            state: absent
-          - name: basic_input
-            type: basics
-            ratelimit_burst: 33333
-            state: absent
-          - name: basic_input
-            type: basics
-            ratelimit_burst: 44444
-            state: absent
+        logging_purge_confs: true
       include_role:
         name: linux-system-roles.logging
 
@@ -376,45 +334,7 @@
 
     - name: END TEST CASE 1; Clean up the deployed config
       vars:
-        logging_enabled: false
-        logging_outputs:
-          - name: files_test0
-            type: files
-            severity: info
-            exclude:
-              - authpriv.none
-              - auth.none
-              - cron.none
-              - mail.none
-            path: "{{ __default_system_log }}"
-            state: absent
-          - name: files_test1
-            type: files
-            facility: authpriv,auth
-            path: /var/log/secure
-            state: absent
-          - name: forwards_severity_and_facility
-            type: forwards
-            facility: local1
-            severity: info
-            target: host.domain
-            tcp_port: 1514
-            state: absent
-          - name: forwards_facility_only
-            type: forwards
-            facility: local2
-            target: host.domain
-            tcp_port: 2514
-            state: absent
-        logging_inputs:
-          - name: basic_input
-            type: basics
-            ratelimit_burst: 33333
-            state: absent
-          - name: "{{ __test_tag }}"
-            type: files
-            input_log_path: "{{ __test_inputfiles_dir }}/*.log"
-            state: absent
+        logging_purge_confs: true
       include_role:
         name: linux-system-roles.logging
 
@@ -603,23 +523,7 @@
 
     - name: END TEST CASE 2; Clean up the deployed config
       vars:
-        logging_enabled: false
-        logging_outputs:
-          - name: files_test0
-            type: files
-            severity: info
-            exclude:
-              - authpriv.none
-              - auth.none
-              - cron.none
-              - mail.none
-            path: "{{ __default_system_log }}"
-            state: absent
-        logging_inputs:
-          - name: basic_input
-            type: basics
-            ratelimit_burst: 33333
-            state: absent
+        logging_purge_confs: true
       include_role:
         name: linux-system-roles.logging
 

--- a/tests/tests_enabled.yml
+++ b/tests/tests_enabled.yml
@@ -21,6 +21,9 @@
   hosts: all
 
   tasks:
+    - name: Check /etc/rsyslog.d
+      command: ls /etc/rsyslog.d
+
     - name: default run
       vars:
         logging_purge_confs: true

--- a/tests/tests_files_elasticsearch.yml
+++ b/tests/tests_files_elasticsearch.yml
@@ -124,24 +124,7 @@
 
     - name: END TEST CASE 0; Clean up the deployed config
       vars:
-        logging_enabled: false
-        logging_outputs:
-          - name: "{{ __test_el }}"
-            type: elasticsearch
-            server_host: logging-es
-            server_port: 9200
-            index_prefix: project.
-            input_type: ovirt
-            retryfailures: true
-            ca_cert_src: "{{ __test_ca_cert }}"
-            cert_src: "{{ __test_cert }}"
-            private_key_src: "{{ __test_key }}"
-            state: absent
-        logging_inputs:
-          - name: files_input
-            type: files
-            input_log_path: "{{ __test_inputfiles_dir }}/*.log"
-            state: absent
+        logging_purge_confs: true
       include_role:
         name: linux-system-roles.logging
 
@@ -240,27 +223,7 @@
 
     - name: END TEST CASE 1; Clean up the deployed config
       vars:
-        logging_enabled: false
-        logging_outputs:
-          - name: elasticsearch_output
-            type: elasticsearch
-            server_host: logging-es
-            server_port: 9200
-            index_prefix: project.
-            input_type: ovirt
-            retryfailures: false
-            ca_cert_src: "{{ __test_ca_cert }}"
-            cert_src: "{{ __test_cert }}"
-            private_key_src: "{{ __test_key }}"
-            ca_cert: "{{ __test_ca_cert_target }}"
-            cert: "{{ __test_cert_target }}"
-            private_key: "{{ __test_key_target }}"
-            state: absent
-        logging_inputs:
-          - name: files_input
-            type: files
-            input_log_path: "{{ __test_inputfiles_dir }}/*.log"
-            state: absent
+        logging_purge_confs: true
       include_role:
         name: linux-system-roles.logging
 
@@ -356,25 +319,7 @@
 
     - name: END TEST CASE 2; Clean up the deployed config
       vars:
-        logging_enabled: false
-        logging_outputs:
-          - name: elasticsearch_output
-            type: elasticsearch
-            server_host: logging-es
-            server_port: 9200
-            index_prefix: project.
-            input_type: ovirt
-            retryfailures: false
-            tls: false
-            ca_cert_src: "{{ __test_ca_cert }}"
-            cert_src: "{{ __test_cert }}"
-            private_key_src: "{{ __test_key }}"
-            state: absent
-        logging_inputs:
-          - name: files_input
-            type: files
-            input_log_path: "{{ __test_inputfiles_dir }}/*.log"
-            state: absent
+        logging_purge_confs: true
       include_role:
         name: linux-system-roles.logging
 
@@ -425,22 +370,7 @@
 
     - name: END TEST CASE 3; Clean up the deployed config
       vars:
-        logging_enabled: false
-        logging_outputs:
-          - name: elasticsearch_output
-            type: elasticsearch
-            server_host: logging-es
-            server_port: 9200
-            index_prefix: project.
-            input_type: ovirt
-            retryfailures: false
-            tls: false
-            state: absent
-        logging_inputs:
-          - name: files_input
-            type: files
-            input_log_path: "{{ __test_inputfiles_dir }}/*.log"
-            state: absent
+        logging_purge_confs: true
       include_role:
         name: linux-system-roles.logging
 
@@ -494,25 +424,9 @@
 
     - name: END TEST CASE 4; Clean up the deployed config
       vars:
-        logging_enabled: false
-        logging_outputs:
-          - name: elasticsearch_output
-            type: elasticsearch
-            server_host: logging-es
-            server_port: 9200
-            index_prefix: project.
-            input_type: ovirt
-            retryfailures: false
-            tls: false
-            state: absent
-        logging_inputs:
-          - name: files_input
-            type: files
-            input_log_path: "{{ __test_inputfiles_dir }}/*.log"
-            state: absent
+        logging_purge_confs: true
       include_role:
         name: linux-system-roles.logging
-
 
     # notify restart rsyslogd is executed at the end of this test task.
     # thus we have to force to invoke handlers

--- a/tests/tests_files_files.yml
+++ b/tests/tests_files_files.yml
@@ -138,35 +138,7 @@
 
     - name: END TEST CASE 0; Clean up the deployed config
       vars:
-        logging_enabled: false
-        logging_outputs:
-          - name: files_output0
-            type: files
-            severity: info
-            exclude:
-              - authpriv.none
-              - auth.none
-              - cron.none
-              - mail.none
-            path: "{{ __default_system_log }}"
-            state: absent
-          - name: files_output1
-            type: files
-            facility: authpriv,auth
-            path: /var/log/secure
-            state: absent
-        logging_inputs:
-          - name: files_input0
-            type: files
-            input_log_path: "{{ __test_inputfiles_dir0 }}/*.log"
-            state: absent
-          - name: files_input1
-            type: files
-            input_log_path: "{{ __test_inputfiles_dir1 }}/*.log"
-            state: absent
-          - name: files_input2
-            type: files
-            state: absent
+        logging_purge_confs: true
       include_role:
         name: linux-system-roles.logging
 

--- a/tests/tests_imuxsock_files.yml
+++ b/tests/tests_imuxsock_files.yml
@@ -80,16 +80,7 @@
 
     - name: END TEST CASE 0; Clean up the deployed config
       vars:
-        logging_enabled: false
-        logging_inputs:
-          - name: basic_input
-            type: basics
-            use_imuxsock: true
-            state: absent
-        logging_outputs:
-          - name: default_files
-            type: files
-            state: absent
+        logging_purge_confs: true
       include_role:
         name: linux-system-roles.logging
 

--- a/tests/tests_ovirt_elasticsearch.yml
+++ b/tests/tests_ovirt_elasticsearch.yml
@@ -187,51 +187,7 @@
 
     - name: END TEST CASE 0; Ensure basic ovirt configuration works
       vars:
-        logging_enabled: false
-        logging_elasticsearch_password: password0
-        logging_outputs:
-          - name: default_files
-            type: files
-            state: absent
-          - name: elasticsearch_output
-            type: elasticsearch
-            server_host: logging-es
-            server_port: 9200
-            index_prefix: project.
-            input_type: ovirt
-            retryfailures: false
-            ca_cert: "/etc/rsyslog.d/es-ca.crt"
-            cert: "/etc/rsyslog.d/es-cert.pem"
-            private_key: "/etc/rsyslog.d/es-key.pem"
-            state: absent
-            uid: testuser0
-          - name: elasticsearch_output_ops
-            type: elasticsearch
-            server_host: logging-es-ops
-            server_port: 9200
-            index_prefix: .operations.
-            input_type: ovirt
-            retryfailures: false
-            ca_cert: "/etc/rsyslog.d/es-ca.crt"
-            cert: "/etc/rsyslog.d/es-cert.pem"
-            private_key: "/etc/rsyslog.d/es-key.pem"
-            state: absent
-        logging_inputs:
-          - name: basic_input
-            type: basics
-            state: absent
-          - name: "{{ __test_collectd_name }}"
-            type: ovirt
-            subtype: collectd
-            state: absent
-          - name: "{{ __test_engine_name }}"
-            type: ovirt
-            subtype: engine
-            state: absent
-          - name: "{{ __test_vdsm_name }}"
-            type: ovirt
-            subtype: vdsm
-            state: absent
+        logging_purge_confs: true
       include_role:
         name: linux-system-roles.logging
 
@@ -453,72 +409,7 @@
 
     - name: END TEST CASE 1; Ensure basic ovirt configuration works
       vars:
-        logging_enabled: false
-        logging_outputs:
-          - name: default_files
-            type: files
-            state: absent
-          - name: elasticsearch_output
-            type: elasticsearch
-            server_host: [logging-es0, logging-es1]
-            server_port: 9200
-            index_prefix: project.
-            input_type: ovirt
-            ca_cert: "/etc/rsyslog.d/es-ca.crt"
-            cert: "/etc/rsyslog.d/es-cert.pem"
-            private_key: "/etc/rsyslog.d/es-key.pem"
-            state: absent
-            uid: testuser0
-          - name: elasticsearch_output_ops
-            type: elasticsearch
-            server_host:
-              - logging-es-ops0
-              - logging-es-ops1
-            server_port: 9200
-            index_prefix: .operations.
-            input_type: ovirt
-            retryfailures: false
-            ca_cert: "/etc/rsyslog.d/es-ca.crt"
-            cert: "/etc/rsyslog.d/es-cert.pem"
-            private_key: "/etc/rsyslog.d/es-key.pem"
-            dynSearchIndex: false
-            bulkmode: false
-            dynbulkid: false
-            allowUnsignedCerts: true
-            usehttps: false
-            state: absent
-        logging_inputs:
-          - name: basic_input
-            type: basics
-            state: absent
-          - name: "{{ __test_collectd_name }}"
-            type: ovirt
-            subtype: collectd
-            ovirt_collectd_port: "{{ __test_collectd_port }}"
-            ovirt_elasticsearch_index_prefix: "{{ __test_metrics_index }}"
-            ovirt_env_name: test-engine
-            ovirt_env_uuid: 111-222-333
-            state: absent
-          - name: "{{ __test_engine_name }}"
-            type: ovirt
-            subtype: engine
-            ovirt_elasticsearch_index_prefix: "{{ __test_logs_index }}"
-            ovirt_env_name: test-engine
-            ovirt_env_uuid: 444-555-666
-            ovirt_vds_cluster_name: test_vds_cluster
-            ovirt_engine_fqdn: engine.ovirt.example.com
-            ovirt_input_file: "{{ __test_engine_input }}"
-            state: absent
-          - name: "{{ __test_vdsm_name }}"
-            type: ovirt
-            subtype: vdsm
-            ovirt_elasticsearch_index_prefix: "{{ __test_logs_index }}"
-            ovirt_env_name: test-engine
-            ovirt_env_uuid: 777-888-999
-            ovirt_vds_cluster_name: test_vds_cluster
-            ovirt_engine_fqdn: engine.ovirt.example.com
-            ovirt_input_file: "{{ __test_vdsm_input }}"
-            state: absent
+        logging_purge_confs: true
       include_role:
         name: linux-system-roles.logging
 

--- a/tests/tests_remote.yml
+++ b/tests/tests_remote.yml
@@ -42,7 +42,7 @@
 
     - name: Ensure config file size and counts
       vars:
-        __conf_count: 10
+        __conf_count: 9
         __conf_size: less
         __conf_files:
           - "{{ __test_input_remote_tcp }}"
@@ -100,20 +100,7 @@
 
     - name: END TEST CASE 0; Clean up the deployed config
       vars:
-        logging_enabled: false
-        logging_outputs:
-          - name: remote_files_output0
-            type: remote_files
-            state: absent
-        logging_inputs:
-          - name: remote_tcp_input
-            type: remote
-            tcp_ports: [514, 40001]
-            state: absent
-          - name: remote_udp_input
-            type: remote
-            udp_ports: [514, 40002]
-            state: absent
+        logging_purge_confs: true
       include_role:
         name: linux-system-roles.logging
 
@@ -169,7 +156,7 @@
 
     - name: Ensure config file size and counts
       vars:
-        __conf_count: 10
+        __conf_count: 9
         __conf_size: less
         __conf_files:
           - "{{ __test_input_remote_tcp }}"
@@ -217,38 +204,7 @@
 
     - name: END TEST CASE 1; Clean up the deployed config
       vars:
-        logging_enabled: false
-        logging_tcp_threads: 2
-        logging_udp_threads: 2
-        logging_server_queue_type: FixedArray
-        logging_outputs:
-          - name: remote_files_output0
-            type: remote_files
-            remote_log_path: >-
-              /var/log/remote/%FROMHOST%/%PROGRAMNAME:::secpath-replace%.log
-            comment: "This is a comment 0."
-            severity: info
-            exclude:
-              - authpriv.none
-            client_count: 20
-            io_buffer_size: 8192
-            async_writing: true
-            state: absent
-          - name: remote_files_output1
-            type: remote_files
-            remote_sub_path: >-
-              others/%FROMHOST%/%PROGRAMNAME:::secpath-replace%.log
-            facility: authpriv
-            state: absent
-        logging_inputs:
-          - name: remote_tcp_input
-            type: remote
-            tcp_ports: [514, 40001]
-            state: absent
-          - name: remote_udp_input
-            type: remote
-            udp_ports: [514, 40002]
-            state: absent
+        logging_purge_confs: true
       include_role:
         name: linux-system-roles.logging
 

--- a/tests/tests_server.yml
+++ b/tests/tests_server.yml
@@ -81,7 +81,7 @@
 
     - name: Ensure config file size and counts
       vars:
-        __conf_count: 12
+        __conf_count: 11
         __conf_size: less
         __conf_files:
           - "{{ __test_server_ptcp }}"
@@ -129,32 +129,7 @@
 
     - name: END TEST CASE 0; Clean up the deployed config
       vars:
-        logging_enabled: false
-        logging_inputs:
-          - name: system_input
-            type: basics
-            state: absent
-          - name: remote_tcp
-            type: remote
-            tcp_ports: [6514, 40000, 40001]
-            tls: true
-            pki_authmode: x509/name
-            permitted_clients:
-              - '*.client.com'
-              - '*.example.com'
-            state: absent
-          - name: remote_ptcp
-            type: remote
-            tcp_ports: [514, 40010, 40011, 40012]
-            state: absent
-          - name: remote_udp
-            type: remote
-            udp_ports: [514, 40020]
-            state: absent
-        logging_outputs:
-          - name: files_output
-            type: files
-            state: absent
+        logging_purge_confs: true
       include_role:
         name: linux-system-roles.logging
 
@@ -220,33 +195,7 @@
     - block:
         - name: END TEST CASE 1; Clean up the deployed config
           vars:
-            logging_enabled: false
-            logging_inputs:
-              - name: system_input
-                type: basics
-                state: absent
-              - name: remote_tcp_0
-                type: remote
-                tcp_ports: [6514, 40000, 40001]
-                tls: true
-                pki_authmode: x509/name
-                permitted_clients:
-                  - '*.client.com'
-                  - '*.example.com'
-                state: absent
-              - name: remote_tcp_1
-                type: remote
-                tcp_ports: [514, 40010, 40011]
-                tls: true
-                state: absent
-              - name: remote_udp
-                type: remote
-                udp_ports: [514, 40020]
-                state: absent
-            logging_outputs:
-              - name: files_output
-                type: files
-                state: absent
+            logging_purge_confs: true
           include_role:
             name: linux-system-roles.logging
 


### PR DESCRIPTION
If no additional config files such as 21-cloudinit.conf exist in
/etc/rsyslog.d; in the cleaning up phase in the test playbooks,
by removing all the generated files by the logging role, it ends
up /etc/rsyslog.d is empty with "$IncludeConfig /etc/rsyslog.d/*.conf"
in /etc/rsyslog.conf. It makes the following rsyslog service restart
fail.

This patch replaces the old cleaning up method - removing the
files in /etc/rsyslog.d with the better one - resetting the
rsyslog config files to the ones from rpm.