### PR TITLE
Fix including a var file in set_vars.yml.

### DIFF
--- a/roles/rsyslog/tasks/set_vars.yml
+++ b/roles/rsyslog/tasks/set_vars.yml
@@ -19,10 +19,10 @@
       {{ ansible_facts['distribution_version'] }}.yml"
   when: item is file
 
-- name: "Include {{ role_path }}/roles/rsyslog/vars/main.yml"
+- name: "Include {{ role_path }}/vars/main.yml"
   include_vars: "{{ item }}"
-  loop: "{{ ['{{ role_path }}/vars/main.yml'] +
-            lookup('lines',
-              '/bin/ls -1 {{ role_path }}/vars/*/*/main.yml').split(',') }}"
+  loop: "{{ lookup('lines',
+         '/bin/ls -1 {{ role_path }}/vars/main.yml
+          {{ role_path }}/vars/*/*/main.yml').split(',') }}"
   when: __snapshot_gather_vars is defined and
         __snapshot_gather_vars | bool


### PR DESCRIPTION
`['{{ role_path }}/vars/main.yml']` in the original code fails with `Could not find or access '{{ role_path }}/vars/main.yml'`.

The path in the name string was fixed, as well.

Complete failed message:
```
"message": "Could not find or access '{{ role_path }}/vars/main.yml'
Searched in:
    /usr/share/ansible/roles/rhel-system-roles.logging/roles/rsyslog/vars/{{ role_path }}/vars/main.yml
    /usr/share/ansible/roles/rhel-system-roles.logging/roles/rsyslog/{{ role_path }}/vars/main.yml
    /usr/share/ansible/roles/rhel-system-roles.logging/vars/{{ role_path }}/vars/main.yml
    /usr/share/ansible/roles/rhel-system-roles.logging/{{ role_path }}/vars/main.yml
    /usr/share/ansible/roles/rhel-system-roles.logging/roles/rsyslog/tasks/vars/{{ role_path }}/vars/main.yml
    /usr/share/ansible/roles/rhel-system-roles.logging/roles/rsyslog/tasks/{{ role_path }}/vars/main.yml
    /tmp/tmp.mctGmt8bV4/roles/rhel-system-roles.logging/tests/vars/{{ role_path }}/vars/main.yml
    /tmp/tmp.mctGmt8bV4/roles/rhel-system-roles.logging/tests/{{ role_path }}/vars/main.yml on the Ansible Controller.
If you are using a module and expect the file to exist on the remote, see the remote_src option"
```