### PR TITLE
support ansible-core-2.13

### DIFF
--- a/roles/rsyslog/tasks/inputs/remote/main.yml
+++ b/roles/rsyslog/tasks/inputs/remote/main.yml
@@ -17,10 +17,10 @@
                               selectattr('tcp_ports', 'defined') | list }}"
     __logging_remote_tls: "{{ __logging_remote_tcp |
                               selectattr('tls', 'defined') | list }}"
-    __logging_remote_ptcp: "{{ __logging_remote_tcp |
-                               selectattr('tls', 'undefined') | list }} +
-                            {{ __logging_remote_tls | rejectattr('tls')
-                               | list }}"
+    __logging_remote_ptcp: "{{ (__logging_remote_tcp |
+                               selectattr('tls', 'undefined') | list) +
+                               (__logging_remote_tls | rejectattr('tls')
+                               | list) }}"
     __logging_remote_tlstcp: "{{ __logging_remote_tls | selectattr('tls')
                               | list }}"
 

--- a/roles/rsyslog/tasks/main_core.yml
+++ b/roles/rsyslog/tasks/main_core.yml
@@ -32,9 +32,9 @@
 
 - name: Install/Update required packages
   package:
-    name: "{{ __rsyslog_base_packages }} + {{ __rsyslog_tls_packages
-      if (logging_pki_files | d([]) | length > 0) else [] }} +
-      {{ rsyslog_extra_packages | flatten }}"
+    name: "{{ __rsyslog_base_packages + (__rsyslog_tls_packages
+      if (logging_pki_files | d([]) | length > 0) else []) +
+      (rsyslog_extra_packages | flatten) }}"
     state: present
   when:
     - __rsyslog_enabled | bool or

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,10 +16,10 @@
 
     - name: Set rsyslog_outputs
       set_fact:
-        rsyslog_outputs: "{{ logging_outputs | d([]) |
+        rsyslog_outputs: "{{ (logging_outputs | d([]) |
           selectattr('name', 'defined') |
-          selectattr('type', 'defined') | list }} +
-          {{ __rsyslog_output_files | d([]) }}"
+          selectattr('type', 'defined') | list) +
+          (__rsyslog_output_files | d([])) }}"
 
     - name: Set rsyslog_inputs
       set_fact:

--- a/tests/setup-snapshot.yml
+++ b/tests/setup-snapshot.yml
@@ -11,10 +11,12 @@
 
         - name: Install test packages
           package:
-            name: "{{ lookup('vars',
-                             *lookup('varnames', '^__rsyslog_.*packages$',
-                                 wantlist=True)) | flatten | unique | sort }}
-                      + ['lsof', 'openssl']"
+            name: "{{ __base_packages + ['lsof', 'openssl'] }}"
             state: present
+          vars:
+            __varnames: "{{ lookup('varnames', '^__rsyslog_.*packages$',
+                            wantlist=True) }}"
+            __base_packages: "{{ lookup('vars', *__varnames, wantlist=True) |
+              flatten | unique | sort }}"
       vars:
         __snapshot_gather_vars: true


### PR DESCRIPTION
Looks like ansible-core-2.13 (or latest jinja3) does not support
constructs like this:
```
var: "{{ [some list] }} + {{ [other list] }}"
```
instead, the entire thing has to be evaluated in the same jinja
evaluation context:
```
var: "{{ [some list] + [other list] }}"
```
