### PR TITLE
Support startmsg.regex and endmsg.regex in the files inputs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ Available options:
 - `input_log_path`: File name to be read by the imfile plugin. The value should be full path. Wildcard '\*' is allowed in the path.  Default to `/var/log/containers/*.log`.
 `facility`: Facility to filter the inputs from the files.
 `severity`: Severity to filter the inputs from the files.
+`startmsg_regex`: The regular expression that matches the start part of a message.
+`endmsg_regex`: The regular expression that matches the last part of a message.
 
 #### ovirt type
 

--- a/roles/rsyslog/templates/input_files.j2
+++ b/roles/rsyslog/templates/input_files.j2
@@ -8,5 +8,11 @@ input(
 {% if __rsyslog_input.facility is defined %}
   facility="{{ __rsyslog_input.facility }}"
 {% endif %}
+{% if __rsyslog_input.startmsg_regex is defined %}
+  startmsg.regex="{{ __rsyslog_input.startmsg_regex }}"
+{% endif %}
+{% if __rsyslog_input.endmsg_regex is defined %}
+  endmsg.regex="{{ __rsyslog_input.endmsg_regex }}"
+{% endif %}
 )
 {{ lookup('template', 'input_template.j2') }}

--- a/tests/tests_combination.yml
+++ b/tests/tests_combination.yml
@@ -52,6 +52,7 @@
           - name: "{{ __test_tag }}"
             type: files
             input_log_path: "{{ __test_inputfiles_dir }}/*.log"
+            endmsg_regex: xyz
           - name: basic_input
             type: basics
             ratelimit_burst: 33333
@@ -163,6 +164,23 @@
       command: >-
         /bin/grep '{{ __test_tag }} .*abcdefghijklmnopqrstuvwxyz$' {{ __default_system_log }}
       changed_when: false
+    # yamllint enable rule:line-length
+
+    # yamllint disable rule:line-length
+    - name: "Create a test log file with a log message in
+      {{ __test_inputfiles_dir }} which will not be logged
+      due to the regex condition"
+      shell: |-
+        set -euo pipefail
+        echo '<167>Jul 22 01:00:00 11.22.33.44 tag msgnum:00000000:24:test message 0123456789' > {{ __test_inputfiles_dir }}/test.log
+      changed_when: false
+
+    - name: Check the fake second test log message is not in {{ __default_system_log }}
+      command: >-
+        /bin/grep '{{ __test_tag }} .*test message 0123456789$' {{ __default_system_log }}
+      register: __result
+      changed_when: false
+      failed_when: __result.rc != 1
     # yamllint enable rule:line-length
 
     - name: END TEST CASE 0; Clean up the deployed config


### PR DESCRIPTION
Adds startmsg_regex and endmsg_regex options:
`startmsg_regex`: The regular expression that matches the start part of a message.
`endmsg_regex`: The regular expression that matches the last part of a message.

A test case specifying `endmsg_regex` is added to tests_combination.yml.