### PR TITLE
Version 1.11.1 - CHANGELOG.md [citest skip]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,24 @@
 Changelog
 =========
 
+[1.11.1] - 2022-11-14
+--------------------
+
+### New Features
+
+- none
+
+### Bug Fixes
+
+- none
+
+### Other Changes
+
+- support ansible-core 2.14, ansible-lint 6.x (#297)
+
+The main issue was getting rid of `warn: false` for the
+`command` module.  The other issues are related to ansible-lint 6.x
+
 [1.11.0] - 2022-11-01
 --------------------
 


### PR DESCRIPTION
[1.11.1] - 2022-11-14
--------------------

### New Features

- none

### Bug Fixes

- none

### Other Changes

- support ansible-core 2.14, ansible-lint 6.x (#297)

The main issue was getting rid of `warn: false` for the
`command` module.  The other issues are related to ansible-lint 6.x

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
