### PR TITLE
cert cleanup needs to use getcert stop-tracking

### DIFF
--- a/tests/tasks/test_logger.yml
+++ b/tests/tasks/test_logger.yml
@@ -25,4 +25,6 @@
 
     - name: Fail if the message was not printed
       fail:
-        msg: Missing log message "{{ __logging_message }}" in "{{ __logging_file }}"
+        msg: >
+          Missing log message "{{ __logging_message }}" in
+          "{{ __logging_file }}"

--- a/tests/tasks/test_logger.yml
+++ b/tests/tasks/test_logger.yml
@@ -7,12 +7,18 @@
     {{ __logging_message }}"
   changed_when: false
 
-- name: Check the test log message in {{ __default_system_log }}
-  vars:
-    __logging_message: "testMessage{{ __logging_index }}"
-  command: /bin/grep "{{ __logging_message }}" "{{ __logging_file }}"
-  register: __result
-  until: __result is success
-  retries: 5
-  delay: 1
-  changed_when: false
+- name: Check test log and check for errors
+  block:
+    - name: Check the test log message in {{ __default_system_log }}
+      vars:
+        __logging_message: "testMessage{{ __logging_index }}"
+      command: /bin/grep "{{ __logging_message }}" "{{ __logging_file }}"
+      register: __result
+      until: __result is success
+      retries: 60
+      delay: 1
+      changed_when: false
+  rescue:
+    - name: See what's in logging file if the test fails
+      command: tail -100 {{ __logging_file }}
+      changed_when: false

--- a/tests/tasks/test_logger.yml
+++ b/tests/tasks/test_logger.yml
@@ -22,3 +22,7 @@
     - name: See what's in logging file if the test fails
       command: tail -100 {{ __logging_file }}
       changed_when: false
+
+    - name: Fail if the message was not printed
+      fail:
+        msg: Missing log message "{{ __logging_message }}" in "{{ __logging_file }}"

--- a/tests/tests_relp.yml
+++ b/tests/tests_relp.yml
@@ -332,6 +332,10 @@
       not waiting for normal sync points"
       meta: flush_handlers
 
+    - name: stop tracking certificate
+      command: getcert stop-tracking -f {{ __test_ca_cert }}
+      changed_when: false
+
     - name: clean up pki files
       file: path="{{ item }}" state=absent
       loop:

--- a/tests/tests_server.yml
+++ b/tests/tests_server.yml
@@ -199,6 +199,10 @@
         - debug:
             msg: Caught an expected error - {{ ansible_failed_result }}
 
+    - name: stop tracking certificate
+      command: getcert stop-tracking -f {{ __test_ca_cert }}
+      changed_when: false
+
     - name: clean up pki files
       file: path="{{ item }}" state=absent
       loop:


### PR DESCRIPTION
Need to use `getcert stop-tracking` when removing the cert, otherwise,
subsequent requests will hang if certmonger is tracking a non-existent
cert.
