### PR TITLE
specify empty inputs, outputs, flows with purge

### DIFF
--- a/tests/tests_basics_files.yml
+++ b/tests/tests_basics_files.yml
@@ -78,6 +78,9 @@
         logging_purge_confs: true
         logging_manage_firewall: false
         logging_manage_selinux: false
+        logging_inputs: []
+        logging_outputs: []
+        logging_flows: []
       include_role:
         name: linux-system-roles.logging
         public: true
@@ -155,6 +158,9 @@
         logging_purge_confs: true
         logging_manage_firewall: false
         logging_manage_selinux: false
+        logging_inputs: []
+        logging_outputs: []
+        logging_flows: []
       include_role:
         name: linux-system-roles.logging
         public: true
@@ -229,6 +235,9 @@
     - name: END TEST CASE 2; Clean up the deployed config
       vars:
         logging_purge_confs: true
+        logging_inputs: []
+        logging_outputs: []
+        logging_flows: []
       include_role:
         name: linux-system-roles.logging
 
@@ -347,6 +356,9 @@
         logging_purge_confs: true
         logging_manage_firewall: false
         logging_manage_selinux: false
+        logging_inputs: []
+        logging_outputs: []
+        logging_flows: []
       include_role:
         name: linux-system-roles.logging
         public: true

--- a/tests/tests_basics_forwards.yml
+++ b/tests/tests_basics_forwards.yml
@@ -300,6 +300,9 @@
         - name: END TEST CASE 0; Clean up the deployed config
           vars:
             logging_purge_confs: true
+            logging_inputs: []
+            logging_outputs: []
+            logging_flows: []
           include_role:
             name: linux-system-roles.logging
 
@@ -404,6 +407,9 @@
         - name: END TEST CASE 1; Clean up the deployed config
           vars:
             logging_purge_confs: true
+            logging_inputs: []
+            logging_outputs: []
+            logging_flows: []
           include_role:
             name: linux-system-roles.logging
 
@@ -521,6 +527,9 @@
         - name: END TEST CASE 2; Clean up the deployed config
           vars:
             logging_purge_confs: true
+            logging_inputs: []
+            logging_outputs: []
+            logging_flows: []
           include_role:
             name: linux-system-roles.logging
 
@@ -586,6 +595,9 @@
         - name: END TEST CASE 3; Clean up the deployed config
           vars:
             logging_purge_confs: true
+            logging_inputs: []
+            logging_outputs: []
+            logging_flows: []
           include_role:
             name: linux-system-roles.logging
 

--- a/tests/tests_combination.yml
+++ b/tests/tests_combination.yml
@@ -190,6 +190,9 @@
     - name: END TEST CASE 0; Clean up the deployed config
       vars:
         logging_purge_confs: true
+        logging_inputs: []
+        logging_outputs: []
+        logging_flows: []
       include_role:
         name: linux-system-roles.logging
         public: true
@@ -361,6 +364,9 @@
     - name: END TEST CASE 1; Clean up the deployed config
       vars:
         logging_purge_confs: true
+        logging_inputs: []
+        logging_outputs: []
+        logging_flows: []
       include_role:
         name: linux-system-roles.logging
         public: true
@@ -548,6 +554,9 @@
     - name: END TEST CASE 2; Clean up the deployed config
       vars:
         logging_purge_confs: true
+        logging_inputs: []
+        logging_outputs: []
+        logging_flows: []
       include_role:
         name: linux-system-roles.logging
         public: true

--- a/tests/tests_files_elasticsearch.yml
+++ b/tests/tests_files_elasticsearch.yml
@@ -144,6 +144,9 @@
         - name: END TEST CASE 0; Clean up the deployed config
           vars:
             logging_purge_confs: true
+            logging_inputs: []
+            logging_outputs: []
+            logging_flows: []
           include_role:
             name: linux-system-roles.logging
 
@@ -230,6 +233,9 @@
         - name: END TEST CASE 1; Clean up the deployed config
           vars:
             logging_purge_confs: true
+            logging_inputs: []
+            logging_outputs: []
+            logging_flows: []
           include_role:
             name: linux-system-roles.logging
 
@@ -318,6 +324,9 @@
         - name: END TEST CASE 2; Clean up the deployed config
           vars:
             logging_purge_confs: true
+            logging_inputs: []
+            logging_outputs: []
+            logging_flows: []
           include_role:
             name: linux-system-roles.logging
 
@@ -369,6 +378,9 @@
         - name: END TEST CASE 3; Clean up the deployed config
           vars:
             logging_purge_confs: true
+            logging_inputs: []
+            logging_outputs: []
+            logging_flows: []
           include_role:
             name: linux-system-roles.logging
 
@@ -423,6 +435,9 @@
         - name: END TEST CASE 4; Clean up the deployed config
           vars:
             logging_purge_confs: true
+            logging_inputs: []
+            logging_outputs: []
+            logging_flows: []
           include_role:
             name: linux-system-roles.logging
 

--- a/tests/tests_files_files.yml
+++ b/tests/tests_files_files.yml
@@ -155,6 +155,9 @@
     - name: END TEST CASE 0; Clean up the deployed config
       vars:
         logging_purge_confs: true
+        logging_inputs: []
+        logging_outputs: []
+        logging_flows: []
       include_role:
         name: linux-system-roles.logging
         public: true

--- a/tests/tests_imuxsock_files.yml
+++ b/tests/tests_imuxsock_files.yml
@@ -79,6 +79,9 @@
     - name: END TEST CASE 0; Clean up the deployed config
       vars:
         logging_purge_confs: true
+        logging_inputs: []
+        logging_outputs: []
+        logging_flows: []
       include_role:
         name: linux-system-roles.logging
         public: true

--- a/tests/tests_ovirt_elasticsearch.yml
+++ b/tests/tests_ovirt_elasticsearch.yml
@@ -175,6 +175,9 @@
     - name: END TEST CASE 0; Ensure basic ovirt configuration works
       vars:
         logging_purge_confs: true
+        logging_inputs: []
+        logging_outputs: []
+        logging_flows: []
       include_role:
         name: linux-system-roles.logging
 
@@ -372,6 +375,9 @@
     - name: END TEST CASE 1; Ensure basic ovirt configuration works
       vars:
         logging_purge_confs: true
+        logging_inputs: []
+        logging_outputs: []
+        logging_flows: []
       include_role:
         name: linux-system-roles.logging
 

--- a/tests/tests_relp.yml
+++ b/tests/tests_relp.yml
@@ -177,6 +177,9 @@
         logging_purge_confs: true
         logging_manage_firewall: false
         logging_manage_selinux: false
+        logging_inputs: []
+        logging_outputs: []
+        logging_flows: []
       include_role:
         name: linux-system-roles.logging
         public: true
@@ -322,6 +325,9 @@
         logging_purge_confs: true
         logging_manage_firewall: false
         logging_manage_selinux: false
+        logging_inputs: []
+        logging_outputs: []
+        logging_flows: []
       include_role:
         name: linux-system-roles.logging
         public: true

--- a/tests/tests_remote.yml
+++ b/tests/tests_remote.yml
@@ -98,6 +98,9 @@
     - name: END TEST CASE 0; Clean up the deployed config
       vars:
         logging_purge_confs: true
+        logging_inputs: []
+        logging_outputs: []
+        logging_flows: []
       include_role:
         name: linux-system-roles.logging
         public: true
@@ -203,6 +206,9 @@
     - name: END TEST CASE 1; Clean up the deployed config
       vars:
         logging_purge_confs: true
+        logging_inputs: []
+        logging_outputs: []
+        logging_flows: []
       include_role:
         name: linux-system-roles.logging
         public: true

--- a/tests/tests_server.yml
+++ b/tests/tests_server.yml
@@ -116,6 +116,9 @@
     - name: END TEST CASE 0; Clean up the deployed config
       vars:
         logging_purge_confs: true
+        logging_inputs: []
+        logging_outputs: []
+        logging_flows: []
       include_role:
         name: linux-system-roles.logging
         public: true
@@ -192,6 +195,9 @@
         - name: END TEST CASE 1; Clean up the deployed config
           vars:
             logging_purge_confs: true
+            logging_inputs: []
+            logging_outputs: []
+            logging_flows: []
           include_role:
             name: linux-system-roles.logging
 


### PR DESCRIPTION
If there are any leftover defined variables that specify inputs, outputs, or flows,
purge will not remove those files since they are referred to.  This typically
happens when using `public: true` which leaves all of those role variables
defined in the public namespace.  The solution when cleaning up is to ensure
that none of the inputs, outputs, or flows is defined when using purge, to
guarantee that all of the config files are removed and none are leftover.
