### PR TITLE
additional ansible-lint 6.x fixes

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,3 +1,18 @@
 ---
 skip_list:
   - fqcn-builtins
+exclude_paths:
+  - tests/roles/
+  - .github/
+  - examples/roles/
+kinds:
+  - yaml: "**/meta/collection-requirements.yml"
+  - yaml: "**/tests/collection-requirements.yml"
+  - playbook: "**/tests/tests_*.yml"
+  - playbook: "**/tests/setup-snapshot.yml"
+  - tasks: "**/tests/*.yml"
+  - playbook: "**/tests/playbooks/*.yml"
+  - tasks: "**/tests/tasks/*.yml"
+  - tasks: "**/tests/tasks/*/*.yml"
+  - vars: "**/tests/vars/*.yml"
+  - playbook: "**/examples/*.yml"

--- a/tests/setup-snapshot.yml
+++ b/tests/setup-snapshot.yml
@@ -1,22 +1,22 @@
 ---
 # SPDX-License-Identifier: GPL-3.0-only
 
-- hosts: all
+- name: Setup snapshot
+  hosts: all
+  vars:
+    __snapshot_gather_vars: true
   tasks:
-    - block:
-        - name: Set platform/version specific variables
-          include_role:
-            name: linux-system-roles.logging
-            public: true
+    - name: Set platform/version specific variables
+      include_role:
+        name: linux-system-roles.logging
+        public: true
 
-        - name: Install test packages
-          package:
-            name: "{{ __base_packages + ['lsof', 'openssl'] }}"
-            state: present
-          vars:
-            __varnames: "{{ lookup('varnames', '^__rsyslog_.*packages$',
-                            wantlist=True) }}"
-            __base_packages: "{{ lookup('vars', *__varnames, wantlist=True) |
-              flatten | unique | sort }}"
+    - name: Install test packages
+      package:
+        name: "{{ __base_packages + ['lsof', 'openssl'] }}"
+        state: present
       vars:
-        __snapshot_gather_vars: true
+        __varnames: "{{ lookup('varnames', '^__rsyslog_.*packages$',
+                        wantlist=True) }}"
+        __base_packages: "{{ lookup('vars', *__varnames, wantlist=True) |
+          flatten | unique | sort }}"

--- a/tests/tests_basics_files.yml
+++ b/tests/tests_basics_files.yml
@@ -137,8 +137,8 @@
       include_tasks: tasks/test_logger.yml
 
     # yamllint disable rule:line-length
-    - name: "Check the files output config that the path is
-      {{ __logging_system_log_dir }}/messages"
+    - name: "Check the files output config that the messages path is
+      {{ __logging_system_log_dir }}"
       command: >-
         /bin/grep
         '\*.info;mail.none;authpriv.none;cron.none.*{{ __logging_system_log_dir }}/messages'
@@ -175,7 +175,13 @@
       meta: flush_handlers
 
     # TEST CASE 2
-    - block:
+    - name: Test case 2
+      vars:
+        __expected_error: >
+          Error: ['bogus_basic_input'] includes undefined logging_inputs item.
+        __expected_error2: >
+          Error: [u'bogus_basic_input'] includes undefined logging_inputs item.
+      block:
         - name: "TEST CASE 2; Test the configuration, which flow
           contains a undefined input bogus_basic_input"
           vars:
@@ -215,14 +221,9 @@
           include_role:
             name: linux-system-roles.logging
 
-        - name: unreachable task
+        - name: Unreachable task
           fail:
             msg: UNREACH
-      vars:
-        __expected_error: >
-          Error: ['bogus_basic_input'] includes undefined logging_inputs item.
-        __expected_error2: >
-          Error: [u'bogus_basic_input'] includes undefined logging_inputs item.
       rescue:
         - name: Expected error
           debug:

--- a/tests/tests_basics_forwards.yml
+++ b/tests/tests_basics_forwards.yml
@@ -30,8 +30,9 @@
     __test_template_sys: RSYSLOG_SyslogProtocol23Format
 
   tasks:
-    - block:
-        - name: create tempdir for test files
+    - name: Run test
+      block:
+        - name: Create tempdir for test files
           tempfile:
             state: directory
             prefix: logging_test_
@@ -134,6 +135,7 @@
             "{{ __test_template_trad }}"
           command: >-
             grep '{{ __test_template_trad }}' '{{ __test_forward_module_conf }}'
+          changed_when: false
 
         - name: Generate a file to check severity_and_facility
           copy:
@@ -419,8 +421,10 @@
           not waiting for normal sync points"
           meta: flush_handlers
 
-        - name: clean up fake pki files
-          file: path="{{ item }}" state=absent
+        - name: Clean up fake pki files
+          file:
+            path: "{{ item }}"
+            state: absent
           loop:
             - "/etc/pki/tls/certs/{{ __test_ca_cert_name }}"
 
@@ -436,6 +440,7 @@
             for conf in $( ls /etc/rsyslog.d ); do
               mv /etc/rsyslog.d/$conf /tmp/rsyslog.d-backup
             done
+          changed_when: false
 
         - name: "TEST CASE 2; Test the configuration, basics input
           and a forwards output with logging_pki_files"
@@ -539,14 +544,16 @@
           not waiting for normal sync points"
           meta: flush_handlers
 
-        - name: clean up fake pki files
-          file: path="{{ item }}" state=absent
+        - name: Clean up fake pki files
+          file:
+            path: "{{ item }}"
+            state: absent
           loop:
             - "/etc/pki/tls/certs/{{ __test_ca_cert_name }}"
             - "/etc/pki/tls/certs/{{ __test_cert_name }}"
             - "/etc/pki/tls/private/{{ __test_key_name }}"
 
-        - name: "Post - move back files to /etc/rsyslog.d"
+        - name: Post - move back files to /etc/rsyslog.d
           shell: |-
             set -euo pipefail
             mv /tmp/rsyslog.d-backup/* /etc/rsyslog.d
@@ -554,9 +561,11 @@
               mv /tmp/rsyslog.d-backup/$conf /tmp/rsyslog.d
             done
             rmdir /tmp/rsyslog.d-backup
+          changed_when: false
 
         # TEST CASE 3
-        - block:
+        - name: Test case 3
+          block:
             - name: "TEST CASE 3; Error case for setting logging_pki_files
               - missing cert_src"
               vars:
@@ -580,14 +589,15 @@
               include_role:
                 name: linux-system-roles.logging
 
-            - name: unreachable task
+            - name: Unreachable task
               fail:
                 msg: UNREACH
 
           rescue:
-            - debug:
+            - name: Report unexpected error
+              debug:
                 msg: "Caught an expected error - {{ ansible_failed_result }}"
-            - name: assert...
+            - name: Assert...
               assert:
                 that: ansible_failed_result.results.0.msg is
                       match(__expected_error)
@@ -607,19 +617,21 @@
           not waiting for normal sync points"
           meta: flush_handlers
 
-        - name: clean up fake pki files
-          file: path="{{ item }}" state=absent
+        - name: Clean up fake pki files
+          file:
+            path: "{{ item }}"
+            state: absent
           loop:
             - "/etc/pki/tls/private/{{ __test_key_name }}"
 
       always:
-        - name: remove tempdir
+        - name: Remove tempdir
           file:
             path: "{{ _tmpdir.path }}"
             state: absent
           delegate_to: localhost
 
-        - name: remove test file
+        - name: Remove test file
           file:
             path: /tmp/__testfile__
             state: absent

--- a/tests/tests_combination.yml
+++ b/tests/tests_combination.yml
@@ -168,9 +168,10 @@
     # yamllint enable rule:line-length
 
     # yamllint disable rule:line-length
-    - name: "Create a test log file with a log message in
-      {{ __test_inputfiles_dir }} which will not be logged
-      due to the regex condition"
+    - name: >-
+        Create a test log file with a log message in the input
+        which will not be logged due to the regex condition - input
+        {{ __test_inputfiles_dir }}
       shell: |-
         set -euo pipefail
         echo '<167>Jul 22 01:00:00 11.22.33.44 tag msgnum:00000000:24:test message 0123456789' > {{ __test_inputfiles_dir }}/test.log
@@ -472,7 +473,7 @@
     - name: Check ports managed by firewall and selinux
       include_tasks: tasks/check_firewall_selinux.yml
 
-    - name: deploy reduced config to output into local files
+    - name: Deploy reduced config to output into local files
       vars:
         logging_outputs:
           - name: files_test0
@@ -533,7 +534,7 @@
         __check_systemctl_status: true
       include_tasks: tasks/check_daemon_config_files.yml
 
-    - name: Check {{ __test_basics_conf }} was updated
+    - name: Check conf was updated {{ __test_basics_conf }}
       command: >-
         /bin/grep
         "# GENERATED BASICS CONFIG FILE"

--- a/tests/tests_default.yml
+++ b/tests/tests_default.yml
@@ -6,6 +6,6 @@
   gather_facts: false
 
   tasks:
-    - name: default run (NOOP)
+    - name: Default run (NOOP)
       include_role:
         name: linux-system-roles.logging

--- a/tests/tests_enabled.yml
+++ b/tests/tests_enabled.yml
@@ -24,8 +24,9 @@
   tasks:
     - name: Check /etc/rsyslog.d
       command: ls /etc/rsyslog.d
+      changed_when: false
 
-    - name: default run
+    - name: Default run
       vars:
         logging_purge_confs: true
       include_role:

--- a/tests/tests_files_elasticsearch.yml
+++ b/tests/tests_files_elasticsearch.yml
@@ -23,8 +23,9 @@
     __keydir: /etc/pki/tls/private/
 
   tasks:
-    - block:
-        - name: create tempdir for test files
+    - name: Run test
+      block:
+        - name: Create tempdir for test files
           tempfile:
             state: directory
             prefix: logging_test_
@@ -43,7 +44,7 @@
           set_fact:
             __test_key: "{{ _tmpdir.path }}/{{ __test_key_name }}"
 
-        - name: "local certs are copied to the target host with
+        - name: "Local certs are copied to the target host with
           the default configuration path."
           copy:
             dest: "{{ item }}"
@@ -156,8 +157,10 @@
           not waiting for normal sync points"
           meta: flush_handlers
 
-        - name: clean up fake pki files
-          file: path="{{ item }}" state=absent
+        - name: Clean up fake pki files
+          file:
+            path: "{{ item }}"
+            state: absent
           loop:
             - "{{ __keydir }}es-key.pem"
             - "{{ __certdir }}es-cert.pem"
@@ -245,8 +248,10 @@
           not waiting for normal sync points"
           meta: flush_handlers
 
-        - name: clean up fake pki files
-          file: path="{{ item }}" state=absent
+        - name: Clean up fake pki files
+          file:
+            path: "{{ item }}"
+            state: absent
           loop:
             - "{{ __test_ca_cert_target }}"
             - "{{ __test_cert_target }}"
@@ -337,7 +342,8 @@
           meta: flush_handlers
 
         # TEST CASE 3
-        - block:
+        - name: Test case 3
+          block:
             - name: "TEST CASE 3; Error case for Elasticsearch config -
               cert and ca_cert_src are missing"
               vars:
@@ -364,14 +370,15 @@
               include_role:
                 name: linux-system-roles.logging
 
-            - name: unreachable task
+            - name: Unreachable task
               fail:
                 msg: UNREACH
 
           rescue:
-            - debug:
+            - name: Report error
+              debug:
                 msg: "Caught an expected error - {{ ansible_failed_result }}"
-            - name: assert...
+            - name: Assert...
               assert:
                 that: ansible_failed_result.msg is match(__expected_err1)
 
@@ -390,14 +397,17 @@
           not waiting for normal sync points"
           meta: flush_handlers
 
-        - name: clean up fake pki files
-          file: path="{{ item }}" state=absent
+        - name: Clean up fake pki files
+          file:
+            path: "{{ item }}"
+            state: absent
           loop:
             - /etc/rsyslog.d/ca_cert.crt
             - /etc/rsyslog.d/key.pem
 
         # TEST CASE 4
-        - block:
+        - name: Test case 4
+          block:
             - name: "TEST CASE 4; Error case for Elasticsearch config -
               although tls is true, no cert data are given."
               vars:
@@ -421,14 +431,15 @@
               include_role:
                 name: linux-system-roles.logging
 
-            - name: unreachable task
+            - name: Unreachable task
               fail:
                 msg: UNREACH
 
           rescue:
-            - debug:
+            - name: Report error
+              debug:
                 msg: "Caught an expected error - {{ ansible_failed_result }}"
-            - name: assert...
+            - name: Assert...
               assert:
                 that: ansible_failed_result.msg is match(__expected_err1)
 
@@ -448,7 +459,7 @@
           meta: flush_handlers
 
       always:
-        - name: remove tempdir
+        - name: Remove tempdir
           file:
             path: "{{ _tmpdir.path }}"
             state: absent

--- a/tests/tests_files_files.yml
+++ b/tests/tests_files_files.yml
@@ -98,6 +98,7 @@
     - name: "Check the module param template is set to {{ __test_template }}"
       command: >-
         grep '{{ __test_template }}' '{{ __test_outputfiles_module_conf }}'
+      changed_when: false
 
     - name: Check if the input files config does not exist
       stat:

--- a/tests/tests_imuxsock_files.yml
+++ b/tests/tests_imuxsock_files.yml
@@ -36,7 +36,7 @@
     __default_system_log: /var/log/messages
 
   tasks:
-    - name: deploy config to output into local files
+    - name: Deploy config to output into local files
       vars:
         logging_inputs:
           - name: basic_input

--- a/tests/tests_include_vars_from_parent.yml
+++ b/tests/tests_include_vars_from_parent.yml
@@ -1,8 +1,9 @@
 ---
-- hosts: all
+- name: Test role variable override
+  hosts: all
   gather_facts: true
   tasks:
-    - name: create var file in caller that can override the one in called role
+    - name: Create var file in caller that can override the one in called role
       delegate_to: localhost
       copy:
         # usually the fake file will cause the called role to crash of
@@ -38,7 +39,8 @@
           map('join') | product(versions) | map('join') | list +
           [facts['distribution'], facts['os_family']] }}"
 
-    - import_role:
+    - name: Import role
+      import_role:
         name: caller
       vars:
         roletoinclude: linux-system-roles.logging

--- a/tests/tests_ovirt_elasticsearch.yml
+++ b/tests/tests_ovirt_elasticsearch.yml
@@ -96,8 +96,7 @@
         __check_systemctl_status: false
       include_tasks: tasks/check_daemon_config_files.yml
 
-    - name: "Check {{ __test_ovirt_collectd_conf }},
-      {{ __test_ovirt_engine_conf }}, {{ __test_ovirt_vdsm_conf }}"
+    - name: Check ovirt config files
       stat:
         path: "{{ item }}"
       register: __result
@@ -107,48 +106,43 @@
         - "{{ __test_ovirt_vdsm_conf }}"
       failed_when: not __result.stat.exists
 
-    - name: Check "{{ __test_ovirt_bogus_conf }} does not exist"
+    - name: Check bogus conf does not exist - {{ __test_ovirt_bogus_conf }}
       stat:
         path: "{{ __test_ovirt_bogus_conf }}"
       register: __result
       failed_when: __result.stat.exists
 
-    - name: Check ovirt_collectd_port is "{{ __test_collectd_port }}"
+    - name: Check ovirt_collectd_port is {{ __test_collectd_port }}
       command: >-
         /bin/grep 'input(name="{{ __test_collectd_name }}" type="imtcp"
         port="{{ __test_collectd_port }}"' {{ __test_ovirt_collectd_conf }}
       changed_when: false
 
-    - name: "Check index_prefix is {{ __test_metrics_index }} in
-      {{ __test_ovirt_collectd_conf }}"
+    - name: Check index_prefix is in {{ __test_ovirt_collectd_conf }}
       command: >-
         /bin/grep 'set $.index_prefix = "{{ __test_metrics_index }}"'
         {{ __test_ovirt_collectd_conf }}
       changed_when: false
 
-    - name: "Check input file is {{ __test_engine_input }} in
-      {{ __test_ovirt_engine_conf }}"
+    - name: Check input file is configured in {{ __test_ovirt_engine_conf }}
       command: >-
         /bin/grep 'input(type="imfile" file="{{ __test_engine_input }}"
         tag="{{ __test_engine_name }}"' {{ __test_ovirt_engine_conf }}
       changed_when: false
 
-    - name: "Check index_prefix is {{ __test_logs_index }} in
-      {{ __test_ovirt_engine_conf }}"
+    - name: Check index_prefix is configured in {{ __test_ovirt_engine_conf }}
       command: >-
         /bin/grep 'set $.index_prefix = "{{ __test_logs_index }}"'
         {{ __test_ovirt_engine_conf }}
       changed_when: false
 
-    - name: "Check input file is {{ __test_vdsm_input }} in
-      {{ __test_ovirt_vdsm_conf }}"
+    - name: Check input file is configured in {{ __test_ovirt_vdsm_conf }}
       command: >-
         /bin/grep 'input(type="imfile" file="{{ __test_vdsm_input }}"
         tag="{{ __test_vdsm_name }}"' {{ __test_ovirt_vdsm_conf }}
       changed_when: false
 
-    - name: "Check index_prefix is {{ __test_logs_index }} in
-      {{ __test_ovirt_vdsm_conf }}"
+    - name: Check index_prefix is configured in {{ __test_ovirt_vdsm_conf }}
       command: >-
         /bin/grep 'set $.index_prefix = "{{ __test_logs_index }}"'
         {{ __test_ovirt_vdsm_conf }}
@@ -280,8 +274,7 @@
         __check_systemctl_status: false
       include_tasks: tasks/check_daemon_config_files.yml
 
-    - name: "Check {{ __test_ovirt_collectd_conf }},
-      {{ __test_ovirt_engine_conf }}, {{ __test_ovirt_vdsm_conf }}"
+    - name: Check ovirt config files
       stat:
         path: "{{ item }}"
       register: __result
@@ -291,7 +284,7 @@
         - "{{ __test_ovirt_vdsm_conf }}"
       failed_when: not __result.stat.exists
 
-    - name: Check "{{ __test_ovirt_bogus_conf }} does not exist"
+    - name: Check bogus config does not exist -  {{ __test_ovirt_bogus_conf }}
       stat:
         path: "{{ __test_ovirt_bogus_conf }}"
       register: __result
@@ -303,36 +296,31 @@
         port="{{ __test_collectd_port }}"' {{ __test_ovirt_collectd_conf }}
       changed_when: false
 
-    - name: "Check index_prefix is {{ __test_metrics_index }} in
-      {{ __test_ovirt_collectd_conf }}"
+    - name: Check index_prefix is configured in {{ __test_ovirt_collectd_conf }}
       command: >-
         /bin/grep 'set $.index_prefix = "{{ __test_metrics_index }}"'
         {{ __test_ovirt_collectd_conf }}
       changed_when: false
 
-    - name: "Check input file is {{ __test_engine_input }} in
-      {{ __test_ovirt_engine_conf }}"
+    - name: Check input file is configured in {{ __test_ovirt_engine_conf }}
       command: >-
         /bin/grep 'input(type="imfile" file="{{ __test_engine_input }}"
         tag="{{ __test_engine_name }}"' {{ __test_ovirt_engine_conf }}
       changed_when: false
 
-    - name: "Check index_prefix is {{ __test_logs_index }} in
-      {{ __test_ovirt_engine_conf }}"
+    - name: Check index_prefix is configured in {{ __test_ovirt_engine_conf }}
       command: >-
         /bin/grep 'set $.index_prefix = "{{ __test_logs_index }}"'
         {{ __test_ovirt_engine_conf }}
       changed_when: false
 
-    - name: "Check input file is {{ __test_vdsm_input }} in
-      {{ __test_ovirt_vdsm_conf }}"
+    - name: Check input file is configured in {{ __test_ovirt_vdsm_conf }}
       command: >-
         /bin/grep 'input(type="imfile" file="{{ __test_vdsm_input }}"
         tag="{{ __test_vdsm_name }}"' {{ __test_ovirt_vdsm_conf }}
       changed_when: false
 
-    - name: "Check index_prefix is {{ __test_logs_index }} in
-      {{ __test_ovirt_vdsm_conf }}"
+    - name: Check index_prefix is configured in {{ __test_ovirt_vdsm_conf }}
       command: >-
         /bin/grep 'set $.index_prefix = "{{ __test_logs_index }}"'
         {{ __test_ovirt_vdsm_conf }}

--- a/tests/tests_purge_reset.yml
+++ b/tests/tests_purge_reset.yml
@@ -7,12 +7,12 @@
   vars:
     __test_default_files_conf: /etc/rsyslog.d/30-output-files-default_files.conf
   tasks:
-    - name: ensure rsyslog is installed
+    - name: Ensure rsyslog is installed
       package:
         name: rsyslog
         state: present
 
-    - name: create some unowned config files
+    - name: Create some unowned config files
       copy:
         dest: "{{ item }}"
         content: "# this is file {{ item }}"
@@ -21,14 +21,14 @@
         - "/etc/rsyslog.d/unowned1.conf"
         - "/etc/rsyslog.d/unowned2.conf"
 
-    - name: modify /etc/rsyslog.conf
+    - name: Modify /etc/rsyslog.conf
       lineinfile:
         path: /etc/rsyslog.conf
         insertafter: EOF
         state: present
         line: "# this is a modification"
 
-    - name: configure with basics + purge
+    - name: Configure with basics + purge
       vars:
         logging_purge_confs: true
         logging_inputs:
@@ -62,14 +62,14 @@
         - "/etc/rsyslog.d/unowned1.conf"
         - "/etc/rsyslog.d/unowned2.conf"
 
-    - name: check1 rsyslog config files
+    - name: Check1 rsyslog config files
       command: ls /etc/rsyslog.d
       changed_when: false
 
     - name: Check ports managed by firewall and selinux
       include_tasks: tasks/check_firewall_selinux.yml
 
-    - name: configure with basics + purge again - check for idempotency
+    - name: Configure with basics + purge again - check for idempotency
       vars:
         logging_purge_confs: true
         logging_inputs:
@@ -79,14 +79,14 @@
         name: linux-system-roles.logging
         public: true
 
-    - name: check11 rsyslog config files
+    - name: Check11 rsyslog config files
       command: ls /etc/rsyslog.d
       changed_when: false
 
     - name: Check ports managed by firewall and selinux
       include_tasks: tasks/check_firewall_selinux.yml
 
-    - name: run again with purge to erase all config
+    - name: Run again with purge to erase all config
       vars:
         logging_purge_confs: true
         logging_enabled: false
@@ -112,14 +112,14 @@
       loop:
         - "{{ __test_default_files_conf }}"
 
-    - name: check2 rsyslog config files
+    - name: Check2 rsyslog config files
       command: ls /etc/rsyslog.d
       changed_when: false
 
     - name: Check ports managed by firewall and selinux
       include_tasks: tasks/check_firewall_selinux.yml
 
-    - name: run again with purge and reset to test idempotency
+    - name: Run again with purge and reset to test idempotency
       vars:
         logging_purge_confs: true
         logging_enabled: false
@@ -130,7 +130,7 @@
         name: linux-system-roles.logging
         public: true
 
-    - name: check3 rsyslog config files
+    - name: Check3 rsyslog config files
       command: ls /etc/rsyslog.d
       changed_when: false
 

--- a/tests/tests_relp.yml
+++ b/tests/tests_relp.yml
@@ -82,14 +82,15 @@
         name: lsof
         state: present
 
-    - name: lsof outputs for rsyslogd
+    - name: Check lsof outputs for rsyslogd
       shell: |-
         set -euo pipefail
         lsof -i -nP | grep rsyslogd
       register: __result
       changed_when: false
 
-    - debug:
+    - name: Show lsof output
+      debug:
         msg: "lsof returned {{ __result.stdout }}"
 
     - name: Check port 6514, 20514 are open for TCP
@@ -339,12 +340,14 @@
       not waiting for normal sync points"
       meta: flush_handlers
 
-    - name: stop tracking certificate
+    - name: Stop tracking certificate
       command: getcert stop-tracking -f {{ __test_ca_cert }}
       changed_when: false
 
-    - name: clean up pki files
-      file: path="{{ item }}" state=absent
+    - name: Clean up pki files
+      file:
+        path: "{{ item }}"
+        state: absent
       loop:
         - "{{ __test_ca_cert }}"
         - "{{ __test_key }}"

--- a/tests/tests_remote.yml
+++ b/tests/tests_remote.yml
@@ -68,14 +68,15 @@
         name: lsof
         state: present
 
-    - name: lsof outputs for rsyslogd
+    - name: Check lsof outputs for rsyslogd
       shell: |-
         set -euo pipefail
         lsof -i -nP | grep rsyslogd
       register: __result
       changed_when: false
 
-    - debug:
+    - name: Show lsof output
+      debug:
         msg: "lsof returned {{ __result.stdout }}"
 
     - name: Check port 514 and 40001 are open for TCP
@@ -176,14 +177,15 @@
         name: lsof
         state: present
 
-    - name: lsof outputs for rsyslogd
+    - name: Check lsof outputs for rsyslogd
       shell: |-
         set -euo pipefail
         lsof -i -nP | grep rsyslogd
       register: __result
       changed_when: false
 
-    - debug:
+    - name: Show lsof output
+      debug:
         msg: "lsof returned {{ __result.stdout }}"
 
     - name: Check port 514 and 40001 is open for TCP

--- a/tests/tests_server.yml
+++ b/tests/tests_server.yml
@@ -86,14 +86,15 @@
         name: lsof
         state: present
 
-    - name: lsof outputs for rsyslogd
+    - name: Check lsof outputs for rsyslogd
       shell: |-
         set -o pipefail
         lsof -i -nP | grep rsyslogd
       register: __result
       changed_when: false
 
-    - debug:
+    - name: Show lsof output
+      debug:
         msg: "lsof returned {{ __result.stdout }}"
 
     - name: Check port 514, 6514, 40010 and 40011 is open for TCP
@@ -132,7 +133,8 @@
     - name: Check ports managed by firewall and selinux
       include_tasks: tasks/check_firewall_selinux.yml
 
-    - block:
+    - name: Test case 1
+      block:
         # TEST CASE 1
         # remote inputs - both remote_tcp_0 and remote_tcp_1 configure
         # the tls connection.
@@ -177,7 +179,7 @@
           include_role:
             name: linux-system-roles.logging
 
-        - name: unreachable task
+        - name: Unreachable task
           fail:
             msg: UNREACH
 
@@ -191,7 +193,8 @@
               item.msg == __expected_error
           loop: "{{ ansible_failed_result.results }}"
 
-    - block:
+    - name: End test case 1
+      block:
         - name: END TEST CASE 1; Clean up the deployed config
           vars:
             logging_purge_confs: true
@@ -202,15 +205,18 @@
             name: linux-system-roles.logging
 
       rescue:
-        - debug:
+        - name: Check error
+          debug:
             msg: Caught an expected error - {{ ansible_failed_result }}
 
-    - name: stop tracking certificate
+    - name: Stop tracking certificate
       command: getcert stop-tracking -f {{ __test_ca_cert }}
       changed_when: false
 
-    - name: clean up pki files
-      file: path="{{ item }}" state=absent
+    - name: Clean up pki files
+      file:
+        path: "{{ item }}"
+        state: absent
       loop:
         - "{{ __test_ca_cert }}"
         - "{{ __test_key }}"

--- a/tests/tests_version.yml
+++ b/tests/tests_version.yml
@@ -13,7 +13,7 @@
     __rsyslog_version: "0.0.0"
 
   tasks:
-    - name: default run
+    - name: Default run
       include_role:
         name: linux-system-roles.logging
 


### PR DESCRIPTION
All tasks must be named
Task names must begin with uppercase letter
vars and when should come before block/rescue/always
There must be only 1 template in a name, and it must come last
