### PR TITLE
deprecate set-output; update actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+---
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -6,6 +6,8 @@ on:  # yamllint disable-line rule:truthy
     branches:
       - main
   workflow_dispatch:
+permissions:
+  contents: read
 jobs:
   ansible_lint:
     runs-on: ubuntu-latest
@@ -13,10 +15,12 @@ jobs:
       - name: Update pip, git
         run: |
           set -euxo pipefail
-          sudo apt-get update
-          sudo apt-get install -y git
+          sudo apt update
+          sudo apt install -y git
+
       - name: Checkout repo
         uses: actions/checkout@v3
+
       - name: Fix up role meta/main.yml namespace and name
         run: |
           set -euxo pipefail
@@ -29,5 +33,6 @@ jobs:
               sed "/galaxy_info:/a\  role_name: logging" -i "$mm"
             fi
           fi
+
       - name: Run ansible-lint
         uses: ansible-community/ansible-lint-action@v6

--- a/.github/workflows/ansible-managed-var-comment.yml
+++ b/.github/workflows/ansible-managed-var-comment.yml
@@ -6,6 +6,8 @@ on:  # yamllint disable-line rule:truthy
     branches:
       - main
   workflow_dispatch:
+permissions:
+  contents: read
 jobs:
   ansible_managed_var_comment:
     runs-on: ubuntu-latest
@@ -14,14 +16,17 @@ jobs:
         run: |
           set -euxo pipefail
           python3 -m pip install --upgrade pip
-          sudo apt-get update
-          sudo apt-get install -y git
+          sudo apt update
+          sudo apt install -y git
+
       - name: Checkout repo
         uses: actions/checkout@v3
+
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
           pip3 install "git+https://github.com/linux-system-roles/tox-lsr@2.13.1"
+
       - name: Run ansible-plugin-scan
         run: |
           set -euxo pipefail

--- a/.github/workflows/ansible-plugin-scan.yml
+++ b/.github/workflows/ansible-plugin-scan.yml
@@ -6,6 +6,8 @@ on:  # yamllint disable-line rule:truthy
     branches:
       - main
   workflow_dispatch:
+permissions:
+  contents: read
 jobs:
   ansible_plugin_scan:
     runs-on: ubuntu-latest
@@ -14,14 +16,17 @@ jobs:
         run: |
           set -euxo pipefail
           python3 -m pip install --upgrade pip
-          sudo apt-get update
-          sudo apt-get install -y git
+          sudo apt update
+          sudo apt install -y git
+
       - name: Checkout repo
         uses: actions/checkout@v3
+
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
           pip3 install "git+https://github.com/linux-system-roles/tox-lsr@2.13.1"
+
       - name: Run ansible-plugin-scan
         run: |
           set -euxo pipefail

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -9,6 +9,8 @@ on:  # yamllint disable-line rule:truthy
 env:
   LSR_ROLE2COLL_NAMESPACE: fedora
   LSR_ROLE2COLL_NAME: linux_system_roles
+permissions:
+  contents: read
 jobs:
   ansible_test:
     runs-on: ubuntu-latest
@@ -17,14 +19,17 @@ jobs:
         run: |
           set -euxo pipefail
           python3 -m pip install --upgrade pip
-          sudo apt-get update
-          sudo apt-get install -y git
+          sudo apt update
+          sudo apt install -y git
+
       - name: Checkout repo
         uses: actions/checkout@v3
+
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
           pip3 install "git+https://github.com/linux-system-roles/tox-lsr@2.13.1"
+
       - name: Convert role to collection format
         run: |
           set -euxo pipefail
@@ -43,6 +48,7 @@ jobs:
               cp "$file" "$ignore_dir/${file//*.sanity-ansible-}"
             fi
           done
+
       - name: Run ansible-test
         uses: ansible-community/ansible-test-gh-action@release/v1
         with:

--- a/.github/workflows/changelog_to_tag.yml
+++ b/.github/workflows/changelog_to_tag.yml
@@ -7,19 +7,23 @@ on:  # yamllint disable-line rule:truthy
       - main
     paths:
       - CHANGELOG.md
-env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # This token is provided by Actions, you do not need to create your own token
+permissions:
+  contents: read
 jobs:
   tag_release_publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Update pip, git
         run: |
           set -euxo pipefail
-          sudo apt-get update
-          sudo apt-get install -y git
+          sudo apt update
+          sudo apt install -y git
+
       - name: checkout PR
         uses: actions/checkout@v3
+
       - name: Get tag and message from the latest CHANGELOG.md commit
         id: tag
         run: |
@@ -62,25 +66,26 @@ jobs:
               git branch -a
               exit 1
           fi
-          echo ::set-output name=tagname::"$_tagname"
-          echo ::set-output name=branch::"$_branch"
+          echo "tagname=$_tagname" >> "$GITHUB_OUTPUT"
+          echo "branch=$_branch" >> "$GITHUB_OUTPUT"
       - name: Create tag
-        uses: mathieudutour/github-tag-action@v6.0
+        uses: mathieudutour/github-tag-action@v6.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           custom_tag: ${{ steps.tag.outputs.tagname }}
           tag_prefix: ''
+
       - name: Create Release
         id: create_release
-        uses: actions/create-release@v1
+        uses: ncipollo/release-action@v1
         with:
-          tag_name: ${{ steps.tag.outputs.tagname }}
-          release_name: Version ${{ steps.tag.outputs.tagname }}
-          body_path: ./.tagmsg.txt
-          draft: false
-          prerelease: false
+          tag: ${{ steps.tag.outputs.tagname }}
+          name: Version ${{ steps.tag.outputs.tagname }}
+          bodyFile: ./.tagmsg.txt
+          makeLatest: true
+
       - name: Publish role to Galaxy
-        uses: robertdebock/galaxy-action@1.2.0
+        uses: robertdebock/galaxy-action@1.2.1
         with:
           galaxy_api_key: ${{ secrets.galaxy_api_key }}
           git_branch: ${{ steps.tag.outputs.branch }}

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -9,6 +9,8 @@ on:  # yamllint disable-line rule:truthy
 env:
   # some scripts source tox-lsr scripts - suppress that check
   SHELLCHECK_OPTS: -e SC1091
+permissions:
+  contents: read
 jobs:
   shellcheck:
     runs-on: ubuntu-latest
@@ -16,13 +18,16 @@ jobs:
       - name: Update git
         run: |
           set -euxo pipefail
-          sudo apt-get update
-          sudo apt-get install -y git
+          sudo apt update
+          sudo apt install -y git
+
       - name: Checkout repo
         uses: actions/checkout@v3
+
       - name: Run ShellCheck
         id: shellcheck_id
         uses: ludeeus/action-shellcheck@master
+
       - name: Show file paths scanned
         run: |
           echo Files scanned:

--- a/.github/workflows/weekly_ci.yml
+++ b/.github/workflows/weekly_ci.yml
@@ -1,3 +1,4 @@
+---
 # yamllint disable rule:line-length
 name: Weekly CI trigger
 on:  # yamllint disable-line rule:truthy
@@ -12,16 +13,23 @@ env:
     We don't currently have a way to trigger CI without a PR,
     so this PR serves that purpose.
   COMMENT: "[citest]"
+permissions:
+  contents: read
 jobs:
   weekly_ci:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - name: Update pip, git
         run: |
           set -euxo pipefail
-          sudo apt-get update
-          sudo apt-get install -y git
-      - uses: actions/checkout@v3
+          sudo apt update
+          sudo apt install -y git
+
+      - name: Checkout latest code
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Create and push empty commit
@@ -48,8 +56,9 @@ jobs:
               base: context.ref,
               state: "open"
             });
+            let pr_number = '';
             if (response.data.length === 0) {
-              const response = await github.rest.pulls.create({
+              pr_number = (await github.rest.pulls.create({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 title: "${{ env.COMMIT_MESSAGE }}",
@@ -57,10 +66,9 @@ jobs:
                 head: "${{ env.BRANCH_NAME }}",
                 base: context.ref,
                 draft: true
-              });
-              var pr_number = response.data.number;
+              })).data.number;
             } else {
-              var pr_number = response.data[0].number;
+              pr_number = response.data[0].number;
             }
             github.rest.issues.createComment({
               owner: context.repo.owner,


### PR DESCRIPTION
The `set-output` has been deprecated - see https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Some of the actions have been updated to fix this issue - update those actions

The `create-release` action has been deprecated
https://github.com/actions/create-release
the highest rated replacement is
https://github.com/marketplace/actions/create-release

reset existing commit after rebase to add without another commit

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
