### PR TITLE
ansible-lint - use changed_when even for tasks with conditionals

### DIFF
--- a/roles/rsyslog/tasks/inputs/ovirt/main.yml
+++ b/roles/rsyslog/tasks/inputs/ovirt/main.yml
@@ -51,4 +51,5 @@
   when:
     - __rsyslog_input.type | d() == 'ovirt'
     - ansible_selinux.mode in ["enforcing", "permissive"]
+  changed_when: true
   notify: Restart rsyslogd

--- a/tests/tasks/check_daemon_config_files.yml
+++ b/tests/tasks/check_daemon_config_files.yml
@@ -38,3 +38,4 @@
   when: __check_systemctl_status == "true"
   failed_when: "'error' in __result.stdout or 'a RainerScript command'
     in __result.stdout or __result is failed"
+  changed_when: false

--- a/tests/tests_basics_files.yml
+++ b/tests/tests_basics_files.yml
@@ -334,6 +334,7 @@
           #
           # Ansible managed
           #
+          # system_role:logging
           ruleset(name="forwards_severity_and_facility") {
               local1.info action(name="forwards_severity_and_facility"
                   type="omfwd"

--- a/tests/tests_basics_forwards.yml
+++ b/tests/tests_basics_forwards.yml
@@ -144,6 +144,7 @@
               #
               # Ansible managed
               #
+              # system_role:logging
               ruleset(name="forwards_severity_and_facility") {
                   local1.info action(name="forwards_severity_and_facility"
                       type="omfwd"
@@ -166,6 +167,7 @@
               #
               # Ansible managed
               #
+              # system_role:logging
               ruleset(name="forwards_facility_only") {
                   local2.* action(name="forwards_facility_only"
                       type="omfwd"
@@ -188,6 +190,7 @@
               #
               # Ansible managed
               #
+              # system_role:logging
               ruleset(name="forwards_severity_only") {
                   *.err action(name="forwards_severity_only"
                       type="omfwd"
@@ -210,6 +213,7 @@
               #
               # Ansible managed
               #
+              # system_role:logging
               ruleset(name="forwards_no_severity_and_facility") {
                   *.* action(name="forwards_no_severity_and_facility"
                       type="omfwd"
@@ -232,6 +236,7 @@
               #
               # Ansible managed
               #
+              # system_role:logging
               ruleset(name="forwards_no_severity_and_facility_udp") {
                   *.* action(name="forwards_no_severity_and_facility_udp"
                       type="omfwd"
@@ -255,6 +260,7 @@
               #
               # Ansible managed
               #
+              # system_role:logging
               ruleset(name="forwards_no_severity_and_facility_protocol_port") {
                   *.* action(name="forwards_no_severity_and_facility_protocol_port"
                       type="omfwd"
@@ -375,6 +381,7 @@
               #
               # Ansible managed
               #
+              # system_role:logging
               ruleset(name="forwards_severity_and_facility") {
                   local1.info action(name="forwards_severity_and_facility"
                       type="omfwd"
@@ -492,6 +499,7 @@
               #
               # Ansible managed
               #
+              # system_role:logging
               ruleset(name="forwards_severity_and_facility") {
                   local1.info action(name="forwards_severity_and_facility"
                       type="omfwd"

--- a/tests/tests_combination.yml
+++ b/tests/tests_combination.yml
@@ -119,6 +119,7 @@
           #
           # Ansible managed
           #
+          # system_role:logging
           ruleset(name="forwards_severity_and_facility") {
               local1.info action(name="forwards_severity_and_facility"
                   type="omfwd"
@@ -311,6 +312,7 @@
           #
           # Ansible managed
           #
+          # system_role:logging
           ruleset(name="forwards_severity_and_facility") {
               local1.info action(name="forwards_severity_and_facility"
                   type="omfwd"


### PR DESCRIPTION
ansible-lint now requires the use of changed_when even for tasks
that are conditional

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
