### PR TITLE
docs: add Collection requirements section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# linux-system-roles/logging
+# logging
+
 ![CI Testing](https://github.com/linux-system-roles/logging/workflows/tox/badge.svg)
 
 ## Table of Contents
@@ -38,6 +39,8 @@ To satisfy such requirements, logging role introduced 3 primary variables `loggi
 
 This role is supported on RHEL-7+, CentOS Stream-8+ and Fedora distributions.
 
+### Collection requirements
+
 The role requires the `firewall` role and the `selinux` role from the
 `fedora.linux_system_roles` collection, if `logging_manage_firewall`
 and `logging_manage_selinux` is set to true, respectively.
@@ -48,6 +51,7 @@ collection or from the Fedora RPM package, the requirement is already
 satisfied.
 
 Otherwise, please run the following command line to install the collection.
+
 ```
 ansible-galaxy collection install -r meta/collection-requirements.yml
 ```


### PR DESCRIPTION
For roles that use other system roles, they have a
`meta/collection-requirements.yml` file, and the README lists
these requirements and instructions.  However, these are only
required for github and Galaxy users, and not for users who
use the packaged roles, where it is confusing to see instructions
about installing requirements when none are needed.  We need to
make it easier to remove these sections when packaging.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
