### PR TITLE
fix: work with ansible-core 2.15

### DIFF
--- a/tests/tests_basics_files.yml
+++ b/tests/tests_basics_files.yml
@@ -19,11 +19,14 @@
 
   tasks:
     # TEST CASE 0
+    - name: Set firewall and selinux to true
+      set_fact:
+        logging_manage_firewall: true
+        logging_manage_selinux: true
+
     - name: "TEST CASE 0; Test the simplest configuration,
       basics input and implicit files output with logging_mark enabled"
       vars:
-        logging_manage_firewall: true
-        logging_manage_selinux: true
         logging_mark: true
         logging_mark_interval: "7200"
         logging_inputs:
@@ -73,11 +76,14 @@
       changed_when: false
       failed_when: __result.stdout != "\"7200\""
 
+    - name: Set firewall and selinux to false for cleanup
+      set_fact:
+        logging_manage_firewall: false
+        logging_manage_selinux: false
+
     - name: END TEST CASE 0; Clean up the deployed config
       vars:
         logging_purge_confs: true
-        logging_manage_firewall: false
-        logging_manage_selinux: false
         logging_inputs: []
         logging_outputs: []
         logging_flows: []
@@ -95,11 +101,14 @@
       meta: flush_handlers
 
     # TEST CASE 1
+    - name: Set firewall true and selinux false
+      set_fact:
+        logging_manage_firewall: true
+        logging_manage_selinux: false
+
     - name: "TEST CASE 1; logging_system_log_dir -
       test switching the local log output file location"
       vars:
-        logging_manage_firewall: true
-        logging_manage_selinux: false
         logging_system_log_dir: "{{ __logging_system_log_dir }}"
         logging_outputs:
           - name: files_output0
@@ -153,11 +162,14 @@
     - name: Check ports managed by firewall and selinux
       include_tasks: tasks/check_firewall_selinux.yml
 
+    - name: Set firewall and selinux to false for cleanup
+      set_fact:
+        logging_manage_firewall: false
+        logging_manage_selinux: false
+
     - name: END TEST CASE 1; Clean up the deployed config
       vars:
         logging_purge_confs: true
-        logging_manage_firewall: false
-        logging_manage_selinux: false
         logging_inputs: []
         logging_outputs: []
         logging_flows: []
@@ -249,11 +261,14 @@
       meta: flush_handlers
 
     # TEST CASE 3
+    - name: Set firewall false and selinux true
+      set_fact:
+        logging_manage_firewall: false
+        logging_manage_selinux: true
+
     - name: "TEST CASE 3; Ensure that the role runs with parameters
       from imjournal input to two omfile and two omfwd outputs"
       vars:
-        logging_manage_firewall: false
-        logging_manage_selinux: true
         logging_purge_confs: true
         logging_outputs:
           - name: files_output0
@@ -353,11 +368,14 @@
     - name: Check ports managed by firewall and selinux
       include_tasks: tasks/check_firewall_selinux.yml
 
+    - name: Set firewall and selinux to false for cleanup
+      set_fact:
+        logging_manage_firewall: false
+        logging_manage_selinux: false
+
     - name: END TEST CASE 3; Clean up the deployed config
       vars:
         logging_purge_confs: true
-        logging_manage_firewall: false
-        logging_manage_selinux: false
         logging_inputs: []
         logging_outputs: []
         logging_flows: []

--- a/tests/tests_relp.yml
+++ b/tests/tests_relp.yml
@@ -15,11 +15,14 @@
     # TEST CASE 0
     # Note: Create a self-signed cert just for the "unit" test.
     #       In the real configuration, CA cert managed by IPA is required.
+    - name: Set firewall and selinux to true
+      set_fact:
+        logging_manage_firewall: true
+        logging_manage_selinux: true
+
     - name: "TEST CASE 0; Test the server configuration containing tls tcp,
       plain tcp and udp connection"
       vars:
-        logging_manage_firewall: true
-        logging_manage_selinux: true
         logging_certificates:
           - name: logging_cert
             dns: ['localhost', 'www.example.com']
@@ -174,11 +177,14 @@
     - name: Check ports managed by firewall and selinux
       include_tasks: tasks/check_firewall_selinux.yml
 
+    - name: Set firewall and selinux to false for cleanup
+      set_fact:
+        logging_manage_firewall: false
+        logging_manage_selinux: false
+
     - name: END TEST CASE 0; Clean up the deployed config
       vars:
         logging_purge_confs: true
-        logging_manage_firewall: false
-        logging_manage_selinux: false
         logging_inputs: []
         logging_outputs: []
         logging_flows: []
@@ -198,11 +204,14 @@
     # TEST CASE 1
     # Note: Create a self-signed cert just for the "unit" test.
     #       In the real configuration, CA cert managed by IPA is required.
+    - name: Set firewall true and selinux false
+      set_fact:
+        logging_manage_firewall: true
+        logging_manage_selinux: false
+
     - name: TEST CASE 1; Test the client configuration using tls relp
       vars:
         logging_enabled: true
-        logging_manage_firewall: true
-        logging_manage_selinux: false
         logging_certificates:
           - name: logging_cert
             dns: ['localhost', 'www.example.com']
@@ -322,11 +331,14 @@
     - name: Check ports managed by firewall and selinux
       include_tasks: tasks/check_firewall_selinux.yml
 
+    - name: Set firewall and selinux to false for cleanup
+      set_fact:
+        logging_manage_firewall: false
+        logging_manage_selinux: false
+
     - name: END TEST CASE 1; Clean up the deployed config
       vars:
         logging_purge_confs: true
-        logging_manage_firewall: false
-        logging_manage_selinux: false
         logging_inputs: []
         logging_outputs: []
         logging_flows: []


### PR DESCRIPTION
Variables set by a task `vars` with an `include_role` task
are no longer exported to the play with a `public: true`.
Use `set_vars` to set the variables globally so they can
be used both by the role and the test.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
