### PR TITLE
ci: Add tests::uses_selinux tag

### DIFF
--- a/tests/tests_basics_files.yml
+++ b/tests/tests_basics_files.yml
@@ -2,6 +2,8 @@
 - name: "Ensure that the role runs with parameters for
   basics input and files output"
   hosts: all
+  tags:
+    - tests::uses_selinux
   vars:
     __test_default_files_conf: /etc/rsyslog.d/30-output-files-default_files.conf
     __test_files_conf0: /etc/rsyslog.d/30-output-files-files_output0.conf

--- a/tests/tests_ovirt_elasticsearch.yml
+++ b/tests/tests_ovirt_elasticsearch.yml
@@ -2,6 +2,8 @@
 - name: "Ensure that the role runs with parameters from ovirt to
   two elasticsearch outputs and local files output"
   hosts: all
+  tags:
+    - tests::uses_selinux
   vars:
     __test_ovirt_collectd_conf: >-
       /etc/rsyslog.d/90-input-ovirt-ovirt_collectd_input.conf

--- a/tests/tests_relp.yml
+++ b/tests/tests_relp.yml
@@ -1,6 +1,8 @@
 ---
 - name: Test the server/client configuration using tls relp
   hosts: all
+  tags:
+    - tests::uses_selinux
   vars:
     __test_cert_name: logging_cert
     __test_ca_cert: "/etc/pki/tls/certs/{{ __test_cert_name }}.crt"


### PR DESCRIPTION
Enhancement:
Set `tests::uses_selinux` tag to the test playbook that uses the
selinux role, one of the selinux modules or commands internally.

Reason:
We are improving tox-lsr runcontainer.sh that runs CI tests using a container. (See also https://github.com/richm/tox-lsr/tree/container-improvements.) In the effort, we need a mechanism to skip a test that depends on SELinux since SELinux is disabled in a container, by default. 

Result:
This is a sample command line to run all the runnable CI tests using `runcontainer.sh` in `tox-lsr`.
```
tox -e container-ansible-core-2.15 -- --erase-old-snapshot --extra-rpm diffutils \
--extra-skip-tag "tests::uses_selinux" --parallel 4 \
--image-name centos-9 tests/tests_*.yml
```
 As shown in the command line, by passing `--extra-skip-tag tests::uses_selinux`, the tests `tests_basics_files.yml`, `tests_ovirt_elasticsearch.yml`, and `tests_relp.yml` will be skipped and the series of the tests pass.