### PR TITLE
ci: update github action checkout to v4

### DIFF
--- a/.github/workflows/weekly_ci.yml
+++ b/.github/workflows/weekly_ci.yml
@@ -7,7 +7,7 @@ on:  # yamllint disable-line rule:truthy
     - cron: 0 8 * * 6
 env:
   BRANCH_NAME: weekly-ci
-  COMMIT_MESSAGE: "ci: This PR is to trigger periodic CI testing"
+  COMMIT_MESSAGE: This PR is to trigger periodic CI testing
   BODY_MESSAGE: >-
     This PR is for the purpose of triggering periodic CI testing.
     We don't currently have a way to trigger CI without a PR,
@@ -41,11 +41,6 @@ jobs:
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout ${{ env.BRANCH_NAME }} || git checkout -b ${{ env.BRANCH_NAME }}
           git rebase main
-          if [ ! -d tests/callback_plugins ]; then
-            mkdir -p tests/callback_plugins
-          fi
-          curl -L -s -o tests/callback_plugins/dump_packages.py https://raw.githubusercontent.com/linux-system-roles/auto-maintenance/main/callback_plugins/dump_packages.py
-          git add tests/callback_plugins
           git commit --allow-empty -m "${{ env.COMMIT_MESSAGE }}"
           git push -f --set-upstream origin ${{ env.BRANCH_NAME }}
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # logging
 
-[![ansible-lint.yml](https://github.com/linux-system-roles/logging/actions/workflows/ansible-lint.yml/badge.svg)](https://github.com/linux-system-roles/logging/actions/workflows/ansible-lint.yml) [![ansible-test.yml](https://github.com/linux-system-roles/logging/actions/workflows/ansible-test.yml/badge.svg)](https://github.com/linux-system-roles/logging/actions/workflows/ansible-test.yml) [![markdownlint.yml](https://github.com/linux-system-roles/logging/actions/workflows/markdownlint.yml/badge.svg)](https://github.com/linux-system-roles/logging/actions/workflows/markdownlint.yml) [![woke.yml](https://github.com/linux-system-roles/logging/actions/workflows/woke.yml/badge.svg)](https://github.com/linux-system-roles/logging/actions/workflows/woke.yml)
+[![woke.yml](https://github.com/linux-system-roles/logging/actions/workflows/woke.yml/badge.svg)](https://github.com/linux-system-roles/logging/actions/workflows/woke.yml) [![markdownlint.yml](https://github.com/linux-system-roles/logging/actions/workflows/markdownlint.yml/badge.svg)](https://github.com/linux-system-roles/logging/actions/workflows/markdownlint.yml) [![ansible-test.yml](https://github.com/linux-system-roles/logging/actions/workflows/ansible-test.yml/badge.svg)](https://github.com/linux-system-roles/logging/actions/workflows/ansible-test.yml) [![ansible-lint.yml](https://github.com/linux-system-roles/logging/actions/workflows/ansible-lint.yml/badge.svg)](https://github.com/linux-system-roles/logging/actions/workflows/ansible-lint.yml)
 
 ## Background
 


### PR DESCRIPTION
Use v4 github action checkout
Update dependabot to include the "ci: " prefix in commit/pr titles
for PR title checking.
Tell dependabot to check weekly instead of monthly

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
