### PR TITLE
ci: update github action checkout to v4; ensure order of badges

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,6 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly
     commit-message:
       prefix: ci

--- a/.github/workflows/weekly_ci.yml
+++ b/.github/workflows/weekly_ci.yml
@@ -7,7 +7,7 @@ on:  # yamllint disable-line rule:truthy
     - cron: 0 8 * * 6
 env:
   BRANCH_NAME: weekly-ci
-  COMMIT_MESSAGE: "ci: This PR is to trigger periodic CI testing"
+  COMMIT_MESSAGE: This PR is to trigger periodic CI testing
   BODY_MESSAGE: >-
     This PR is for the purpose of triggering periodic CI testing.
     We don't currently have a way to trigger CI without a PR,
@@ -41,11 +41,6 @@ jobs:
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout ${{ env.BRANCH_NAME }} || git checkout -b ${{ env.BRANCH_NAME }}
           git rebase main
-          if [ ! -d tests/callback_plugins ]; then
-            mkdir -p tests/callback_plugins
-          fi
-          curl -L -s -o tests/callback_plugins/dump_packages.py https://raw.githubusercontent.com/linux-system-roles/auto-maintenance/main/callback_plugins/dump_packages.py
-          git add tests/callback_plugins
           git commit --allow-empty -m "${{ env.COMMIT_MESSAGE }}"
           git push -f --set-upstream origin ${{ env.BRANCH_NAME }}
 


### PR DESCRIPTION
Use v4 github action checkout
Ensure dependabot git commit message conforms to our
project
Ensure order of common badges (badges common to all roles)
Role extra badges are appended to the end of the list of common
badges

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
