### PR TITLE
fix: check that logging_max_message_size is set, not rsyslog_max_message_size

### DIFF
--- a/roles/rsyslog/templates/global.j2
+++ b/roles/rsyslog/templates/global.j2
@@ -27,7 +27,7 @@ global(
   defaultNetstreamDriverKeyFile="{{ key_path }}"
 {%   endif %}
 {% endif %}
-{% if rsyslog_max_message_size is defined %}
+{% if logging_max_message_size is defined %}
   maxMessageSize="{{ logging_max_message_size }}"
 {% endif %}
 )


### PR DESCRIPTION
Enhancement: Check that `logging_max_message_size` is set, not `rsyslog_max_message_size`

Reason: The play does not check if the correct variable is defined

Result: Changed so that the test and action use the same variable name