### PR TITLE
refactor: improve support for ostree systems

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -22,5 +22,3 @@ exclude_paths:
   - examples/roles/
 mock_roles:
   - linux-system-roles.logging
-mock_modules:
-  - ansible.utils.update_fact

--- a/meta/collection-requirements.yml
+++ b/meta/collection-requirements.yml
@@ -2,5 +2,4 @@
 ---
 collections:
   - ansible.posix
-  - ansible.utils
   - fedora.linux_system_roles

--- a/roles/rsyslog/tasks/deploy.yml
+++ b/roles/rsyslog/tasks/deploy.yml
@@ -5,6 +5,8 @@
   package:
     name: "{{ __rsyslog_packages }}"
     state: present
+    use: "{{ (__logging_is_ostree | d(false)) |
+             ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
   when:
     - __rsyslog_packages | length > 0
     - not rsyslog_in_image | bool

--- a/roles/rsyslog/tasks/deploy_nolog.yml
+++ b/roles/rsyslog/tasks/deploy_nolog.yml
@@ -9,6 +9,8 @@
   package:
     name: "{{ __rsyslog_packages }}"
     state: present
+    use: "{{ (__logging_is_ostree | d(false)) |
+             ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
   when:
     - __rsyslog_packages | length > 0
     - not rsyslog_in_image | bool

--- a/roles/rsyslog/tasks/main_core.yml
+++ b/roles/rsyslog/tasks/main_core.yml
@@ -4,12 +4,10 @@
 # if inputs are given and rsyslog_enabled is true, rsyslog.conf will be
 # overwritten, so no need to reinstall package
 - name: Reinstall package to restore rsyslog config if purging
-  vars:
-    ostree_pkg_mgr: ansible.posix.rhel_rpm_ostree
   when:
     - logging_purge_confs | bool | d(false)
     - not (rsyslog_inputs and __rsyslog_enabled | bool)
-    - not ansible_facts.pkg_mgr | d() == ostree_pkg_mgr
+    - not __logging_is_ostree | d(false)
   block:
     # it is assumed that the only packages providing config files that might
     # be modified are the base packages - if this is not so, then additional
@@ -25,6 +23,8 @@
       package:
         name: "{{ __rsyslog_base_packages }}"
         state: absent
+        use: "{{ (__logging_is_ostree | d(false)) |
+                 ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
       register: __rsyslog_erased
       when: __rsyslog_package_status.results |
         rejectattr('stdout', 'match', '^package .* is not installed') |
@@ -37,6 +37,8 @@
       if (logging_pki_files | d([]) | length > 0) else []) +
       (rsyslog_extra_packages | flatten) }}"
     state: present
+    use: "{{ (__logging_is_ostree | d(false)) |
+             ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
   when:
     - __rsyslog_enabled | bool or
       (__rsyslog_erased is success and __rsyslog_erased is changed)
@@ -385,9 +387,7 @@
 
 - name: Create or recreate main config file
   vars:
-    ostree_pkg_mgr: ansible.posix.rhel_rpm_ostree
-    is_ostree: "{{ ansible_facts.pkg_mgr | d() == ostree_pkg_mgr }}"
-    __rsyslog_generate_conf: "{{ is_ostree |
+    __rsyslog_generate_conf: "{{ (__logging_is_ostree | d(false)) |
       ternary(true,
               __rsyslog_enabled and rsyslog_inputs | d([]) | length > 0) }}"
   when: __rsyslog_generate_conf | bool
@@ -397,7 +397,7 @@
         paths: "{{ __rsyslog_config_dir }}"
         patterns: "*.conf"
       register: __rsyslog_find_result
-      when: is_ostree | bool
+      when: __logging_is_ostree | d(false)
 
     - name: Get mode of rsyslog.conf if it exists
       stat:
@@ -414,4 +414,4 @@
       when: __rsyslog_generate_conf | bool
       vars:
         __rsyslog_has_config_files: "{{ __rsyslog_find_result.matched > 0
-          if is_ostree else true }}"
+          if __logging_is_ostree | d(false) else true }}"

--- a/roles/rsyslog/tasks/set_vars.yml
+++ b/roles/rsyslog/tasks/set_vars.yml
@@ -7,23 +7,17 @@
   when: __logging_required_facts |
     difference(ansible_facts.keys() | list) | length > 0
 
-- name: Ensure correct package manager for ostree systems
-  vars:
-    ostree_pkg_mgr: ansible.posix.rhel_rpm_ostree
-    ostree_booted_file: /run/ostree-booted
-  when: ansible_facts.pkg_mgr | d("") != ostree_pkg_mgr
+- name: Determine if system is ostree and set flag
+  when: not __logging_is_ostree is defined
   block:
     - name: Check if system is ostree
       stat:
-        path: "{{ ostree_booted_file }}"
+        path: /run/ostree-booted
       register: __ostree_booted_stat
 
-    - name: Set package manager to use for ostree
-      ansible.utils.update_fact:
-        updates:
-          - path: ansible_facts.pkg_mgr
-            value: "{{ ostree_pkg_mgr }}"
-      when: __ostree_booted_stat.stat.exists
+    - name: Set flag to indicate system is ostree
+      set_fact:
+        __logging_is_ostree: "{{ __ostree_booted_stat.stat.exists }}"
 
 - name: Set platform/version specific variables
   include_vars: "{{ item }}"

--- a/tests/tests_enabled.yml
+++ b/tests/tests_enabled.yml
@@ -40,9 +40,8 @@
 
     - name: Ensure config file size and counts
       vars:
-        ostree_pkg_mgr: ansible.posix.rhel_rpm_ostree
         __conf_count: 0
-        __conf_size: "{{ 'less' if ansible_facts.pkg_mgr | d() == ostree_pkg_mgr
+        __conf_size: "{{ 'less' if __logging_is_ostree | d(false)
           else 'more' }}"
         __conf_files: []
         __check_systemctl_status: true

--- a/tests/tests_purge_reset.yml
+++ b/tests/tests_purge_reset.yml
@@ -6,29 +6,25 @@
   hosts: all
   vars:
     __test_default_files_conf: /etc/rsyslog.d/30-output-files-default_files.conf
-    ostree_pkg_mgr: ansible.posix.rhel_rpm_ostree
   tasks:
-    - name: Ensure correct package manager for ostree systems
-      vars:
-        ostree_booted_file: /run/ostree-booted
-      when: ansible_facts.pkg_mgr | d("") != ostree_pkg_mgr
+    - name: Determine if system is ostree and set flag
+      when: not __logging_is_ostree is defined
       block:
         - name: Check if system is ostree
           stat:
-            path: "{{ ostree_booted_file }}"
+            path: /run/ostree-booted
           register: __ostree_booted_stat
 
-        - name: Set package manager to use for ostree
-          ansible.utils.update_fact:
-            updates:
-              - path: ansible_facts.pkg_mgr
-                value: "{{ ostree_pkg_mgr }}"
-          when: __ostree_booted_stat.stat.exists
+        - name: Set flag to indicate system is ostree
+          set_fact:
+            __logging_is_ostree: "{{ __ostree_booted_stat.stat.exists }}"
 
     - name: Ensure rsyslog is installed
       package:
         name: rsyslog
         state: present
+        use: "{{ (__logging_is_ostree | d(false)) |
+                 ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
 
     - name: Create some unowned config files
       copy:
@@ -118,7 +114,7 @@
     - name: Ensure config file size and counts
       vars:
         __conf_count: 0
-        __conf_size: "{{ 'less' if ansible_facts.pkg_mgr | d() == ostree_pkg_mgr
+        __conf_size: "{{ 'less' if __logging_is_ostree | d(false)
           else 'more' }}"
         __check_systemctl_status: true
       include_tasks: tasks/check_daemon_config_files.yml

--- a/tests/tests_relp.yml
+++ b/tests/tests_relp.yml
@@ -89,6 +89,8 @@
       package:
         name: lsof
         state: present
+        use: "{{ (__logging_is_ostree | d(false)) |
+                 ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
 
     - name: Check lsof outputs for rsyslogd
       shell: |-

--- a/tests/tests_remote.yml
+++ b/tests/tests_remote.yml
@@ -67,6 +67,8 @@
       package:
         name: lsof
         state: present
+        use: "{{ (__logging_is_ostree | d(false)) |
+                 ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
 
     - name: Check lsof outputs for rsyslogd
       shell: |-
@@ -191,6 +193,8 @@
       package:
         name: lsof
         state: present
+        use: "{{ (__logging_is_ostree | d(false)) |
+                 ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
 
     - name: Check lsof outputs for rsyslogd
       shell: |-

--- a/tests/tests_server.yml
+++ b/tests/tests_server.yml
@@ -85,6 +85,8 @@
       package:
         name: lsof
         state: present
+        use: "{{ (__logging_is_ostree | d(false)) |
+                 ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
 
     - name: Check lsof outputs for rsyslogd
       shell: |-


### PR DESCRIPTION
The dependency on `ansible.utils.update_fact` is causing issue with
some users who now must install that collection in order to run
the role, even if they do not care about ostree.

The fix is to stop trying to set `ansible_facts.pkg_mgr`, and instead
force the use of the ostree package manager with the `package:` module
`use:` option.  The strategy is - on ostree systems, set the flag
`__$ROLENAME_is_ostree` if the system is an ostree system.  The flag
will either be undefined or `false` on non-ostree systems.
Then, change every invocation of the `package:` module like this:

```yaml
- name: Ensure required packages are present
  package:
    name: "{{ __$ROLENAME_packages }}"
    state: present
    use: "{{ (__$ROLENAME_is_ostree | d(false)) |
      ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
```

This should ensure that the `use:` parameter is not used if the system
is non-ostree.  The goal is to make the ostree support as unobtrusive
as possible for non-ostree systems.
The user can also set `__$ROLENAME_is_ostree: true` in the inventory or play
if the user knows that ostree is being used and wants to skip the check.
Or, the user is concerned about the performance hit for ostree detection
on non-ostree systems, and sets `__$ROLENAME_is_ostree: false` to skip
the check.
The flag `__$ROLENAME_is_ostree` can also be used in the role or tests to
include or exclude tasks from being run on ostree systems.

This fix also improves error reporting in the `get_ostree_data.sh` script
when included roles cannot be found.
