### PR TITLE
fix: avoid conf of RatelimitBurst when RatelimitInterval is zero

### DIFF
--- a/roles/rsyslog/templates/input_basics.j2
+++ b/roles/rsyslog/templates/input_basics.j2
@@ -15,7 +15,7 @@ module(load="imuxsock"    # provides support for local system logging (e.g. via 
 module(load="imjournal"
        StateFile="{{ __rsyslog_work_dir }}/imjournal.state"
        RateLimit.Interval="{{ __rsyslog_input.ratelimit_interval | d(600) }}"
-{% if __rsyslog_input.ratelimit_interval is defined and __rsyslog_input.ratelimit_interval > 0 %}
+{% if __rsyslog_input.ratelimit_interval | d(0) > 0 %}
        RateLimit.Burst="{{ __rsyslog_input.ratelimit_burst | d(20000) }}"
 {% endif %}
        PersistStateInterval="{{ __rsyslog_input.journal_persist_state_interval | d(10) }}")

--- a/roles/rsyslog/templates/input_basics.j2
+++ b/roles/rsyslog/templates/input_basics.j2
@@ -4,7 +4,7 @@ module(load="imklog" permitnonkernelfacility="on")
 {% if __rsyslog_input.use_imuxsock | d(false) | bool %}
 module(load="imuxsock"    # provides support for local system logging (e.g. via logger command)
        SysSock.RateLimit.Interval="{{ __rsyslog_input.ratelimit_interval | d(0) }}"
-{% if __rsyslog_input.ratelimit_interval is defined and __rsyslog_input.ratelimit_interval > 0 %}
+{% if __rsyslog_input.ratelimit_interval | d(0) > 0 %}
        SysSock.RateLimit.Burst="{{ __rsyslog_input.ratelimit_burst | d(200) }}"
 {% endif %}
        SysSock.Use="on")  # Turn on message reception via local log socket.

--- a/roles/rsyslog/templates/input_basics.j2
+++ b/roles/rsyslog/templates/input_basics.j2
@@ -3,8 +3,10 @@ module(load="imklog" permitnonkernelfacility="on")
 {% endif %}
 {% if __rsyslog_input.use_imuxsock | d(false) | bool %}
 module(load="imuxsock"    # provides support for local system logging (e.g. via logger command)
+       SysSock.RateLimit.Interval="{{ __rsyslog_input.ratelimit_interval | d(0) }}"
+{% if __rsyslog_input.ratelimit_interval is defined and __rsyslog_input.ratelimit_interval > 0 %}
        SysSock.RateLimit.Burst="{{ __rsyslog_input.ratelimit_burst | d(200) }}"
-       SysSock.RateLimit.Interval="{{ __rsyslog_input.ratelimit_burst | d(0) }}"
+{% endif %}
        SysSock.Use="on")  # Turn on message reception via local log socket.
 input(name="basics_imuxsock" type="imuxsock" socket="/dev/log")
 {% else %}
@@ -12,8 +14,10 @@ module(load="imuxsock"    # provides support for local system logging (e.g. via 
        SysSock.Use="off") # Turn off message reception via local log socket.
 module(load="imjournal"
        StateFile="{{ __rsyslog_work_dir }}/imjournal.state"
-       RateLimit.Burst="{{ __rsyslog_input.ratelimit_burst | d(20000) }}"
        RateLimit.Interval="{{ __rsyslog_input.ratelimit_interval | d(600) }}"
+{% if __rsyslog_input.ratelimit_interval is defined and __rsyslog_input.ratelimit_interval > 0 %}
+       RateLimit.Burst="{{ __rsyslog_input.ratelimit_burst | d(20000) }}"
+{% endif %}
        PersistStateInterval="{{ __rsyslog_input.journal_persist_state_interval | d(10) }}")
 {% endif %}
 {{ lookup('template', 'input_template.j2') }}

--- a/roles/rsyslog/templates/input_basics_rhel7.j2
+++ b/roles/rsyslog/templates/input_basics_rhel7.j2
@@ -9,8 +9,10 @@ $OmitLocalLogging off
 $ModLoad imjournal # provides access to the systemd journal
 # File to store the position in the journal
 $IMJournalStateFile imjournal.state
-$imjournalRatelimitBurst {{ __rsyslog_input.ratelimit_burst | d(20000) }}
 $imjournalRatelimitInterval {{ __rsyslog_input.ratelimit_interval | d(600) }}
+{% if __rsyslog_input.ratelimit_interval is defined and __rsyslog_input.ratelimit_interval > 0 %}
+$imjournalRatelimitBurst {{ __rsyslog_input.ratelimit_burst | d(20000) }}
+{% endif %}
 $imjournalPersistStateInterval {{ __rsyslog_input.journal_persist_state_interval | d(10) }}
 
 # Turn off message reception via local log socket;

--- a/roles/rsyslog/templates/input_basics_rhel7.j2
+++ b/roles/rsyslog/templates/input_basics_rhel7.j2
@@ -10,7 +10,7 @@ $ModLoad imjournal # provides access to the systemd journal
 # File to store the position in the journal
 $IMJournalStateFile imjournal.state
 $imjournalRatelimitInterval {{ __rsyslog_input.ratelimit_interval | d(600) }}
-{% if __rsyslog_input.ratelimit_interval is defined and __rsyslog_input.ratelimit_interval > 0 %}
+{% if __rsyslog_input.ratelimit_interval | d(0) > 0 %}
 $imjournalRatelimitBurst {{ __rsyslog_input.ratelimit_burst | d(20000) }}
 {% endif %}
 $imjournalPersistStateInterval {{ __rsyslog_input.journal_persist_state_interval | d(10) }}


### PR DESCRIPTION
Enhancement: As documented in main [rsyslog documentation](https://rsyslog.readthedocs.io/en/latest/configuration/modules/imjournal.html), `ratelimit.burst` have some sense only when `ratelimit.interval` is configured and different from zero.

Reason: Improve `ratelimit.burst`  configuration when `ratelimit.interval` is disable (equal to zero)

Result: `ratelimit.burst` is not present when `ratelimit.interval` is disable (equal to zero)

Issue Tracker Tickets (Jira or BZ if any):
