### PR TITLE
fix: ansible-core-2.16 - only use to_nice_json for output formatting

### DIFF
--- a/roles/rsyslog/tasks/main_core.yml
+++ b/roles/rsyslog/tasks/main_core.yml
@@ -259,7 +259,7 @@
         __rsyslog_current_files: "{{ __rsyslog_template_results |
           selectattr('results', 'defined') | map(attribute='results') |
           flatten | selectattr('dest', 'defined') | map(attribute='dest') |
-          list | to_nice_json }}"
+          list }}"
         __rsyslog_files_to_remove: "{{
           __rsyslog_confs.stdout_lines | difference(__rsyslog_current_files) }}"
 


### PR DESCRIPTION
Cause: The code was using `to_nice_json` to construct a list used for
further processing.

Consequence: The variable was evaluated as a `string`, not a `list`
and was causing no files to match.

Fix: Remove the `to_nice_json` so the variable is evaluated as
a `list`.

Result: The code works as expected.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
