### PR TITLE
feat: add support for reopen_on_truncate for files input

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,11 +115,16 @@ Available options:
 
 Available options:
 
-* `input_log_path`: File name to be read by the imfile plugin. The value should be full path. Wildcard '\*' is allowed in the path.  Default to `/var/log/containers/*.log`.
-`facility`: Facility to filter the inputs from the files.
-`severity`: Severity to filter the inputs from the files.
-`startmsg_regex`: The regular expression that matches the start part of a message.
-`endmsg_regex`: The regular expression that matches the last part of a message.
+* `input_log_path`: File name to be read by the imfile plugin. The value should
+  be full path. Wildcard '\*' is allowed in the path.  No default - this parameter
+  is mandatory.
+* `facility`: Facility to filter the inputs from the files.
+* `severity`: Severity to filter the inputs from the files.
+* `startmsg_regex`: The regular expression that matches the start part of a message.
+* `endmsg_regex`: The regular expression that matches the last part of a message.
+* `reopen_on_truncate`: Tells rsyslog to reopen input file when it was truncated
+  (inode unchanged but file size on disk is less than current offset in memory).
+  Default is `false`
 
 #### logging_inputs ovirt type
 

--- a/roles/rsyslog/templates/input_files.j2
+++ b/roles/rsyslog/templates/input_files.j2
@@ -14,5 +14,8 @@ input(
 {% if __rsyslog_input.endmsg_regex is defined %}
   endmsg.regex="{{ __rsyslog_input.endmsg_regex }}"
 {% endif %}
+{% if __rsyslog_input.reopen_on_truncate is defined %}
+  reopenOnTruncate="{{ __rsyslog_input.reopen_on_truncate | ternary('on', 'off') }}"
+{% endif %}
 )
 {{ lookup('template', 'input_template.j2') }}

--- a/tests/tests_files_files.yml
+++ b/tests/tests_files_files.yml
@@ -65,9 +65,11 @@
             input_log_path: "{{ __test_inputfiles_dir0 }}/*.log"
             severity: err
             facility: local6
+            reopen_on_truncate: true
           - name: "php:"
             type: files
             input_log_path: "{{ __test_inputfiles_dir1 }}/*.log"
+            reopen_on_truncate: false
           - name: files_input2
             type: files
         logging_flows:
@@ -137,6 +139,7 @@
         - tag="files_input0"
         - severity="err"
         - facility="local6"
+        - reopenOnTruncate="on"
 
     - name: Check the filter 1
       lineinfile:
@@ -150,6 +153,7 @@
         - type="imfile"
         - file="/var/log/inputdirectory1/*.log"
         - tag="php:"
+        - reopenOnTruncate="off"
 
     - name: Check ports managed by firewall and selinux
       include_tasks: tasks/check_firewall_selinux.yml


### PR DESCRIPTION
Feature: Add support for reopen_on_truncate for files input.  This is
a boolean value which sets the rsyslog reopenOnTruncate option for
the imfile module.

Reason: Users need to be able to configure rsyslog to reopen
input file when it was truncated.

Result: Users can configure rsyslog reopenOnTruncate.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
