### PR TITLE
feat: support custom config files with logging_custom_config_files

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,6 +475,12 @@ These variables are set in the same level of the `logging_inputs`, `logging_outp
   NOTE: `logging_manage_selinux` is limited to _adding_ policy.
   It cannot be used for _removing_ policy.
   If you want to remove policy, you will need to use the `selinux` role directly.
+* `logging_custom_config_files`: A list of files to copy to the remote logging configuration
+  directory.  For `rsyslog`, this will be `/etc/rsyslog.d/`.  This assumes the
+  default logging configuration will load and process the configuration files in
+  that directory.  For example, the default `rsyslog` configuration has a directive
+  like `$IncludeConfig /etc/rsyslog.d/*.conf`.  WARNING: The use of
+  `rsyslog_custom_config_files` or using `type: custom` is deprecated.
 * `logging_certificates`: Information used to generate a private key and certificate.
   Default to `[]`.
   The value of `logging_certificates` is passed on to the `certificate_requests`
@@ -573,7 +579,9 @@ logging_flows:
 
 ### Standalone configuration
 
-Deploying `basics input` reading logs from systemd journal and implicit `files output` to write to the local files.
+Deploying `basics input` reading logs from systemd journal and implicit `files output`
+to write to the local files. This also deploys two custom files to the
+`/etc/rsyslog.d/` directory.
 
 ```yaml
 ---
@@ -582,6 +590,9 @@ Deploying `basics input` reading logs from systemd journal and implicit `files o
   roles:
     - linux-system-roles.logging
   vars:
+    logging_custom_config_files:
+      - files/90-my-custom-file.conf
+      - files/my-custom-file.rulebase
     logging_inputs:
       - name: system_input
         type: basics
@@ -596,6 +607,9 @@ The following playbook generates the same logging configuration files.
   roles:
     - linux-system-roles.logging
   vars:
+    logging_custom_config_files:
+      - files/90-my-custom-file.conf
+      - files/my-custom-file.rulebase
     logging_inputs:
       - name: system_input
         type: basics

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -102,6 +102,10 @@ logging_manage_firewall: false
 # configure the selinux for the ports using the selinux role.
 logging_manage_selinux: false
 
+# A list of custom config files to copy to the default logging
+# configuration directory
+logging_custom_config_files: []
+
 # If you want the role to generate the certificates in the logging
 # configuration, specify the arguments to pass to the certificate
 # system role. Here's an example.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,13 +30,25 @@
           selectattr('name', 'defined') |
           selectattr('type', 'defined') | list }}"
 
-    - name: Set custom_config_files fact
-      set_fact:
-        rsyslog_custom_config_files: "{{ item.custom_config_files }}"
-      with_items: "{{ logging_outputs }}"
-      when:
-        - item.type | d('') == 'custom'
-        - logging_enabled | d(true)
+    - name: Use of rsyslog_custom_config_files is deprecated
+      debug:
+        msg: >-
+          WARNING: The use of rsyslog_custom_config_files is deprecated -
+          use logging_custom_config_files instead
+      when: rsyslog_custom_config_files is defined
+
+    - name: Use of type custom is deprecated
+      debug:
+        msg: >-
+          WARNING: The use of type custom is deprecated -
+          use logging_custom_config_files instead
+      when: __custom_output_files | length > 0
+      vars:
+        __custom_output_files: "{{ logging_outputs | d([]) |
+          selectattr('type', 'defined') |
+          selectattr('type', 'match', 'custom$') |
+          selectattr('custom_config_files', 'defined') |
+          map(attribute='custom_config_files') | flatten | list }}"
 
     - name: Check logging inputs
       vars:
@@ -112,6 +124,12 @@
   vars:
     __rsyslog_enabled: "{{ logging_enabled }}"
     __rsyslog_system_log_dir: "{{ logging_system_log_dir }}"
+    rsyslog_custom_config_files: "{{ __custom_config_files +
+      logging_custom_config_files }}"
+    __custom_config_files: "{{ logging_outputs | d([]) |
+      selectattr('type', 'defined') | selectattr('type', 'match', 'custom$') |
+      selectattr('custom_config_files', 'defined') |
+      map(attribute='custom_config_files') | flatten | list }}"
   include_role:
     name: "{{ role_path }}/roles/rsyslog"  # noqa role-name[path]
   when: logging_provider == 'rsyslog'

--- a/tests/files/90-custom-output.conf
+++ b/tests/files/90-custom-output.conf
@@ -1,0 +1,2 @@
+# need some sort of valid rsyslog here - what it does isn't important
+*.=crit;kern.none /var/adm/critical

--- a/tests/tests_basics_files.yml
+++ b/tests/tests_basics_files.yml
@@ -31,6 +31,8 @@
       vars:
         logging_mark: true
         logging_mark_interval: "7200"
+        logging_custom_config_files:
+          - files/90-custom-output.conf
         logging_inputs:
           - name: basic_input
             type: basics
@@ -46,10 +48,11 @@
 
     - name: Ensure config file size and counts
       vars:
-        __conf_count: 5
+        __conf_count: 6
         __conf_size: less
         __conf_files:
           - "{{ __test_default_files_conf }}"
+          - /etc/rsyslog.d/90-custom-output.conf
         __check_systemctl_status: true
       include_tasks: tasks/check_daemon_config_files.yml
 


### PR DESCRIPTION
Feature: Allow users to provide custom logging configuration files
using the new variable `logging_custom_config_files` which is a list
of config files to copy to the default logging configuration directory.
For example, this directory for rsyslog is `/etc/rsyslog.d/`.  This
assumes the logging configuration will load all files matching `*.conf`
in this directory as in the default rsyslog directive
`$IncludeConfig /etc/rsyslog.d/*.conf`.

Reason: Users need customized configuration not provided by the role.
The role allowed this previously by the use of the variable
`rsyslog_custom_config_files`, but that variable was intended to be used
privately and is now marked DEPRECATED.

Result: Users can provide custom configuration in a supported manner.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
