### PR TITLE
test: use selinux for relp to fix test AVC

### DIFF
--- a/tests/tests_relp.yml
+++ b/tests/tests_relp.yml
@@ -232,7 +232,7 @@
     - name: Set firewall true and selinux false
       set_fact:
         logging_manage_firewall: true
-        logging_manage_selinux: false
+        logging_manage_selinux: true
 
     - name: TEST CASE 1; Test the client configuration using tls relp
       vars:


### PR DESCRIPTION
The tests_relp is causing AVCs.  Use selinux in the test to
avoid the AVCs.