### PR TITLE
test: workaround a systemd issue in el10 restarting journald

### DIFF
--- a/tests/tests_imuxsock_files.yml
+++ b/tests/tests_imuxsock_files.yml
@@ -112,12 +112,17 @@
         # odd idiosyncrasies
         - name: Restart journald units
           shell: |
+            set -euxo pipefail
+            exec 1>&2
             for service in {{ __journald_units | join(" ") }}; do
               if systemctl is-active "$service"; then
                 systemctl stop "$service" || :
                 sleep 1
               fi
             done
+            if [ "$(systemctl show -p SubState systemd-journald.service)" = SubState=dead-resources-pinned ]; then
+              systemctl clean --what fdstore systemd-journald.service
+            fi
             for service in {{ __journald_units | join(" ") }}; do
               if ! systemctl is-active "$service"; then
                 systemctl start "$service"


### PR DESCRIPTION
Due to https://github.com/systemd/systemd/pull/33874
we need to clear the SubState=dead-resources-pinned of journald
when restarting it after the test.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
