### PR TITLE
test: sort files to compare

### DIFF
--- a/tests/tasks/compare_file_to_content.yml
+++ b/tests/tasks/compare_file_to_content.yml
@@ -1,0 +1,17 @@
+---
+# input
+# * expected_content - the expected contents
+# * compare_file - the actual contents
+# NOTE: Have to sort because order of dict is not guaranteed to
+# be stable on all supported platforms
+- name: Get file to compare
+  slurp:
+    path: "{{ compare_file }}"
+  register: __actual_content
+
+- name: Compare expected to actual
+  assert:
+    that: __expected == __actual
+  vars:
+    __expected: "{{ expected_content.split('\n') | sort | select | list }}"
+    __actual: "{{ (__actual_content.content | b64decode).split('\n') | sort | select | list }}"

--- a/tests/tests_basics_forwards.yml
+++ b/tests/tests_basics_forwards.yml
@@ -145,10 +145,11 @@
             grep '{{ __test_template_trad }}' '{{ __test_forward_module_conf }}'
           changed_when: false
 
-        - name: Generate a file to check severity_and_facility
-          copy:
-            dest: /tmp/__testfile__
-            content: |
+        - name: Check severity_and_facility
+          include_tasks: tasks/compare_file_to_content.yml
+          vars:
+            compare_file: "{{ __test_forward_conf_s_f }}"
+            expected_content: |
               #
               # Ansible managed
               #
@@ -166,16 +167,12 @@
                       queue.saveonshutdown="on"
                   )
               }
-            mode: '0600'
 
-        - name: Check severity_and_facility
-          command: diff -B /tmp/__testfile__ '{{ __test_forward_conf_s_f }}'
-          changed_when: false
-
-        - name: Generate a file to check facility_only
-          copy:
-            dest: /tmp/__testfile__
-            content: |
+        - name: Check facility_only
+          include_tasks: tasks/compare_file_to_content.yml
+          vars:
+            compare_file: "{{ __test_forward_conf_f }}"
+            expected_content: |
               #
               # Ansible managed
               #
@@ -189,16 +186,12 @@
                       Template="{{ __test_template }}"
                   )
               }
-            mode: '0600'
 
-        - name: Check facility_only
-          command: diff -B /tmp/__testfile__ '{{ __test_forward_conf_f }}'
-          changed_when: false
-
-        - name: Generate a file to check severity_only
-          copy:
-            dest: /tmp/__testfile__
-            content: |
+        - name: Check severity_only
+          include_tasks: tasks/compare_file_to_content.yml
+          vars:
+            compare_file: "{{ __test_forward_conf_s }}"
+            expected_content: |
               #
               # Ansible managed
               #
@@ -212,16 +205,12 @@
                       Template="{{ __test_template }}"
                   )
               }
-            mode: '0600'
 
-        - name: Check severity_only
-          command: diff -B /tmp/__testfile__ '{{ __test_forward_conf_s }}'
-          changed_when: false
-
-        - name: Generate a file to check no_severity_and_facility
-          copy:
-            dest: /tmp/__testfile__
-            content: |
+        - name: Check no_severity_and_facility
+          include_tasks: tasks/compare_file_to_content.yml
+          vars:
+            compare_file: "{{ __test_forward_conf_no }}"
+            expected_content: |
               #
               # Ansible managed
               #
@@ -235,16 +224,12 @@
                       Template="{{ __test_template }}"
                   )
               }
-            mode: '0600'
 
-        - name: Check no_severity_and_facility
-          command: diff -B /tmp/__testfile__ '{{ __test_forward_conf_no }}'
-          changed_when: false
-
-        - name: Generate a file to check no_severity_and_facility_udp
-          copy:
-            dest: /tmp/__testfile__
-            content: |
+        - name: Check no_severity_and_facility_udp
+          include_tasks: tasks/compare_file_to_content.yml
+          vars:
+            compare_file: "{{ __test_forward_conf_no_udp }}"
+            expected_content: |
               #
               # Ansible managed
               #
@@ -258,17 +243,13 @@
                       Template="{{ __test_template }}"
                   )
               }
-            mode: '0600'
-
-        - name: Check no_severity_and_facility_udp
-          command: diff -B /tmp/__testfile__ '{{ __test_forward_conf_no_udp }}'
-          changed_when: false
 
         # yamllint disable rule:line-length
-        - name: Generate a file to check no_severity_and_facility_protocol_port
-          copy:
-            dest: /tmp/__testfile__
-            content: |
+        - name: Check no_severity_and_facility_protocol_port
+          include_tasks: tasks/compare_file_to_content.yml
+          vars:
+            compare_file: "{{ __test_forward_conf_no_p_p }}"
+            expected_content: |
               #
               # Ansible managed
               #
@@ -280,11 +261,6 @@
                       Template="{{ __test_template }}"
                   )
               }
-            mode: '0600'
-
-        - name: Check no_severity_and_facility_protocol_port
-          command: diff -B /tmp/__testfile__ '{{ __test_forward_conf_no_p_p }}'
-          changed_when: false
 
         - name: Grep no_severity_and_facility_protocol_port_target
           shell: |-
@@ -292,7 +268,7 @@
             /bin/grep '<action.*forwards_no_severity_and_facility_protocol_port_target>' /etc/rsyslog.d/30-output-forwards*.conf
           register: __result
           changed_when: false
-          failed_when: "__result is not failed"
+          failed_when: __result is not failed
 
         - name: Grep no_name
           shell: |-
@@ -300,7 +276,7 @@
             /bin/grep '<action.*forwards_no_name\.localdomain>' /etc/rsyslog.d/30-output-forwards*.conf
           register: __result
           changed_when: false
-          failed_when: "__result is not failed"
+          failed_when: __result is not failed
 
         - name: Check output to messages line
           command: >-
@@ -386,10 +362,11 @@
             __check_systemctl_status: true
           include_tasks: tasks/check_daemon_config_files.yml
 
-        - name: Generate a file to check severity_and_facility
-          copy:
-            dest: /tmp/__testfile__
-            content: |
+        - name: Check severity_and_facility
+          include_tasks: tasks/compare_file_to_content.yml
+          vars:
+            compare_file: "{{ __test_forward_conf_s_f }}"
+            expected_content: |
               #
               # Ansible managed
               #
@@ -407,11 +384,6 @@
                       Template="{{ __test_template }}"
                   )
               }
-            mode: '0600'
-
-        - name: Check severity_and_facility
-          command: diff -B /tmp/__testfile__ '{{ __test_forward_conf_s_f }}'
-          changed_when: false
 
         - name: Check the fake ca cert is successfully copied
           stat:
@@ -504,10 +476,11 @@
             __check_systemctl_status: true
           include_tasks: tasks/check_daemon_config_files.yml
 
-        - name: Generate a file to check severity_and_facility
-          copy:
-            dest: /tmp/__testfile__
-            content: |
+        - name: Check severity_and_facility
+          include_tasks: tasks/compare_file_to_content.yml
+          vars:
+            compare_file: "{{ __test_forward_conf_s_f }}"
+            expected_content: |
               #
               # Ansible managed
               #
@@ -525,11 +498,6 @@
                       Template="{{ __test_template }}"
                   )
               }
-            mode: '0600'
-
-        - name: Check severity_and_facility
-          command: diff -B /tmp/__testfile__ '{{ __test_forward_conf_s_f }}'
-          changed_when: false
 
         - name: Check the fake key/certs are successfully copied
           stat:
@@ -653,8 +621,3 @@
             path: "{{ _tmpdir.path }}"
             state: absent
           delegate_to: localhost
-
-        - name: Remove test file
-          file:
-            path: /tmp/__testfile__
-            state: absent


### PR DESCRIPTION
On some platforms the parameters are stored in a `dict`, and the ordering
of the elements is not guaranteed to be stable.  So when comparing
the expected results to the actual file, sort both.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
