### PR TITLE
test: restart firewalld before checking ports status

### DIFF
--- a/tests/tasks/check_firewall_selinux.yml
+++ b/tests/tasks/check_firewall_selinux.yml
@@ -12,6 +12,15 @@
 - name: Check firewall port status
   when: logging_manage_firewall | bool
   block:
+    # not sure what tests_imuxsock is doing on el10, but it leaves firewalld
+    # in a strange state such that it cannot connect to dbus and gives
+    # ERROR: Exception DBusException: org.freedesktop.DBus.Error.AccessDenied: Request to own name refused by policy
+    # restarting firewalld here seems to clear that state.
+    - name: Restart firewall to clear error state
+      service:
+        name: firewalld
+        state: restarted
+
     - name: Check firewall port status (manage - tcp)
       shell: |
         set -euo pipefail
@@ -29,6 +38,15 @@
       loop: "{{ logging_tls_udp_ports + logging_udp_ports }}"
       when:
         - (logging_tls_udp_ports + logging_udp_ports) | d([]) | length > 0
+  rescue:
+    - name: Debug errors
+      shell: |
+        set -x
+        exec 1>&2
+        systemctl status firewalld || :
+        grep type=AVC /var/log/audit/audit.log || :
+      failed_when: true
+      changed_when: false
 
 - name: Check SELinux port status
   when: logging_manage_selinux | bool


### PR DESCRIPTION
tests_imuxsock_files.yml on el10 leaves firewalld in a really strange
state such that when started it reports

and firewall-cmd fails because firewalld is not listening to dbus.

ERROR: Exception DBusException: org.freedesktop.DBus.Error.AccessDenied: Request to own name refused by policy

Restaring firewalld here seems to clear the condition.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
