### PR TITLE
test: tests_combination.yml requires fact gathering

### DIFF
--- a/tests/tests_combination.yml
+++ b/tests/tests_combination.yml
@@ -2,6 +2,7 @@
 - name: "Combination test - test for (2 types of inputs) x
   (2 types of outputs) combination"
   hosts: all
+  gather_facts: true  # test needs facts
   vars:
     __test_files_conf: /etc/rsyslog.d/30-output-files-files_test0.conf
     __test_forwards_conf_s_f: >-


### PR DESCRIPTION
The test will fail with `ANSIBLE_GATHERING=explicit` because
the test needs facts.  Ensure `gather_facts: true` with the
test.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
