### PR TITLE
test: restart dbus broker after restarting journald

### DIFF
--- a/tests/tests_imuxsock_files.yml
+++ b/tests/tests_imuxsock_files.yml
@@ -129,6 +129,17 @@
                 sleep 1
               fi
             done
+            # dbus needs to be restarted after journald or services will not be able to
+            # listen for dbus
+            for service in dbus dbus-broker; do
+              if systemctl is-active "$service"; then
+                systemctl restart "$service" || { systemctl status "$service" || :; journalctl -ex; }
+              fi
+            done
+            # ensure journal is working again
+            logger tests_imuxsock_files_ensure_journal_working
+            sleep 1
+            journalctl -ex | grep tests_imuxsock_files_ensure_journal_working
           changed_when: true
           vars:
             __journald_units:


### PR DESCRIPTION
Restarting journald seems to break the ability of dbus to
configure policy for newly installed services.  Restarting
dbus broker seems to fix that.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
