### PR TITLE
fix: Add a variable for rsyslog base package on Debian

### DIFF
--- a/roles/rsyslog/vars/Debian.yml
+++ b/roles/rsyslog/vars/Debian.yml
@@ -1,0 +1,7 @@
+# __rsyslog_base_packages
+#
+# List of default rpm packages to install.
+# NOTE: iproute2 is needed for the ip command which
+# is needed for the default_ipv4 fact
+# package is named iproute2 for Debian/Ubuntu systems
+__rsyslog_base_packages: ['iproute2', 'rsyslog']


### PR DESCRIPTION
On RedHat, it's named "iproute" but on Debian based systems it's named "iproute2"

Enhancement: Make this role functional again for Debian based systems

Reason: Newer version of this role (see commit 64f915a5c) included the package "iproute" which is named "iproute2" on Debian based systems.

Result: Define an own __rsyslog_base_packages list for Debian based systems

Issue Tracker Tickets (Jira or BZ if any):
