### PR TITLE
fix: Only remove rsyslog* packages, remove packages with command line

### DIFF
--- a/roles/rsyslog/tasks/main_core.yml
+++ b/roles/rsyslog/tasks/main_core.yml
@@ -22,11 +22,11 @@
       changed_when: false
 
     - name: Reset original confs - logging package is absent
-      package:
-        name: "{{ __rsyslog_only_packages }}"
-        state: absent
-        use: "{{ (__logging_is_ostree | d(false)) |
-                 ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
+      # we can't do this with "package", dnf5 does not remove reverse
+      # dependencies (such as rsyslog-gnutls) any more
+      command: "{{ ansible_pkg_mgr }} remove -y {{ __rsyslog_only_packages | join(' ') }}"
+      # we know it's a change here, as we just rpm -V'ed it above
+      changed_when: true
       register: __rsyslog_erased
       when: __rsyslog_package_status.results |
         rejectattr('stdout', 'match', '^package .* is not installed') |
@@ -43,7 +43,7 @@
              ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
   when:
     - __rsyslog_enabled | bool or
-      (__rsyslog_erased is success and __rsyslog_erased is changed)
+      __rsyslog_erased is success
 
 # make sure we do not pollute the global namespace for subsequent runs
 # of this role

--- a/roles/rsyslog/tasks/main_core.yml
+++ b/roles/rsyslog/tasks/main_core.yml
@@ -8,20 +8,22 @@
     - logging_purge_confs | bool | d(false)
     - not (rsyslog_inputs and __rsyslog_enabled | bool)
     - not __logging_is_ostree | d(false)
+  vars:
+    __rsyslog_only_packages: "{{ __rsyslog_base_packages | select('search', 'rsyslog') | list }}"
   block:
     # it is assumed that the only packages providing config files that might
-    # be modified are the base packages - if this is not so, then additional
-    # packages will need to be added to this check
+    # be modified are the base packages (but not others like iproute);
+    # if this is not so, then additional packages will need to be added to this check
     - name: Get status of rsyslog packages
       command: rpm -V {{ item }}  # noqa command-instead-of-module
-      loop: "{{ __rsyslog_base_packages }}"
+      loop: "{{ __rsyslog_only_packages }}"
       register: __rsyslog_package_status
       failed_when: false
       changed_when: false
 
     - name: Reset original confs - logging package is absent
       package:
-        name: "{{ __rsyslog_base_packages }}"
+        name: "{{ __rsyslog_only_packages }}"
         state: absent
         use: "{{ (__logging_is_ostree | d(false)) |
                  ternary('ansible.posix.rhel_rpm_ostree', omit) }}"

--- a/tests/tests_imuxsock_files.yml
+++ b/tests/tests_imuxsock_files.yml
@@ -124,7 +124,8 @@
               systemctl clean --what fdstore systemd-journald.service
             fi
             for service in {{ __journald_units | join(" ") }}; do
-              if ! systemctl is-active "$service"; then
+              # systemd-journald-dev-log.socket does not exist on RHEL 7, so check existence
+              if systemctl cat "$service" >/dev/null && ! systemctl is-active "$service"; then
                 systemctl start "$service"
                 sleep 1
               fi
@@ -153,7 +154,7 @@
           stat:
             path: /dev/log
           register: __dev_log
-          failed_when: __dev_log.stat.lnk_target != "/run/systemd/journal/dev-log"
+          failed_when: not __dev_log.stat.issock and __dev_log.stat.lnk_target != "/run/systemd/journal/dev-log"
 
       rescue:
         - name: Check journal for errors


### PR DESCRIPTION
Cause: During the "Reset original confs" step, the role tried to remove
packages like `iproute`.

Consequence: Removal may fail because other packages require iproute,
such as as dhcp-client.

Fix: Only remove rsyslog related packages during the reset step.

Result: The role does not remove unrelated packages and works on Fedora
≥ 41 as well.

Signed-off-by: Martin Pitt <mpitt@redhat.com>


----

The test has always failed on F41 since its inception (see #358 and e. g. [this log](https://dl.fedoraproject.org/pub/alt/linuxsystemroles/logs/tf_logging-358_Fedora-41-2.17_20241207-081546/artifacts/)). This is quite a serious bug also on RHEL/CentOS.

https://issues.redhat.com/browse/RHELMISC-11204