### PR TITLE
feat: Support this role in container builds

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.6.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.7.1"
 
       - name: Convert role to collection format
         id: collection

--- a/.github/workflows/ansible-managed-var-comment.yml
+++ b/.github/workflows/ansible-managed-var-comment.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.6.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.7.1"
 
       - name: Run ansible-plugin-scan
         run: |

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.6.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.7.1"
 
       - name: Convert role to collection format
         run: |

--- a/.github/workflows/qemu-kvm-integration-tests.yml
+++ b/.github/workflows/qemu-kvm-integration-tests.yml
@@ -74,7 +74,7 @@ jobs:
           python3 -m pip install --upgrade pip
           sudo apt update
           sudo apt install -y --no-install-recommends git ansible-core genisoimage qemu-system-x86
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.6.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.7.1"
 
       - name: Configure tox-lsr
         if: steps.check_platform.outputs.supported

--- a/.github/workflows/qemu-kvm-integration-tests.yml
+++ b/.github/workflows/qemu-kvm-integration-tests.yml
@@ -1,5 +1,5 @@
 ---
-name: QEMU/KVM Integration tests
+name: Test
 on:  # yamllint disable-line rule:truthy
   pull_request:
   merge_group:
@@ -17,18 +17,34 @@ permissions:
   # This is required for the ability to create/update the Pull request status
   statuses: write
 jobs:
-  qemu_kvm:
+  scenario:
     runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
       matrix:
         scenario:
+          # QEMU
           - { image: "centos-9", env: "qemu-ansible-core-2.16" }
           - { image: "centos-10", env: "qemu-ansible-core-2.17" }
           # ansible/libdnf5 bug: https://issues.redhat.com/browse/RHELMISC-10110
           # - { image: "fedora-41", env: "qemu-ansible-core-2.17" }
           - { image: "fedora-42", env: "qemu-ansible-core-2.17" }
+
+          # container
+          - { image: "centos-9", env: "container-ansible-core-2.16" }
+          - { image: "centos-9-bootc", env: "container-ansible-core-2.16" }
+          # broken on non-running dbus
+          # - { image: "centos-10", env: "container-ansible-core-2.17" }
+          - { image: "centos-10-bootc", env: "container-ansible-core-2.17" }
+          - { image: "fedora-41", env: "container-ansible-core-2.17" }
+          - { image: "fedora-42", env: "container-ansible-core-2.17" }
+          - { image: "fedora-41-bootc", env: "container-ansible-core-2.17" }
+          - { image: "fedora-42-bootc", env: "container-ansible-core-2.17" }
+
+    env:
+      TOX_ARGS: "--skip-tags tests::infiniband,tests::nvme,tests::scsi"
+
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -38,6 +54,7 @@ jobs:
         run: |
           set -euxo pipefail
           image="${{ matrix.scenario.image }}"
+          image="${image%-bootc}"
 
           # convert image to tag formats
           platform=
@@ -49,6 +66,20 @@ jobs:
           supported=
           if yq -e '.galaxy_info.galaxy_tags[] | select(. == "'${platform_version}'" or . == "'${platform}'")' meta/main.yml; then
             supported=true
+          fi
+
+          # bootc build support (in buildah) has a separate flag
+          if [ "${{ matrix.scenario.image }}" != "$image" ]; then
+            if ! yq -e '.galaxy_info.galaxy_tags[] | select(. == "containerbuild")' meta/main.yml; then
+              supported=
+            fi
+          else
+            # roles need to opt into support for running in a system container
+            env="${{ matrix.scenario.env }}"
+            if [ "${env#container}" != "$env" ] &&
+              ! yq -e '.galaxy_info.galaxy_tags[] | select(. == "container")' meta/main.yml; then
+              supported=
+            fi
           fi
 
           echo "supported=$supported" >> "$GITHUB_OUTPUT"
@@ -82,14 +113,13 @@ jobs:
           curl -o ~/.config/linux-system-roles.json
           https://raw.githubusercontent.com/linux-system-roles/linux-system-roles.github.io/master/download/linux-system-roles.json
 
-      - name: Run qemu/kvm tox integration tests
-        if: steps.check_platform.outputs.supported
-        run: >-
-          tox -e ${{ matrix.scenario.env }} -- --image-name ${{ matrix.scenario.image }} --make-batch
-          --log-level=debug --skip-tags tests::infiniband,tests::nvme,tests::scsi --
+      - name: Run qemu integration tests
+        if: steps.check_platform.outputs.supported && startsWith(matrix.scenario.env, 'qemu')
+        run: |
+          tox -e ${{ matrix.scenario.env }} -- --image-name ${{ matrix.scenario.image }} --make-batch $TOX_ARGS --
 
-      - name: Test result summary
-        if: steps.check_platform.outputs.supported && always()
+      - name: Qemu result summary
+        if: steps.check_platform.outputs.supported && startsWith(matrix.scenario.env, 'qemu') && always()
         run: |
           set -euo pipefail
           # some platforms may have setup/cleanup playbooks - need to find the
@@ -108,6 +138,24 @@ jobs:
               fi
               echo "$f"
           done < batch.report
+
+      - name: Run container tox integration tests
+        if: steps.check_platform.outputs.supported && startsWith(matrix.scenario.env, 'container')
+        run: |
+          set -euo pipefail
+          # HACK: debug.py/profile.py setup is broken
+          export LSR_CONTAINER_PROFILE=false
+          export LSR_CONTAINER_PRETTY=false
+          rc=0
+          for t in tests/tests_*.yml; do
+              if tox -e ${{ matrix.scenario.env }} -- --image-name ${{ matrix.scenario.image }} $t > ${t}.log 2>&1; then
+                  echo "PASS: $(basename $t)"
+              else
+                  echo "FAIL: $(basename $t)"
+                  rc=1
+              fi
+          done
+          exit $rc
 
       - name: Upload test logs on failure
         if: failure()
@@ -139,6 +187,6 @@ jobs:
         uses: myrotvorets/set-commit-status-action@master
         with:
           status: success
-          context: "${{ github.workflow }} / qemu_kvm (${{ matrix.scenario.image }}, ${{ matrix.scenario.env }}) (pull_request)"
+          context: "${{ github.workflow }} / scenario (${{ matrix.scenario.image }}, ${{ matrix.scenario.env }}) (pull_request)"
           description: The role does not support this platform. Skipping.
           targetUrl: ""

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -24,4 +24,5 @@ galaxy_info:
     - logging
     - redhat
     - rsyslog
+    - containerbuild
 allow_duplicates: true

--- a/roles/rsyslog/handlers/main.yml
+++ b/roles/rsyslog/handlers/main.yml
@@ -3,8 +3,10 @@
   service:
     name: rsyslog
     state: restarted
+  when: __logging_is_booted
 
 - name: Stop rsyslogd
   service:
     name: rsyslog
     state: stopped
+  when: __logging_is_booted

--- a/roles/rsyslog/tasks/main_core.yml
+++ b/roles/rsyslog/tasks/main_core.yml
@@ -379,8 +379,16 @@
       systemd:
         name: rsyslog.service
         enabled: false
+      when:
+        - not __rsyslog_enabled | bool
+        - not rsyslog_in_image | default(false) | bool
+
+    - name: Stop rsyslog service
+      systemd:
+        name: rsyslog.service
         state: stopped
       when:
+        - __logging_is_booted
         - not __rsyslog_enabled | bool
         - not rsyslog_in_image | default(false) | bool
 

--- a/tasks/certificate.yml
+++ b/tasks/certificate.yml
@@ -1,4 +1,11 @@
 ---
+- name: Certificates are only supported in a booted system
+  fail:
+    msg: "The logging_certificates option is only supported in booted systems, not container builds."
+  when:
+    - not __logging_is_booted
+    - logging_certificates | length > 0
+
 - name: Generate certificates
   include_role:
     name: fedora.linux_system_roles.certificate

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,7 @@
 ---
+- name: Set global variables
+  include_tasks: set_vars.yml
+
 - name: Set Rsyslog facts then include rsyslog role
   when:
     - logging_provider == 'rsyslog'

--- a/tasks/set_vars.yml
+++ b/tasks/set_vars.yml
@@ -1,0 +1,22 @@
+---
+# SPDX-License-Identifier: GPL-3.0-only
+
+- name: Determine if system is booted with systemd
+  when: not __logging_is_booted is defined
+  block:
+    - name: Run systemctl
+      # noqa command-instead-of-module
+      command: systemctl is-system-running
+      register: __is_system_running
+      changed_when: false
+      failed_when: false
+
+    - name: Require installed systemd
+      fail:
+        msg: "Error: This role requires systemd to be installed."
+      when: __is_system_running.msg is defined and "No such file or directory" in __is_system_running.msg
+
+    - name: Set flag to indicate that systemd runtime operations are available
+      set_fact:
+        # see https://www.man7.org/linux/man-pages/man1/systemctl.1.html#:~:text=is-system-running%20output
+        __logging_is_booted: "{{ __is_system_running.stdout not in ['offline', 'degraded'] }}"

--- a/tests/tasks/test_logger.yml
+++ b/tests/tasks/test_logger.yml
@@ -1,5 +1,6 @@
 ---
 - name: Check test log and check for errors
+  when: __logging_is_booted
   vars:
     __logging_message: testMessage{{ __logging_index }}
     __logging_tag: testTag{{ __logging_index }}

--- a/tests/tests_cert_container.yml
+++ b/tests/tests_cert_container.yml
@@ -1,0 +1,31 @@
+---
+- name: "Certificate creation is not supported in container builds"
+  hosts: all
+  tasks:
+    - name: Set __logging_is_booted
+      include_tasks: ../tasks/set_vars.yml
+
+    - name: Try to run role with logging_certificates in container build
+      when: not __logging_is_booted
+      block:
+        - name: Run role
+          vars:
+            logging_certificates:
+              - name: logging_cert
+                dns: ['localhost', 'www.example.com']
+                ca: self-sign
+          include_role:
+            name: linux-system-roles.logging
+
+        - name: Unreachable task
+          fail:
+            msg: UNREACH
+
+      rescue:
+        - name: Expected error
+          debug:
+            msg: "{{ ansible_failed_result }}"
+
+        - name: Ensure the expected error message is issued
+          assert:
+            that: '"only supported in booted systems" in ansible_failed_result.msg'

--- a/tests/tests_combination.yml
+++ b/tests/tests_combination.yml
@@ -171,6 +171,7 @@
       command: >-
         /bin/grep '{{ __test_tag }} .*abcdefghijklmnopqrstuvwxyz$' {{ __default_system_log }}
       changed_when: false
+      when: __logging_is_booted
     # yamllint enable rule:line-length
 
     # yamllint disable rule:line-length
@@ -189,6 +190,7 @@
       register: __result
       changed_when: false
       failed_when: __result.rc != 1
+      when: __logging_is_booted
     # yamllint enable rule:line-length
 
     - name: Check ports managed by firewall and selinux
@@ -364,6 +366,7 @@
       command: >-
         /bin/grep '{{ __test_tag }} .*ABCDEFGHIJKLMNOPQRSTUVWXYZ$' {{ __default_system_log }}
       changed_when: false
+      when: __logging_is_booted
     # yamllint enable rule:line-length
 
     - name: Check ports managed by firewall and selinux
@@ -555,6 +558,7 @@
       register: __result
       changed_when: false
       failed_when: "'error' in __result.stdout or __result is failed"
+      when: __logging_is_booted
 
     - name: Check ports managed by firewall and selinux
       include_tasks: tasks/check_firewall_selinux.yml

--- a/tests/tests_enabled.yml
+++ b/tests/tests_enabled.yml
@@ -22,9 +22,16 @@
   hosts: all
 
   tasks:
+      # rsyslog package may not be installed
+    - name: Check if /etc/rsyslog.d exists
+      stat:
+        path: /etc/rsyslog.d
+      register: rsyslog_d_dir
+
     - name: Check /etc/rsyslog.d
       command: ls /etc/rsyslog.d
       changed_when: false
+      when: rsyslog_d_dir.stat.exists
 
     - name: Default run
       vars:

--- a/tests/tests_imuxsock_files.yml
+++ b/tests/tests_imuxsock_files.yml
@@ -105,7 +105,9 @@
       register: __dev_log
 
     - name: Restore /dev/log by restarting journald units
-      when: not __dev_log.stat.exists
+      when:
+        - __logging_is_booted
+        - not __dev_log.stat.exists
       block:
         # This is really hacky - but I could not find a reliable way to do this
         # that works on older rhel8, newer rhel9, and fedora - each platform has

--- a/tests/tests_remote.yml
+++ b/tests/tests_remote.yml
@@ -62,6 +62,7 @@
       changed_when: false
       failed_when: "'error' in __result.stdout or
         'a RainerScript command' in __result.stdout or __result is failed"
+      when: __logging_is_booted
 
     - name: Install lsof
       package:
@@ -69,6 +70,7 @@
         state: present
         use: "{{ (__logging_is_ostree | d(false)) |
                  ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
+      when: __logging_is_booted
 
     - name: Check lsof outputs for rsyslogd
       shell: |-
@@ -76,10 +78,12 @@
         lsof -i -nP | grep rsyslogd
       register: __result
       changed_when: false
+      when: __logging_is_booted
 
     - name: Show lsof output
       debug:
         msg: "lsof returned {{ __result.stdout }}"
+      when: __logging_is_booted
 
     - name: Check port 514 and 40001 are open for TCP
       shell: |-
@@ -87,6 +91,7 @@
         lsof -i -nP | grep rsyslogd | grep TCP | grep {{ item }}
       loop: [514, 40001]
       changed_when: false
+      when: __logging_is_booted
 
     - name: Check port 514 and 40002 are open for UDP
       shell: |-
@@ -94,6 +99,7 @@
         lsof -i -nP | grep rsyslogd | grep UDP | grep {{ item }}
       loop: [514, 40002]
       changed_when: false
+      when: __logging_is_booted
 
     - name: Check ports managed by firewall and selinux
       include_tasks: tasks/check_firewall_selinux.yml
@@ -195,6 +201,7 @@
         state: present
         use: "{{ (__logging_is_ostree | d(false)) |
                  ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
+      when: __logging_is_booted
 
     - name: Check lsof outputs for rsyslogd
       shell: |-
@@ -202,10 +209,12 @@
         lsof -i -nP | grep rsyslogd
       register: __result
       changed_when: false
+      when: __logging_is_booted
 
     - name: Show lsof output
       debug:
         msg: "lsof returned {{ __result.stdout }}"
+      when: __logging_is_booted
 
     - name: Check port 514 and 40001 is open for TCP
       shell: |-
@@ -213,6 +222,7 @@
         lsof -i -nP | grep rsyslogd | grep TCP | grep {{ item }}
       loop: [514, 40001]
       changed_when: false
+      when: __logging_is_booted
 
     - name: Check port 514 and 40002 is open for UDP
       shell: |-
@@ -220,6 +230,7 @@
         lsof -i -nP | grep rsyslogd | grep UDP | grep {{ item }}
       loop: [514, 40002]
       changed_when: false
+      when: __logging_is_booted
 
     - name: Check ports managed by firewall and selinux
       include_tasks: tasks/check_firewall_selinux.yml

--- a/tests/tests_server.yml
+++ b/tests/tests_server.yml
@@ -11,6 +11,9 @@
 - name: "Test the server configuration containing tls tcp,
   plain tcp and udp connection"
   hosts: all
+  tags:
+    # certmonger does not work in container builds
+    - tests::booted
   vars:
     __test_cert_name: logging_cert
     __test_ca_cert: "/etc/pki/tls/certs/{{ __test_cert_name }}.crt"


### PR DESCRIPTION
Feature: Support running the cockpit role during container builds.

Reason: This is particularly useful for building bootc derivative OSes.

Result: These flags enable running the bootc container scenarios in CI, which ensures that the role works in buildah build environment. This allows us to officially support this role for image mode builds.

Do *not* enable the role for system containers (the `container`) flag. `rsyslog.service` is not designed to work in containers, and fails in all RHEL/CentOS and older Fedora releases (it finally works in Fedora 42).

Fixes https://issues.redhat.com/browse/RHEL-88689

---

 - [x] Land initial test and infra, then do final sync: https://github.com/linux-system-roles/sudo/pull/52
