### PR TITLE
ci: bump tox-lsr to 3.8.0; rename qemu/kvm tests

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.7.1"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.8.0"
 
       - name: Convert role to collection format
         id: collection

--- a/.github/workflows/ansible-managed-var-comment.yml
+++ b/.github/workflows/ansible-managed-var-comment.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.7.1"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.8.0"
 
       - name: Run ansible-plugin-scan
         run: |

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.7.1"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.8.0"
 
       - name: Convert role to collection format
         run: |

--- a/.github/workflows/qemu-kvm-integration-tests.yml
+++ b/.github/workflows/qemu-kvm-integration-tests.yml
@@ -70,7 +70,7 @@ jobs:
 
           # bootc build support (in buildah) has a separate flag
           if [ "${{ matrix.scenario.image }}" != "$image" ]; then
-            if ! yq -e '.galaxy_info.galaxy_tags[] | select(. == "containerbuild")' meta/main.yml; then
+          if ! yq -e '.galaxy_info.galaxy_tags[] | select(. == "containerbuild")' meta/main.yml; then
               supported=
             fi
           else
@@ -105,7 +105,7 @@ jobs:
           python3 -m pip install --upgrade pip
           sudo apt update
           sudo apt install -y --no-install-recommends git ansible-core genisoimage qemu-system-x86
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.7.1"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.8.0"
 
       - name: Configure tox-lsr
         if: steps.check_platform.outputs.supported
@@ -115,8 +115,9 @@ jobs:
 
       - name: Run qemu integration tests
         if: steps.check_platform.outputs.supported && startsWith(matrix.scenario.env, 'qemu')
-        run: |
-          tox -e ${{ matrix.scenario.env }} -- --image-name ${{ matrix.scenario.image }} --make-batch $TOX_ARGS --
+        run: >-
+          tox -e ${{ matrix.scenario.env }} -- --image-name ${{ matrix.scenario.image }} --make-batch
+          --log-level=debug --skip-tags tests::infiniband,tests::nvme,tests::scsi --
 
       - name: Qemu result summary
         if: steps.check_platform.outputs.supported && startsWith(matrix.scenario.env, 'qemu') && always()
@@ -175,7 +176,7 @@ jobs:
         run: |
           set -euo pipefail
           for f in tests/*.log; do
-              if FAIL=$(grep -B100 -A30 "fatal:" "$f"); then
+              if FAIL=$(grep -E -B100 -A30 "fatal:|An exception occurred" "$f"); then
                   echo "::group::$(basename $f)"
                   echo "$FAIL"
                   echo "::endgroup::"


### PR DESCRIPTION
This will make the qemu/kvm tests be tested in either
ascending or descending ASCII order.  This should give
us better test coverage of clean up scenarios which may
fail depending on the order of the previous tests.

Rename the qemu/kvm tests so that the statuses are shorter
and more intuitive.

Improve qemu/kvm test failure error reporting.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
