### PR TITLE
test: restart firewalld after dbus if firewalld is running

### DIFF
--- a/tests/tests_cert_container.yml
+++ b/tests/tests_cert_container.yml
@@ -3,7 +3,10 @@
   hosts: all
   tasks:
     - name: Set __logging_is_booted
-      include_tasks: ../tasks/set_vars.yml
+      include_role:
+        name: linux-system-roles.logging
+        tasks_from: set_vars.yml
+        public: true
 
     - name: Try to run role with logging_certificates in container build
       when: not __logging_is_booted

--- a/tests/tests_cert_container.yml
+++ b/tests/tests_cert_container.yml
@@ -6,7 +6,6 @@
       include_role:
         name: linux-system-roles.logging
         tasks_from: set_vars.yml
-        public: true
 
     - name: Try to run role with logging_certificates in container build
       when: not __logging_is_booted

--- a/tests/tests_imuxsock_files.yml
+++ b/tests/tests_imuxsock_files.yml
@@ -116,6 +116,11 @@
           shell: |
             set -euxo pipefail
             exec 1>&2
+            # see if firewalld is running
+            restart_firewalld=false
+            if systemctl is-active firewalld.service; then
+              restart_firewalld=true
+            fi
             for service in {{ __journald_units | join(" ") }}; do
               if systemctl is-active "$service"; then
                 systemctl stop "$service" || :
@@ -145,6 +150,12 @@
             journalctl -ex | grep tests_imuxsock_files_ensure_journal_working
             # ensure loginctl is working - if not it will error with a timeout
             loginctl list-sessions
+            # restart firewalld if firewalld is enabled - note that it might not
+            # be active due to the dbus stuff above, but the tests that use
+            # logging_manage_firewall: true usually (always?) enable it
+            if [ "$restart_firewalld" = true ]; then
+              systemctl restart firewalld.service
+            fi
           changed_when: true
           vars:
             __journald_units:


### PR DESCRIPTION
firewalld must be restarted if it is running, after restarting dbus/journald.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Tests:
- Detect if firewalld.service is active before restarting dbus/journald and restart it afterward in imuxsock file tests