### PR TITLE
refactor: Re-unify service disabling and stopping

### DIFF
--- a/roles/rsyslog/tasks/main_core.yml
+++ b/roles/rsyslog/tasks/main_core.yml
@@ -379,16 +379,8 @@
       systemd:
         name: rsyslog.service
         enabled: false
+        state: "{{ 'stopped' if __logging_is_booted else omit }}"
       when:
-        - not __rsyslog_enabled | bool
-        - not rsyslog_in_image | default(false) | bool
-
-    - name: Stop rsyslog service
-      systemd:
-        name: rsyslog.service
-        state: stopped
-      when:
-        - __logging_is_booted
         - not __rsyslog_enabled | bool
         - not rsyslog_in_image | default(false) | bool
 


### PR DESCRIPTION
Commit 8b6916a799 split the rsyslog.service disabling and stopping to restrict the latter to booted environments. Use `omit` instead to simplify.

---

Thanks to @richm for the hint in https://github.com/linux-system-roles/firewall/pull/270#discussion_r2087436072 !

## Summary by Sourcery

Enhancements:
- Merge separate disable and stop tasks for rsyslog into one systemd invocation, using 'stopped' only when the host is booted and omitting otherwise