### PR TITLE
fix: Consider "degraded" systemd state as booted

### DIFF
--- a/tasks/set_vars.yml
+++ b/tasks/set_vars.yml
@@ -19,4 +19,4 @@
     - name: Set flag to indicate that systemd runtime operations are available
       set_fact:
         # see https://www.man7.org/linux/man-pages/man1/systemctl.1.html#:~:text=is-system-running%20output
-        __logging_is_booted: "{{ __is_system_running.stdout not in ['offline', 'degraded'] }}"
+        __logging_is_booted: "{{ __is_system_running.stdout != 'offline' }}"

--- a/tasks/set_vars.yml
+++ b/tasks/set_vars.yml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
 - name: Determine if system is booted with systemd
-  when: not __logging_is_booted is defined
+  when: __logging_is_booted is not defined
   block:
     - name: Run systemctl
       # noqa command-instead-of-module
@@ -14,7 +14,7 @@
     - name: Require installed systemd
       fail:
         msg: "Error: This role requires systemd to be installed."
-      when: __is_system_running.msg is defined and "No such file or directory" in __is_system_running.msg
+      when: '"No such file or directory" in __is_system_running.msg | d("")'
 
     - name: Set flag to indicate that systemd runtime operations are available
       set_fact:


### PR DESCRIPTION
This was a thinko in commit 8b6916a79929b.

---

Plus some syntactic updates suggested by sourcery.ai and @richm in https://github.com/linux-system-roles/mssql/pull/349

## Summary by Sourcery

Fix systemd boot detection to include degraded state and refine conditional checks

Bug Fixes:
- Consider 'degraded' systemd state as booted in the system-run check

Enhancements:
- Use 'is not defined' syntax for undefined checks
- Apply default filter when checking systemctl error messages
- Simplify systemd boot fact assignment by only checking for 'offline' state