### PR TITLE
docs(changelog): version 1.15.0 [citest skip]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,24 @@
 Changelog
 =========
 
+[1.15.0] - 2025-05-15
+--------------------
+
+### New Features
+
+- feat: Support this role in container builds (#444)
+
+### Bug Fixes
+
+- fix: Consider "degraded" systemd state as booted (#449)
+
+### Other Changes
+
+- ci: bump sclorg/testing-farm-as-github-action from 3 to 4 (#445)
+- ci: bump tox-lsr to 3.8.0; rename qemu/kvm tests (#446)
+- test: restart firewalld after dbus if firewalld is running (#447)
+- refactor: Re-unify service disabling and stopping (#448)
+
 [1.14.2] - 2025-04-23
 --------------------
 


### PR DESCRIPTION
Update changelog and .README.html for version 1.15.0

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Update documentation to reflect the 1.15.0 release

Documentation:
- Add a new 1.15.0 section to the changelog with featured items, bug fixes, and other changes
- Refresh README.html to reference version 1.15.0