### PR TITLE
ci: Use ansible 2.19 for fedora 42 testing; support python 3.13

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.10.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.11.0"
 
       - name: Convert role to collection format
         id: collection

--- a/.github/workflows/ansible-managed-var-comment.yml
+++ b/.github/workflows/ansible-managed-var-comment.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.10.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.11.0"
 
       - name: Run ansible-plugin-scan
         run: |

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.10.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.11.0"
 
       - name: Convert role to collection format
         run: |

--- a/.github/workflows/qemu-kvm-integration-tests.yml
+++ b/.github/workflows/qemu-kvm-integration-tests.yml
@@ -29,7 +29,7 @@ jobs:
           - { image: "centos-10", env: "qemu-ansible-core-2.17" }
           # ansible/libdnf5 bug: https://issues.redhat.com/browse/RHELMISC-10110
           # - { image: "fedora-41", env: "qemu-ansible-core-2.17" }
-          - { image: "fedora-42", env: "qemu-ansible-core-2.17" }
+          - { image: "fedora-42", env: "qemu-ansible-core-2.19" }
 
           # container
           - { image: "centos-9", env: "container-ansible-core-2.16" }
@@ -105,7 +105,7 @@ jobs:
           python3 -m pip install --upgrade pip
           sudo apt update
           sudo apt install -y --no-install-recommends git ansible-core genisoimage qemu-system-x86
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.10.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.11.0"
 
       # HACK: Drop this when moving this workflow to 26.04 LTS
       - name: Update podman to 5.x for compatibility with bootc-image-builder's podman 5

--- a/.github/workflows/tft.yml
+++ b/.github/workflows/tft.yml
@@ -101,7 +101,7 @@ jobs:
           - platform: Fedora-41
             ansible_version: 2.17
           - platform: Fedora-42
-            ansible_version: 2.17
+            ansible_version: 2.19
           - platform: CentOS-7-latest
             ansible_version: 2.9
           - platform: CentOS-Stream-8


### PR DESCRIPTION
NOTE: This also requires upgrading to tox-lsr 3.11.0

Ansible 2.19 will be released soon and has some changes which will
require fixes in system roles.  This adds 2.19 to our testing matrix
on fedora 42 so that we can start addressing these issues.

python 3.13 is now being used on some platforms.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Add Ansible 2.19 to Fedora 42 CI matrix and bump tox-lsr to 3.11.0 across workflows

New Features:
- Include ansible-core 2.19 for Fedora-42 in the qemu-kvm integration and Terraform test workflows

Enhancements:
- Upgrade tox-lsr from 3.10.0 to 3.11.0 in all GitHub Actions workflows