### PR TITLE
docs(changelog): version 1.15.1 [citest skip]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 Changelog
 =========
 
+[1.15.1] - 2025-06-16
+--------------------
+
+### Other Changes
+
+- ci: Add Fedora 42; use tox-lsr 3.9.0; use lsr-report-errors for qemu tests (#453)
+- ci: Add support for bootc end-to-end validation tests (#454)
+- tests: Update tests_combination for bootc end-to-end validation (#455)
+- ci: Use ansible 2.19 for fedora 42 testing; support python 3.13 (#456)
+
 [1.15.0] - 2025-05-15
 --------------------
 


### PR DESCRIPTION
Update changelog and .README.html for version 1.15.1

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Record release of version 1.15.1 in the changelog and README with updates for CI environments and test coverage.

New Features:
- Add support for bootc end-to-end validation tests

Enhancements:
- Add Fedora 42 to the CI matrix
- Upgrade tox-lsr to 3.9.0 and integrate lsr-report-errors for QEMU tests
- Use Ansible 2.19 for Fedora 42 testing and add Python 3.13 support

Documentation:
- Update CHANGELOG and README for version 1.15.1

Tests:
- Update tests_combination for bootc end-to-end validation