### PR TITLE
refactor: disable ansible-lint invalid jinja error

### DIFF
--- a/roles/rsyslog/tasks/inputs/remote/main.yml
+++ b/roles/rsyslog/tasks/inputs/remote/main.yml
@@ -10,6 +10,8 @@
                               selectattr('tcp_ports', 'defined') | list }}"
     __logging_remote_tls: "{{ __logging_remote_tcp |
                               selectattr('tls', 'defined') | list }}"
+    # not really invalid - see https://github.com/ansible/ansible-lint/issues/4702
+    # noqa jinja[invalid]
     __logging_remote_ptcp: "{{ (__logging_remote_tcp |
                                selectattr('tls', 'undefined') | list) +
                                (__logging_remote_tls | rejectattr('tls')

--- a/tests/setup-snapshot.yml
+++ b/tests/setup-snapshot.yml
@@ -13,6 +13,8 @@
 
     - name: Install test packages
       package:
+        # not really invalid - see https://github.com/ansible/ansible-lint/issues/4702
+        # noqa jinja[invalid]
         name: "{{ __base_packages + ['lsof', 'openssl'] }}"
         state: present
       vars:


### PR DESCRIPTION
Not really invalid
see https://github.com/ansible/ansible-lint/issues/4702

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Suppress false-positive ansible-lint jinja invalid errors by adding noqa directives in role and test files.

Enhancements:
- Add '# noqa jinja[invalid]' comments to disable ansible-lint invalid jinja errors in the rsyslog remote inputs task
- Add '# noqa jinja[invalid]' comments to disable ansible-lint invalid jinja errors in the setup snapshot test playbook