### PR TITLE
ci: use JSON format for __bootc_validation

### DIFF
--- a/.github/workflows/qemu-kvm-integration-tests.yml
+++ b/.github/workflows/qemu-kvm-integration-tests.yml
@@ -201,7 +201,7 @@ jobs:
               if tox -e "$env" -- --image-file "$(pwd)/$image_file" \
                      --log-level debug $TOX_ARGS \
                      --lsr-report-errors-url DEFAULT \
-                     -e "__bootc_validation: true" \
+                     -e '{"__bootc_validation": true}' \
                      -- "$test" >out 2>&1; then
                   mv out "${test}-PASS.log"
               else


### PR DESCRIPTION
On some versions of ansible/jinja, the YAML format does not work, so use
the JSON format to pass in __bootc_validation

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

CI:
- Pass __bootc_validation as a JSON string instead of YAML in the tox command in qemu-kvm integration tests workflow